### PR TITLE
Persist manual message mappings

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -81,6 +81,18 @@ def init_db():
             )
         """)
 
+        # Tabella message_map (associa messaggi inoltrati all'originale)
+        db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS message_map (
+                trainer_message_id INTEGER PRIMARY KEY,
+                chat_id INTEGER NOT NULL,
+                message_id INTEGER NOT NULL,
+                timestamp REAL
+            )
+            """
+        )
+
 # 🧠 Inserisce una nuova memoria nel database
 def insert_memory(
     content: str,

--- a/core/message_map.py
+++ b/core/message_map.py
@@ -1,0 +1,71 @@
+# core/message_map.py
+
+"""Persistent mapping between trainer forwarded messages and original targets."""
+
+import time
+from core.db import get_db
+
+
+def init_table():
+    """Ensure the message_map table exists."""
+    with get_db() as db:
+        db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS message_map (
+                trainer_message_id INTEGER PRIMARY KEY,
+                chat_id INTEGER NOT NULL,
+                message_id INTEGER NOT NULL,
+                timestamp REAL
+            )
+            """
+        )
+
+
+def add_mapping(trainer_message_id: int, chat_id: int, message_id: int):
+    """Store mapping from trainer message to original chat/message."""
+    ts = time.time()
+    with get_db() as db:
+        db.execute(
+            """
+            INSERT OR REPLACE INTO message_map
+                (trainer_message_id, chat_id, message_id, timestamp)
+            VALUES (?, ?, ?, ?)
+            """,
+            (trainer_message_id, chat_id, message_id, ts),
+        )
+    print(f"[DEBUG/message_map] Stored mapping {trainer_message_id} -> {chat_id}/{message_id}")
+
+
+def get_mapping(trainer_message_id: int):
+    """Retrieve mapping if exists."""
+    with get_db() as db:
+        row = db.execute(
+            "SELECT chat_id, message_id FROM message_map WHERE trainer_message_id = ?",
+            (trainer_message_id,),
+        ).fetchone()
+    if row:
+        result = {"chat_id": row["chat_id"], "message_id": row["message_id"]}
+        print(f"[DEBUG/message_map] Found mapping for {trainer_message_id}: {result}")
+        return result
+    print(f"[DEBUG/message_map] No mapping for {trainer_message_id}")
+    return None
+
+
+def delete_mapping(trainer_message_id: int):
+    """Remove a mapping."""
+    with get_db() as db:
+        db.execute("DELETE FROM message_map WHERE trainer_message_id = ?", (trainer_message_id,))
+    print(f"[DEBUG/message_map] Deleted mapping for {trainer_message_id}")
+
+
+def purge_old_entries(max_age_seconds: int) -> int:
+    """Delete mappings older than given age in seconds. Returns number deleted."""
+    cutoff = time.time() - max_age_seconds
+    with get_db() as db:
+        cur = db.execute(
+            "DELETE FROM message_map WHERE timestamp < ?",
+            (cutoff,),
+        )
+        deleted = cur.rowcount
+    print(f"[DEBUG/message_map] Purged {deleted} entries older than {max_age_seconds} seconds")
+    return deleted

--- a/core/message_sender.py
+++ b/core/message_sender.py
@@ -1,6 +1,5 @@
-from llm_engines.manual import ManualAIPlugin
 from core import response_proxy, say_proxy
-from core.plugin_instance import plugin
+import core.plugin_instance as plugin_instance
 import traceback
 
 async def send_content(bot, chat_id, message, content_type, reply_to_message_id=None):
@@ -119,7 +118,7 @@ def extract_response_target(message, user_id):
     if not target and message.reply_to_message:
         replied = message.reply_to_message
         print(f"[DEBUG] Risposta a messaggio: {replied.message_id}")
-        print(f"[DEBUG] reply_map = {plugin_instance.reply_map}")
+        print("[DEBUG] Verifica mapping nel plugin")
 
         for attempt in [replied.message_id,
                         getattr(replied.reply_to_message, "message_id", None)]:


### PR DESCRIPTION
## Summary
- add persistent message_map SQLite table
- use message_map from ManualAIPlugin
- expose command `/purge_map` to cleanup mappings
- ensure table exists for purge command
- fix newline at end of message_sender

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6865c036def0832893ffee9951033105