### PR TITLE
Auto-create memory DB on missing file

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -2,16 +2,36 @@
 
 import sqlite3
 import time
+import os
 from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime, timezone
 
-DB_PATH = Path(__file__).parent.parent / "persona" / "rekku_memories.db"
+DB_PATH = Path(
+    os.getenv(
+        "MEMORY_DB",
+        Path(__file__).parent.parent / "persona" / "rekku_memories.db",
+    )
+)
 
 @contextmanager
 def get_db():
+    first_time = not DB_PATH.exists()
+    if first_time:
+        print(f"[WARN] {DB_PATH.name} not found, creating new database")
+
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row  # ✅ accesso per chiave
+
+    if first_time:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS settings (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            )
+            """
+        )
     try:
         yield conn
         conn.commit()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import sqlite3
+from pathlib import Path
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from importlib import reload
+import core.db as db_module
+
+
+def test_get_db_creates_db(tmp_path, capsys):
+    db_path = tmp_path / "test.db"
+    os.environ["MEMORY_DB"] = str(db_path)
+
+    reload(db_module)
+
+    with db_module.get_db():
+        pass
+
+    captured = capsys.readouterr()
+    assert "not found, creating new database" in captured.out
+    assert db_path.exists()
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' and name='settings'"
+        ).fetchone()
+        assert row is not None
+
+    os.environ.pop("MEMORY_DB")
+


### PR DESCRIPTION
## Summary
- load memory DB path from `MEMORY_DB` env var
- print a warning and create database on first use
- ensure `settings` table is created automatically
- add tests for DB creation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68666cf1d90c8328913dec32068e5ca6