### PR TITLE
Include weekday in prompt date

### DIFF
--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -73,7 +73,7 @@ async def build_json_prompt(message, context_memory) -> dict:
         tz = pytz.utc
 
     now_local = datetime.now(tz)
-    date = now_local.strftime("%Y-%m-%d")
+    date = now_local.strftime("%a %Y-%m-%d")
     time = now_local.strftime("%H:%M")
 
     weather = core.weather.current_weather


### PR DESCRIPTION
## Summary
- add weekday to the date string in `build_json_prompt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868a6a95a488328b5076b95506b5131