### PR TITLE
fix: remove outdated plugin registration from telegram interface

### DIFF
--- a/interface/telegram_bot.py
+++ b/interface/telegram_bot.py
@@ -1032,7 +1032,3 @@ class TelegramInterface:
 # Register TelegramInterface for discovery by the core
 PLUGIN_CLASS = TelegramInterface
 
-# Ensure the action type is registered globally
-from core.action_parser import set_available_plugins
-set_available_plugins([TelegramInterface])
-


### PR DESCRIPTION
## Summary
- remove deprecated call to `set_available_plugins` in telegram interface
- rely on core for plugin registration to prevent startup errors

## Testing
- `./run_tests.sh` *(fails: Could not install dependencies python-telegram-bot, aiomysql, pytest)*

------
https://chatgpt.com/codex/tasks/task_e_689dd7a26680832880f530dda503d662