### PR TITLE
Refresh action schemas when registering interfaces

### DIFF
--- a/interface/telegram_bot.py
+++ b/interface/telegram_bot.py
@@ -822,9 +822,9 @@ async def start_bot():
         register_interface("telegram_bot", telegram_interface)
         log_debug("[telegram_bot] Interface instance registered")
 
-        # Display startup summary now that the interface is registered
-        # (actions block is already built in core initialization)
+        # Rebuild action schemas and display updated startup summary
         from core.core_initializer import core_initializer
+        await core_initializer.refresh_actions_block()
         core_initializer.display_startup_summary()
         
         await app.start()


### PR DESCRIPTION
## Summary
- Rebuild the core action block whenever a new interface registers so its capabilities are exposed
- Telegram interface now refreshes the action schema before printing the startup summary

## Testing
- `python -m venv venv && source venv/bin/activate && pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-telegram-bot)*
- `./run_tests.sh` *(fails: Could not find a version that satisfies the requirement python-telegram-bot)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c99e2de883288a6a4a5d53ccaad9