### PR TITLE
Gemini Live Voice — bidirectional context ingestion & quality fixes

### DIFF
--- a/core/chat_history_cache.py
+++ b/core/chat_history_cache.py
@@ -194,7 +194,7 @@ async def load_chat_history(interface_path: str) -> deque:
                     SELECT sender_name, sender_id, message_text, timestamp, interface_path
                     FROM chat_history_cache
                     WHERE interface_path = %s
-                    ORDER BY timestamp ASC
+                    ORDER BY timestamp ASC, id ASC
                     LIMIT %s
                 """,
                     (interface_path, history_limit),

--- a/core/config.py
+++ b/core/config.py
@@ -12,7 +12,6 @@ except Exception:  # pragma: no cover - fallback when dotenv not installed
         return False
 
 
-
 # aiomysql is optional at import time — make the import lazy/fail-safe so
 # importing core.config doesn't raise in environments where aiomysql isn't
 # installed (e.g., lightweight tests or build-time checks). Modules that need

--- a/core/live_session_manager.py
+++ b/core/live_session_manager.py
@@ -17,6 +17,7 @@ expected input format.
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from typing import Any, Callable, Awaitable
 
@@ -36,6 +37,11 @@ RECONNECT_BUFFER_SECONDS = 30  # reconnect 30s before limit
 # Live API model
 LIVE_MODEL = "gemini-2.5-flash-native-audio-preview-12-2025"
 
+# Default voice — configurable via LIVE_VOICE_NAME in persona.json or .env.
+# Available prebuilt voices: Puck, Charon, Kore, Fenrir, Aoede, Orbit,
+# Zephyr, Leda, Orus, Autonoe.  Check Google's docs for the full current list.
+_DEFAULT_VOICE = "Aoede"
+
 try:
     from google import genai
     from google.genai import types
@@ -45,6 +51,22 @@ except ImportError:
     genai = None  # type: ignore[assignment]
     types = None  # type: ignore[assignment]
     _HAS_GENAI_SDK = False
+
+
+def _clean_transcript(parts: list[str]) -> str:
+    """Join transcript fragments and normalise the result.
+
+    Fragments are concatenated without an extra separator because Gemini
+    streams them with their own surrounding whitespace.  We then strip
+    emotion-state tags injected by the persona engine and collapse any
+    runs of multiple spaces left behind.
+    """
+    text = "".join(parts).strip()
+    # Remove emotion/state tags: {emotion neutral  intensity  3.0}
+    text = re.sub(r"\{[^}]*\}", "", text)
+    # Collapse runs of whitespace to a single space
+    text = re.sub(r" {2,}", " ", text).strip()
+    return text
 
 
 class LiveSessionState:
@@ -58,6 +80,7 @@ class LiveSessionState:
         "is_active",
         "_session",
         "_receive_task",
+        "_ctx",
     )
 
     def __init__(
@@ -92,6 +115,9 @@ class LiveSessionManager:
     a Live API WebSocket session is opened. When it leaves, the session closes.
     """
 
+    # How often (seconds) the flush task drains accumulated audio to Gemini.
+    _FLUSH_INTERVAL_S = 0.2  # 200ms
+
     def __init__(self, api_key: str) -> None:
         if not _HAS_GENAI_SDK:
             raise RuntimeError(
@@ -107,7 +133,12 @@ class LiveSessionManager:
         self._on_audio: Callable[[int, bytes], Awaitable[None]] | None = None
         self._on_text: Callable[[int, str], Awaitable[None]] | None = None
         self._on_tool_call: Callable[[int, dict], Awaitable[dict]] | None = None
+        self._on_turn_complete: Callable[[int, str, str], Awaitable[None]] | None = None
         self._reconnect_locks: dict[int, asyncio.Lock] = {}
+        # Audio send buffers: guild_id -> bytearray
+        self._send_buffers: dict[int, bytearray] = {}
+        # Periodic flush tasks: guild_id -> Task
+        self._flush_tasks: dict[int, asyncio.Task[None]] = {}
 
     def set_audio_callback(
         self, callback: Callable[[int, bytes], Awaitable[None]]
@@ -126,6 +157,17 @@ class LiveSessionManager:
     ) -> None:
         """Set callback for tool/function calls. Args: (guild_id, call_dict) -> response_dict."""
         self._on_tool_call = callback
+
+    def set_turn_complete_callback(
+        self, callback: Callable[[int, str, str], Awaitable[None]]
+    ) -> None:
+        """Set callback fired after each model turn completes.
+
+        Args: (guild_id, user_transcript, model_transcript) — both sides of the turn.
+        user_transcript comes from input_audio_transcription; model_transcript from
+        output_audio_transcription. Either may be empty if transcription is unavailable.
+        """
+        self._on_turn_complete = callback
 
     async def start_session(
         self,
@@ -151,8 +193,28 @@ class LiveSessionManager:
             )
             await self.stop_session(guild_id)
 
+        # Resolve the voice name: persona config → .env → hardcoded default.
+        _voice_name = _DEFAULT_VOICE
+        try:
+            from core.config_manager import config_registry
+
+            _v = config_registry.get_value("LIVE_VOICE_NAME", None)
+            if _v and isinstance(_v, str) and _v.strip():
+                _voice_name = _v.strip()
+        except Exception:
+            pass
+
         live_config = types.LiveConnectConfig(
             response_modalities=["AUDIO"],  # type: ignore[arg-type]
+            input_audio_transcription=types.AudioTranscriptionConfig(),
+            output_audio_transcription=types.AudioTranscriptionConfig(),
+            speech_config=types.SpeechConfig(
+                voice_config=types.VoiceConfig(
+                    prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                        voice_name=_voice_name
+                    )
+                )
+            ),
             system_instruction=system_instruction,
         )
         if tools:
@@ -184,10 +246,33 @@ class LiveSessionManager:
                 name=f"live_receive_{guild_id}",
             )
 
+            # Start periodic audio flush task
+            self._flush_tasks[guild_id] = asyncio.create_task(
+                self._audio_flush_loop(guild_id),
+                name=f"live_flush_{guild_id}",
+            )
+
             log_info(
                 f"[live_session] Session started for guild {guild_id} "
                 f"channel {channel_id} (model={LIVE_MODEL})"
             )
+
+            # Kick off the model with an initial text turn so it sends a greeting
+            # without waiting for user audio. The system instruction handles the persona.
+            try:
+                await session.send_client_content(
+                    turns=types.Content(
+                        role="user",
+                        parts=[types.Part(text="[Session started. Greet naturally.]")],
+                    ),
+                    turn_complete=True,
+                )
+                log_info(
+                    f"[live_session] Sent initial kick to model for guild {guild_id}"
+                )
+            except Exception as e:
+                log_warning(f"[live_session] Initial kick failed (non-fatal): {e}")
+
             return True
 
         except Exception as e:
@@ -200,6 +285,17 @@ class LiveSessionManager:
     async def stop_session(self, guild_id: int) -> None:
         """Stop the Live API session for a guild."""
         state = self._sessions.pop(guild_id, None)
+        self._send_buffers.pop(guild_id, None)
+
+        # Cancel the flush task
+        flush_task = self._flush_tasks.pop(guild_id, None)
+        if flush_task and not flush_task.done():
+            flush_task.cancel()
+            try:
+                await flush_task
+            except asyncio.CancelledError:
+                pass
+
         if not state:
             return
 
@@ -227,28 +323,91 @@ class LiveSessionManager:
         log_info(f"[live_session] Session stopped for guild {guild_id}")
 
     async def send_audio(self, guild_id: int, pcm_data: bytes) -> None:
-        """Send PCM audio data to the Live API session.
+        """Buffer PCM audio data for the Live API session.
+
+        Audio is accumulated here and flushed by ``_audio_flush_loop``
+        every ~200ms.  This avoids flooding the WebSocket with many tiny
+        messages (which can cause keepalive ping timeouts) while still
+        ensuring speech tails are sent promptly.
 
         Args:
             guild_id: Target guild's session.
             pcm_data: Raw PCM 16-bit LE, 16kHz, mono audio bytes.
         """
         state = self._sessions.get(guild_id)
-        if not state or not state.is_active or not state._session:
+        if not state or not state.is_active:
             return
 
-        # Check if session needs reconnection
-        if state.should_reconnect:
-            asyncio.create_task(self._reconnect(guild_id))
-            return
-
-        try:
-            await state._session.send_realtime_input(
-                audio=types.Blob(data=pcm_data, mime_type=LIVE_AUDIO_MIME)
+        buf = self._send_buffers.get(guild_id)
+        if buf is None:
+            buf = bytearray()
+            self._send_buffers[guild_id] = buf
+            log_debug(
+                f"[live_session] First audio data buffered for guild {guild_id} "
+                f"({len(pcm_data)} bytes)"
             )
-        except Exception as e:
-            log_warning(
-                f"[live_session] Failed to send audio for guild {guild_id}: {e}"
+        buf.extend(pcm_data)
+
+    async def _audio_flush_loop(self, guild_id: int) -> None:
+        """Periodically flush accumulated audio to the Gemini Live API.
+
+        Runs every ``_FLUSH_INTERVAL_S`` seconds, draining whatever audio
+        has accumulated in the send buffer.  This guarantees that speech
+        tails (< one full buffer) are sent within 200ms.
+        """
+        send_count = 0
+        total_bytes = 0
+        try:
+            log_info(f"[live_session] Audio flush loop started for guild {guild_id}")
+            while True:
+                await asyncio.sleep(self._FLUSH_INTERVAL_S)
+
+                state = self._sessions.get(guild_id)
+                if not state or not state.is_active or not state._session:
+                    log_info(
+                        f"[live_session] Flush loop exiting: session inactive "
+                        f"(guild {guild_id}, sent {send_count} chunks, "
+                        f"{total_bytes} bytes total)"
+                    )
+                    break
+
+                # Check if session needs reconnection
+                if state.should_reconnect:
+                    asyncio.create_task(self._reconnect(guild_id))
+                    break
+
+                buf = self._send_buffers.get(guild_id)
+                if not buf:
+                    continue  # Nothing to send
+
+                chunk = bytes(buf)
+                buf.clear()
+                send_count += 1
+                total_bytes += len(chunk)
+
+                # Log first send and then every 25 sends (~5s)
+                if send_count == 1 or send_count % 25 == 0:
+                    log_info(
+                        f"[live_session] Flush #{send_count}: sending {len(chunk)} "
+                        f"bytes to Gemini (guild {guild_id}, "
+                        f"total {total_bytes} bytes)"
+                    )
+
+                try:
+                    await state._session.send_realtime_input(
+                        audio=types.Blob(data=chunk, mime_type=LIVE_AUDIO_MIME)
+                    )
+                except Exception as e:
+                    log_warning(
+                        f"[live_session] Failed to send audio for guild {guild_id}: {e}"
+                    )
+                    if "close" in str(e).lower() or "1011" in str(e):
+                        state.is_active = False
+                        break
+        except asyncio.CancelledError:
+            log_debug(
+                f"[live_session] Flush loop cancelled for guild {guild_id} "
+                f"(sent {send_count} chunks)"
             )
 
     async def send_text(self, guild_id: int, text: str) -> None:
@@ -282,70 +441,127 @@ class LiveSessionManager:
         """Background task: receive messages from the Live API and dispatch callbacks."""
         state = self._sessions.get(guild_id)
         if not state or not state._session:
+            log_warning(
+                f"[live_session] Receive loop aborted: no state/session for guild {guild_id}"
+            )
             return
 
+        log_info(f"[live_session] Receive loop started for guild {guild_id}")
+
+        msg_count = 0
+        turn_count = 0
         try:
-            async for message in state._session.receive():
+            # receive() covers ONE complete model turn then exits.
+            # Loop to keep receiving across all turns for the duration of the session.
+            while state.is_active and state._session:
+                turn_count += 1
+                # Per-turn transcript accumulators (filled from transcription fields).
+                user_parts: list[str] = []
+                model_parts: list[str] = []
+
+                async for message in state._session.receive():
+                    if not state.is_active:
+                        break
+
+                    msg_count += 1
+                    if msg_count <= 3 or msg_count % 50 == 0:
+                        log_info(
+                            f"[live_session] Received message #{msg_count} "
+                            f"(turn {turn_count}) from Gemini (guild {guild_id})"
+                        )
+
+                    # Audio — use SDK convenience property (handles inline_data decoding)
+                    audio_data = message.data
+                    if audio_data and self._on_audio:
+                        log_debug(
+                            f"[live_session] Received audio from model: "
+                            f"{len(audio_data)} bytes"
+                        )
+                        try:
+                            await self._on_audio(guild_id, audio_data)
+                        except Exception as e:
+                            log_warning(f"[live_session] Audio callback error: {e}")
+
+                    # Text — use SDK convenience property (skips thought parts)
+                    text = message.text
+                    if text and self._on_text:
+                        try:
+                            await self._on_text(guild_id, text)
+                        except Exception as e:
+                            log_warning(f"[live_session] Text callback error: {e}")
+
+                    # Collect audio transcription fragments for both sides of the turn.
+                    # input_transcription = what the user said (speech-to-text).
+                    # output_transcription = what the model said (transcription of audio output).
+                    sc = getattr(message, "server_content", None)
+                    if sc is not None:
+                        it = getattr(sc, "input_transcription", None)
+                        if it is not None:
+                            t = getattr(it, "text", None)
+                            if t:
+                                user_parts.append(t)
+                        ot = getattr(sc, "output_transcription", None)
+                        if ot is not None:
+                            t = getattr(ot, "text", None)
+                            if t:
+                                model_parts.append(t)
+
+                    # Tool/function calls
+                    tool_call = getattr(message, "tool_call", None)
+                    if tool_call and self._on_tool_call:
+                        function_calls = getattr(tool_call, "function_calls", []) or []
+                        for fc in function_calls:
+                            fc_name: str = str(getattr(fc, "name", ""))
+                            fc_id: str = str(getattr(fc, "id", ""))
+                            call_dict = {
+                                "name": fc_name,
+                                "id": fc_id,
+                                "args": getattr(fc, "args", {}),
+                            }
+                            try:
+                                result = await self._on_tool_call(guild_id, call_dict)
+                                await state._session.send_tool_response(
+                                    function_responses=types.FunctionResponse(
+                                        name=fc_name,
+                                        id=fc_id,
+                                        response=result or {"status": "ok"},
+                                    )
+                                )
+                            except Exception as e:
+                                log_warning(
+                                    f"[live_session] Tool call handling error: {e}"
+                                )
+
+                # Turn complete — fire callback with accumulated transcripts.
+                if self._on_turn_complete and (user_parts or model_parts):
+                    user_transcript = _clean_transcript(user_parts)
+                    model_transcript = _clean_transcript(model_parts)
+                    try:
+                        await self._on_turn_complete(
+                            guild_id, user_transcript, model_transcript
+                        )
+                    except Exception as e:
+                        log_warning(f"[live_session] Turn complete callback error: {e}")
+
                 if not state.is_active:
                     break
 
-                server_content = getattr(message, "server_content", None)
-                tool_call = getattr(message, "tool_call", None)
-
-                # Handle audio/text responses
-                if server_content:
-                    model_turn = getattr(server_content, "model_turn", None)
-                    if model_turn and model_turn.parts:
-                        for part in model_turn.parts:
-                            # Audio output
-                            inline_data = getattr(part, "inline_data", None)
-                            if inline_data and inline_data.data and self._on_audio:
-                                try:
-                                    await self._on_audio(guild_id, inline_data.data)
-                                except Exception as e:
-                                    log_warning(
-                                        f"[live_session] Audio callback error: {e}"
-                                    )
-
-                            # Text output
-                            text = getattr(part, "text", None)
-                            if text and self._on_text:
-                                try:
-                                    await self._on_text(guild_id, text)
-                                except Exception as e:
-                                    log_warning(
-                                        f"[live_session] Text callback error: {e}"
-                                    )
-
-                # Handle function/tool calls
-                if tool_call and self._on_tool_call:
-                    function_calls = getattr(tool_call, "function_calls", []) or []
-                    for fc in function_calls:
-                        fc_name: str = str(getattr(fc, "name", ""))
-                        fc_id: str = str(getattr(fc, "id", ""))
-                        call_dict = {
-                            "name": fc_name,
-                            "id": fc_id,
-                            "args": getattr(fc, "args", {}),
-                        }
-                        try:
-                            result = await self._on_tool_call(guild_id, call_dict)
-                            # Send tool response back
-                            await state._session.send_tool_response(
-                                function_responses=types.FunctionResponse(
-                                    name=fc_name,
-                                    id=fc_id,
-                                    response=result or {"status": "ok"},
-                                )
-                            )
-                        except Exception as e:
-                            log_warning(f"[live_session] Tool call handling error: {e}")
+                # After each turn, check if session is approaching time limit
+                if state.should_reconnect:
+                    log_info(
+                        f"[live_session] Session nearing time limit for guild "
+                        f"{guild_id}, reconnecting"
+                    )
+                    asyncio.create_task(self._reconnect(guild_id))
+                    break
 
         except asyncio.CancelledError:
             log_debug(f"[live_session] Receive loop cancelled for guild {guild_id}")
         except Exception as e:
             log_error(f"[live_session] Receive loop error for guild {guild_id}: {e}")
             state.is_active = False
+            log_info(f"[live_session] Attempting auto-reconnect for guild {guild_id}")
+            asyncio.create_task(self._reconnect(guild_id))
 
     async def _reconnect(self, guild_id: int) -> None:
         """Reconnect a session approaching the time limit.
@@ -362,12 +578,12 @@ class LiveSessionManager:
 
         async with lock:
             state = self._sessions.get(guild_id)
-            if not state or not state.is_active:
-                return
+            if not state:
+                return  # Session was fully removed — nothing to reconnect
 
             log_info(
                 f"[live_session] Reconnecting session for guild {guild_id} "
-                f"(elapsed {state.elapsed_seconds:.0f}s)"
+                f"(elapsed {state.elapsed_seconds:.0f}s, was_active={state.is_active})"
             )
 
             channel_id = state.channel_id

--- a/docs/gemini/synth-live-voice-integration.md
+++ b/docs/gemini/synth-live-voice-integration.md
@@ -16,6 +16,7 @@ Discord User
     ▼ (48 kHz stereo PCM)
 ┌──────────────────────────┐
 │  LiveVoiceAudioSink      │ ← discord-ext-voice-recv AudioSink
+│  bot/None filter          │   (skips bot & unmapped SSRCs)
 │  48 kHz stereo → 16 kHz  │
 │  mono (audioop)           │
 └──────────┬───────────────┘
@@ -26,8 +27,9 @@ Discord User
 │  WebSocket session        │
 │  send_realtime_input()    │
 │  receive() loop           │
+│  _on_turn_complete()      │
 └──────────┬───────────────┘
-           │ 24 kHz mono PCM + tool calls
+           │ 24 kHz mono PCM + tool calls + transcripts
            ▼
 ┌──────────────────────────┐
 │  LiveAudioBuffer          │ ← interface/discord_interface.py
@@ -45,14 +47,21 @@ Discord User
       Discord User
 ```
 
+After each model turn, `_on_turn_complete` fires and persists both sides of
+the conversation across all context subsystems (see
+[Context Ingestion](#context-ingestion)).
+
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `core/live_session_manager.py` | Session lifecycle, audio I/O, receive loop, tool call dispatch, reconnect logic |
+| `core/live_session_manager.py` | Session lifecycle, audio I/O, receive loop, transcript accumulation, tool call dispatch, reconnect logic, voice config |
 | `llm_engines/gemini_api.py` | `get_live_session_manager()` factory, `start_live_voice_session()` / `stop_live_voice_session()` wrappers |
 | `core/prompt_engine.py` | `build_live_system_instruction()` — condensed persona for live sessions |
-| `interface/discord_interface.py` | Discord actions, audio pipeline classes, tool-calling bridge, voice state cleanup |
+| `interface/discord_interface.py` | Discord actions, audio pipeline classes, tool-calling bridge, `on_turn_complete` callback, voice state cleanup |
+| `core/chat_history_cache.py` | Per-interface and global chat history persistence |
+| `plugins/ai_diary.py` | Diary entry persistence |
+| `core/synth_core_memory.py` | Semantic memory persistence (`memories` table) |
 
 ## Audio Format Details
 
@@ -83,21 +92,26 @@ it based on conversation context).
    objects.
 4. **Open WebSocket** — `LiveSessionManager.start_session()` opens a
    connection to `gemini-2.5-flash-native-audio-preview-12-2025` with
-   `response_modalities=["AUDIO"]`, the system instruction, and tool
-   declarations.
+   `response_modalities=["AUDIO"]`, bidirectional transcription, the configured
+   voice, the system instruction, and tool declarations.
 5. **Start audio pipeline** — The `LivePCMAudioSource` begins playing buffered
    model audio, and `LiveVoiceAudioSink` begins forwarding user audio.
+6. **Initial kick** — A `[Session started. Greet naturally.]` text turn is sent
+   so the persona greets without waiting for the user to speak first.
 
 ### During a Session
 
-- **User speaks** → `LiveVoiceAudioSink.write()` downsamples and forwards to
-  `send_realtime_input()`.
+- **User speaks** → `LiveVoiceAudioSink.write()` filters out bot/unmapped
+  SSRCs, downsamples, and forwards to `send_realtime_input()`.
 - **Model speaks** → `_receive_loop()` dispatches `on_audio` callback →
   `LiveAudioBuffer.write()` upsamples → `LivePCMAudioSource.read()` feeds
   Discord.
 - **Model calls a function** → `_receive_loop()` dispatches `on_tool_call` →
   `_handle_live_tool_call()` → `core.action_parser.run_action()` → result
   sent back via `send_tool_response()`.
+- **Turn ends** → `_receive_loop()` fires `_on_turn_complete(guild_id,
+  user_transcript, model_transcript)` with cleaned, normalised transcripts from
+  both sides. See [Context Ingestion](#context-ingestion).
 
 ### Stopping a Session
 
@@ -125,6 +139,115 @@ Reconnection:
 **Note:** Conversation context is not preserved across reconnections yet.
 Future work: inject a conversation summary via `send_client_content()` or
 use Google's session resumption feature.
+
+## Audio Feedback Prevention
+
+`LiveVoiceAudioSink.write()` drops packets before processing if:
+
+```python
+if user is None or getattr(user, "bot", False):
+    return
+```
+
+- `user is None` — SSRC not yet mapped to a Discord user. This typically
+  includes the bot's own audio stream as reflected by Discord's voice server,
+  as well as the first few packets of any participant before mapping completes.
+- `user.bot` — Any bot user, including the bot itself if Discord has resolved
+  its SSRC.
+
+Without this guard, the bot's spoken audio is echoed back to Gemini, which
+hears its own voice and loops on it (most visibly as infinite chuckling).
+
+## Transcription and Transcript Cleaning
+
+Both `input_audio_transcription` and `output_audio_transcription` are enabled
+in `LiveConnectConfig` via `types.AudioTranscriptionConfig()`. Fragments arrive
+as streaming chunks inside `server_content.input_transcription.text` and
+`server_content.output_transcription.text` respectively.
+
+Fragments are processed by `_clean_transcript()` in
+`core/live_session_manager.py`:
+
+1. **Concatenate** with `"".join(parts)` — fragments already carry correct
+   surrounding whitespace; inserting an extra separator produces double spaces.
+2. **Strip `{...}` tags** — persona-engine emotion/state tags
+   (e.g. `{emotion neutral  intensity  3.0}`) appear in the model's output
+   audio transcription and must be removed before persistence.
+3. **Normalise whitespace** — collapse any remaining runs of two or more
+   spaces to a single space.
+
+> **Note on ASR quality:** Gemini's speech-to-text occasionally splits words
+> at sub-word boundaries (e.g. `wo ndering`). This is a model artifact; the
+> cleaning step does not attempt to rejoin split words.
+
+## Speaker Attribution
+
+`LiveVoiceAudioSink` tracks the last human speaker:
+
+```python
+self._last_speaker_name = str(
+    getattr(user, "display_name", None) or getattr(user, "name", None)
+)
+self._last_speaker_id = str(getattr(user, "id", ""))
+```
+
+`on_turn_complete` reads these from `_live_voice_state[gid]["sink"]` and
+passes them to `save_chat_message()` as `sender_name` / `sender_id`, so the
+`chat_history_cache` table records the real Discord display name and ID rather
+than the placeholder `[voice_user]`.
+
+## Context Ingestion
+
+After each model turn completes, `on_turn_complete` in
+`interface/discord_interface.py` persists the conversation to all four context
+subsystems.  The `interface_path` key used for voice conversations is
+`discord_live_{guild_id}`.
+
+| Subsystem | Table | How |
+|-----------|-------|-----|
+| `chat_history_cache` | `chat_history_cache` | `save_chat_message()` called for both sides; user entry uses real Discord name/ID from speaker attribution |
+| `ai_diary` | `ai_diary` | `add_diary_entry()` called via `run_in_executor` on the configured cadence (`_LIVE_DIARY_EVERY_N_TURNS`, default 1) |
+| `synth_core_memory` | `memories` | `silently_record_memory()` called as `asyncio.create_task` when both sides have content; tagged `["voice", "auto"]`, `source="voice"` |
+| Grillo introspection | — | Passive — Grillo's beat-based introspection reads `load_global_chat_history()` which queries all `interface_path` values including `discord_live_*` |
+
+The `chat_history_cache` load query uses `ORDER BY timestamp ASC, id ASC` so
+that user/model pairs saved within the same second always appear in insertion
+order (user before model).
+
+`discord_live_{guild_id}` entries are automatically included when
+`HistoryEngine.build_context()` calls `load_global_chat_history()`, so the
+full voice conversation history flows into future text-channel interactions and
+`build_live_system_instruction()` on reconnect.
+
+## Voice Configuration
+
+The output voice is configurable without code changes via the `LIVE_VOICE_NAME`
+config key (`.env` or persona config):
+
+```env
+LIVE_VOICE_NAME=Aoede
+```
+
+The key is read at `start_session()` time, so changing it and restarting the
+voice session (without a full process restart) picks up the new value.
+
+### Available Prebuilt Voices
+
+| Voice | Character |
+|-------|-----------|
+| **Aoede** | Breezy, natural *(default)* |
+| **Puck** | Upbeat, playful |
+| **Charon** | Informational, calm |
+| **Kore** | Firm, clear |
+| **Fenrir** | Excitable |
+| **Orbit** | Easy-going |
+| **Zephyr** | Bright |
+| **Leda** | Youthful |
+| **Orus** | Firm, deep |
+| **Autonoe** | Bright, warm |
+
+See [Google's documentation](https://ai.google.dev/gemini-api/docs/live) for
+the authoritative and up-to-date list.
 
 ## Tool / Function Calling
 
@@ -185,10 +308,12 @@ uv sync
 
 ## Configuration
 
-| Variable | Description |
-|----------|-------------|
-| `GEMINI_API_KEY` | Google AI API key (required) |
-| `DISCORD_BOT_TOKEN` | Discord bot token (required) |
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `GEMINI_API_KEY` | Google AI API key | Yes |
+| `DISCORD_BOT_TOKEN` | Discord bot token | Yes |
+| `LIVE_VOICE_NAME` | Prebuilt voice name (see [Voice Configuration](#voice-configuration)) | No (default: `Aoede`) |
+| `CONTEXT_VERBOSITY` / `CHAT_HISTORY` | History depth for `load_chat_history()` | No |
 
 The Live API model is hardcoded as `gemini-2.5-flash-native-audio-preview-12-2025`
 in `core/live_session_manager.py:LIVE_MODEL`.
@@ -203,14 +328,18 @@ in `core/live_session_manager.py:LIVE_MODEL`.
 | WebSocket disconnects | 15-minute session limit hit; reconnection should fire automatically |
 | Tool calls not working | Check `_build_gemini_tool_declarations()` log output for declaration count |
 | Bot stays in voice after session ends | `on_voice_state_update` handler should clean up; check for exceptions in logs |
+| Infinite audio loop (bot laughs or repeats itself) | Audio feedback — ensure `LiveVoiceAudioSink` bot/None filter is in place |
+| `sender_name` shows `[voice_user]` in DB | SSRC not mapped before turn ended; check `voice_recv` version and that the user was speaking before the turn fired |
+| Emotion tags in model transcript | Check `_clean_transcript()` regex; tags must be `{...}` delimited |
 
 ## Remaining Work
 
-- **Integration testing** against the real Gemini Live API (audio format
-  verification, auth, WebSocket stability).
-- **Audio output sample rate verification** — the assumed 24 kHz may differ;
-  inspect `mime_type` of received audio blobs during testing.
 - **Session resumption** — use `send_client_content()` to inject conversation
   summaries on reconnect, or implement Google's `SessionResumptionConfig`.
-- **Speech config** — add `speech_config` to `LiveConnectConfig` to
-  explicitly request a voice and output format.
+- **Integration testing** against the real Gemini Live API (audio format
+  verification, auth, WebSocket stability under load).
+- **Multi-speaker attribution** — currently only the *last* speaker before
+  turn-complete is attributed. Mixed-speaker turns lose earlier speaker info.
+- **VAD tuning** — Gemini's built-in VAD ends turns on short pauses, splitting
+  single utterances into multiple turns. Custom turn detection would require
+  buffering audio and implementing silence thresholds on our side.

--- a/interface/discord_interface.py
+++ b/interface/discord_interface.py
@@ -1,7 +1,7 @@
 import os
 import asyncio
 import audioop
-import io
+import threading
 from collections import deque
 from types import SimpleNamespace
 from typing import List, Any
@@ -36,6 +36,47 @@ from core.interfaces_registry import get_interface_registry
 
 context_memory: dict[int, deque] = {}
 chat_link_store = ChatLinkStore()
+
+# How often (turns) to flush a diary entry during a live voice session.
+# Set to 1 to capture every turn; increase to reduce write frequency.
+_LIVE_DIARY_EVERY_N_TURNS: int = 1
+
+
+async def _write_live_diary_entry(
+    guild_id: int, user_transcript: str, model_transcript: str
+) -> None:
+    """Write a diary entry for a completed Gemini Live voice turn.
+
+    Uses run_in_executor so the sync add_diary_entry call doesn't block
+    the event loop while aiomysql is scheduled back on it.
+    """
+    try:
+        import asyncio as _asyncio
+        from plugins.ai_diary import add_diary_entry
+
+        if user_transcript and len(user_transcript) > 80:
+            summary = f"Voice turn: user said '{user_transcript[:80]}…'"
+        elif user_transcript:
+            summary = f"Voice turn: user said '{user_transcript}'"
+        else:
+            summary = "Voice turn (no user transcript)"
+
+        loop = _asyncio.get_event_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: add_diary_entry(
+                content=model_transcript,
+                user_message=user_transcript,
+                interaction_summary=summary,
+                interface="discord",
+                chat_id=str(guild_id),
+            ),
+        )
+        log_debug(f"[live_voice] Diary entry written for guild {guild_id}")
+    except Exception as e:
+        log_warning(
+            f"[live_voice] Failed to write diary entry for guild {guild_id}: {e}"
+        )
 
 
 class DiscordInterface:
@@ -220,8 +261,8 @@ class DiscordInterface:
             },
             "join_voice_discord": {
                 "description": "Join a Discord voice channel.",
-                "required_fields": ["channel_id"],
-                "optional_fields": ["interface_path"],
+                "required_fields": [],
+                "optional_fields": ["channel_id", "interface_path"],
             },
             "leave_voice_discord": {
                 "description": "Leave the current Discord voice channel.",
@@ -235,8 +276,8 @@ class DiscordInterface:
             },
             "start_live_voice_discord": {
                 "description": "Start a Gemini Live API voice session in the current voice channel. Enables real-time bidirectional voice conversation.",
-                "required_fields": ["channel_id"],
-                "optional_fields": ["interface_path"],
+                "required_fields": [],
+                "optional_fields": ["channel_id", "interface_path"],
             },
             "stop_live_voice_discord": {
                 "description": "Stop the active Gemini Live API voice session.",
@@ -280,7 +321,8 @@ class DiscordInterface:
                     "channel_id": {
                         "type": "string",
                         "example": "123456789",
-                        "description": "The ID of the voice channel to join.",
+                        "description": "The ID of the voice channel to join. If the sender is in a voice channel, use input.payload.source.voice_channel_id. Otherwise derive from interface_path or omit to auto-resolve.",
+                        "optional": True,
                     },
                     "interface_path": {
                         "type": "string",
@@ -289,6 +331,10 @@ class DiscordInterface:
                         "optional": True,
                     },
                 },
+                "important_notes": [
+                    "If the sender is currently in a voice channel, their voice_channel_id is available in input.payload.source.voice_channel_id — use it as channel_id.",
+                    "If voice_channel_id is not available and no channel_id is known, omit channel_id and the system will attempt auto-resolve.",
+                ],
             }
         if action_name == "leave_voice_discord":
             return {
@@ -336,9 +382,13 @@ class DiscordInterface:
                     "channel_id": {
                         "type": "string",
                         "example": "123456789",
-                        "description": "The ID of the voice channel to start the live session in.",
+                        "description": "The ID of the voice channel to start the live session in. If the sender is in a voice channel, use input.payload.source.voice_channel_id.",
+                        "optional": True,
                     },
                 },
+                "important_notes": [
+                    "If the sender is currently in a voice channel, their voice_channel_id is available in input.payload.source.voice_channel_id — use it as channel_id.",
+                ],
             }
         if action_name == "stop_live_voice_discord":
             return {
@@ -359,12 +409,7 @@ class DiscordInterface:
         errors: list[str] = []
 
         if action_type == "join_voice_discord":
-            channel_id = payload.get("channel_id")
-            interface_path = payload.get("interface_path")
-            if not channel_id and not interface_path:
-                errors.append(
-                    "payload.channel_id or payload.interface_path is required"
-                )
+            # channel_id, interface_path, or author voice state auto-resolve at execute time
             return errors
 
         if action_type == "leave_voice_discord":
@@ -511,139 +556,6 @@ class DiscordInterface:
                 f"[discord_interface] Failed to send message to {channel_id}: {repr(e)}"
             )
 
-    async def execute_action(self, action: dict, context: dict, bot, original_message):
-        """Execute non-message actions."""
-        action_type = action.get("type")
-        payload = action.get("payload", {})
-
-        if action_type == "join_voice_discord":
-            channel_id = payload.get("channel_id")
-            interface_path = payload.get("interface_path")
-
-            if not channel_id and interface_path:
-                # Try to extract channel ID from interface path if not explicitly provided
-                try:
-                    from core.interface_path_utils import parse_interface_path
-
-                    _, levels = parse_interface_path(interface_path)
-                    # discord_bot/guild_id/channel_id
-                    if len(levels) >= 2:
-                        channel_id = levels[1]
-                except Exception:
-                    pass
-
-            if not channel_id:
-                return {"status": "failed", "message": "Missing channel_id"}
-
-            return await self._join_voice(channel_id)
-
-        elif action_type == "leave_voice_discord":
-            guild_id = payload.get("guild_id")
-            interface_path = payload.get("interface_path")
-
-            if not guild_id and interface_path:
-                try:
-                    from core.interface_path_utils import parse_interface_path
-
-                    _, levels = parse_interface_path(interface_path)
-                    if len(levels) >= 1:
-                        guild_id = levels[0]
-                except Exception:
-                    pass
-
-            if not guild_id:
-                return {"status": "failed", "message": "Missing guild_id"}
-
-            return await self._leave_voice(guild_id)
-
-        elif action_type == "audio_discord_bot":
-            audio_path = payload.get("audio")
-            channel_id = payload.get("channel_id")
-            interface_path = payload.get("interface_path")
-            caption = payload.get("caption")
-
-            if not channel_id and interface_path:
-                try:
-                    from core.interface_path_utils import parse_interface_path
-
-                    _, levels = parse_interface_path(interface_path)
-                    # discord_bot/guild_id/channel_id
-                    if len(levels) >= 2:
-                        channel_id = levels[1]
-                except Exception:
-                    pass
-
-            # Check if we are in a voice channel in this guild
-            streaming = False
-            if channel_id and self.client:
-                try:
-                    channel = self.client.get_channel(int(channel_id))
-                    if not channel:
-                        channel = await self.client.fetch_channel(int(channel_id))
-
-                    if channel and channel.guild and channel.guild.voice_client:
-                        # We are connected to voice in this guild
-                        # Verify if we are in the requested channel OR if the request was just for the guild context
-                        # Actually, if we are in ANY voice channel in this guild, we can stream.
-                        # But typically we want to stream to the channel we are in.
-                        vc = channel.guild.voice_client
-                        if vc.is_connected():
-                            return await self._stream_audio(vc, audio_path)
-                except Exception as e:
-                    log_debug(f"[discord_interface] Voice check failed: {e}")
-
-            # Fallback to sending as file
-            log_debug(
-                "[discord_interface] Not in voice or lookup failed, sending as file attachment"
-            )
-            await self.send_message(
-                channel_id=channel_id,
-                text=caption,
-                audio=audio_path,
-                interface_path=interface_path,
-            )
-            return {"status": "success", "message": "Sent as file"}
-
-        elif action_type == "start_live_voice_discord":
-            channel_id = payload.get("channel_id")
-            interface_path = payload.get("interface_path")
-
-            if not channel_id and interface_path:
-                try:
-                    from core.interface_path_utils import parse_interface_path
-
-                    _, levels = parse_interface_path(interface_path)
-                    if len(levels) >= 2:
-                        channel_id = levels[1]
-                except Exception:
-                    pass
-
-            if not channel_id:
-                return {"status": "failed", "message": "Missing channel_id"}
-
-            return await self._start_live_voice(channel_id)
-
-        elif action_type == "stop_live_voice_discord":
-            guild_id = payload.get("guild_id")
-            interface_path = payload.get("interface_path")
-
-            if not guild_id and interface_path:
-                try:
-                    from core.interface_path_utils import parse_interface_path
-
-                    _, levels = parse_interface_path(interface_path)
-                    if len(levels) >= 1:
-                        guild_id = levels[0]
-                except Exception:
-                    pass
-
-            if not guild_id:
-                return {"status": "failed", "message": "Missing guild_id"}
-
-            return await self._stop_live_voice(int(guild_id))
-
-        return {"status": "failed", "message": f"Unknown action {action_type}"}
-
     async def _stream_audio(self, voice_client, audio_path):
         """Stream audio to voice client."""
         if not os.path.exists(audio_path):
@@ -663,7 +575,11 @@ class DiscordInterface:
             return {"status": "failed", "message": str(e)}
 
     async def _join_voice(self, channel_id):
-        """Join a voice channel."""
+        """Join a voice channel.
+
+        Uses VoiceRecvClient when available so that ``_start_live_voice``
+        does not need to disconnect and reconnect.
+        """
         if not self.client:
             return {"status": "failed", "message": "Discord client not initialized"}
 
@@ -678,13 +594,19 @@ class DiscordInterface:
             guild = channel.guild
             voice_client = guild.voice_client
 
+            # Pick the right client class so live voice doesn't need to reconnect
+            cls = voice_recv.VoiceRecvClient if _HAS_VOICE_RECV and voice_recv else None
+
             if voice_client:
                 if voice_client.channel.id == channel.id:
                     return {"status": "success", "message": "Already in channel"}
                 await voice_client.move_to(channel)
                 return {"status": "success", "message": f"Moved to {channel.name}"}
             else:
-                await channel.connect()
+                if cls:
+                    await channel.connect(cls=cls)
+                else:
+                    await channel.connect()
                 return {"status": "success", "message": f"Connected to {channel.name}"}
 
         except Exception as e:
@@ -797,9 +719,79 @@ class DiscordInterface:
                 """Route Gemini function calls to the SyntH action pipeline."""
                 return await _handle_live_tool_call(gid, call_dict, self.client)
 
+            # Stable interface_path for this guild's live voice conversation.
+            live_interface_path = f"discord_live_{guild_id}"
+
+            async def on_turn_complete(
+                gid: int, user_transcript: str, model_transcript: str
+            ) -> None:
+                """Store both sides of a live turn to history and trigger diary."""
+                from core.chat_history_cache import save_chat_message
+
+                # Resolve the real Discord user from the sink's last-speaker info.
+                _sink = (
+                    self._live_voice_state.get(gid, {}).get("sink")
+                    if hasattr(self, "_live_voice_state")
+                    else None
+                )
+                _speaker_name: str | None = getattr(_sink, "_last_speaker_name", None)
+                _speaker_id: str | None = getattr(_sink, "_last_speaker_id", None)
+
+                if user_transcript:
+                    await save_chat_message(
+                        interface_path=live_interface_path,
+                        message_text=user_transcript,
+                        sender_name=_speaker_name or "[voice_user]",
+                        sender_id=_speaker_id or None,
+                    )
+                if model_transcript:
+                    await save_chat_message(
+                        interface_path=live_interface_path,
+                        message_text=model_transcript,
+                        sender_name="Synth",
+                    )
+
+                # Track turn count for diary cadence.
+                live_state = (
+                    self._live_voice_state.get(gid, {})
+                    if hasattr(self, "_live_voice_state")
+                    else {}
+                )
+                turn_n: int = live_state.get("turn_count", 0) + 1
+                if hasattr(self, "_live_voice_state") and gid in self._live_voice_state:
+                    self._live_voice_state[gid]["turn_count"] = turn_n
+
+                # Write a diary entry on the configured cadence.
+                if model_transcript and turn_n % _LIVE_DIARY_EVERY_N_TURNS == 0:
+                    asyncio.create_task(
+                        _write_live_diary_entry(gid, user_transcript, model_transcript)
+                    )
+
+                # Persist to the memories table so semantic memory search can
+                # surface voice conversations in future context injections.
+                if user_transcript and model_transcript:
+                    from core.synth_core_memory import silently_record_memory
+
+                    asyncio.create_task(
+                        silently_record_memory(
+                            user_text=user_transcript,
+                            response_text=model_transcript,
+                            tags='["voice", "auto"]',
+                            scope="general",
+                            source="voice",
+                        )
+                    )
+
+                log_debug(
+                    f"[live_voice] Turn {turn_n} stored for guild {gid}: "
+                    f"user={len(user_transcript)} chars, "
+                    f"model={len(model_transcript)} chars"
+                )
+
             manager.set_audio_callback(on_audio_from_model)
             manager.set_text_callback(on_text_from_model)
             manager.set_tool_call_callback(on_tool_call)
+            manager.set_turn_complete_callback(on_turn_complete)
 
             # Start the Live API session
             started = await manager.start_session(
@@ -832,6 +824,7 @@ class DiscordInterface:
                 "audio_buffer": audio_buffer,
                 "sink": sink,
                 "source": source,
+                "turn_count": 0,
             }
 
             log_info(
@@ -1119,6 +1112,28 @@ class DiscordInterface:
                 if not parts:
                     return
                 command, *args = parts
+
+                # Discord-specific: /leave requires guild context not available to registry handlers
+                if command == "leave":
+                    guild = getattr(message, "guild", None)
+                    if not guild:
+                        await self._discord_send(
+                            message.channel.id, "❌ Not in a server."
+                        )
+                        return
+                    await self._stop_live_voice(guild.id)
+                    leave_result = await self._leave_voice(guild.id)
+                    if leave_result.get("status") == "success":
+                        await self._discord_send(
+                            message.channel.id, "👋 Left voice channel."
+                        )
+                    else:
+                        await self._discord_send(
+                            message.channel.id,
+                            f"❌ {leave_result.get('message', 'Failed to leave.')}",
+                        )
+                    return
+
                 try:
                     response = await execute_command(command, *args)
                     if response:
@@ -1159,6 +1174,18 @@ class DiscordInterface:
                             ),
                         ),
                     )
+
+            # Check if author is currently in a voice channel (used for join_voice_discord auto-resolve)
+            voice_channel_id: str | None = None
+            try:
+                author_voice = getattr(message.author, "voice", None)
+                if author_voice and getattr(author_voice, "channel", None):
+                    voice_channel_id = str(author_voice.channel.id)
+                    log_debug(
+                        f"[discord_interface] Author is in voice channel: {voice_channel_id}"
+                    )
+            except Exception:
+                pass
 
             # Discord thread detection and handling
             thread_id = None
@@ -1223,6 +1250,7 @@ class DiscordInterface:
                 message_id=getattr(message, "id", None),
                 chat_id=channel_id,  # In Discord, this is thread ID if in thread, channel ID otherwise
                 interface_path=interface_path,  # Add interface_path to message
+                voice_channel_id=voice_channel_id,  # Author's current voice channel, if any
                 text=content,
                 caption=None,
                 date=getattr(message, "created_at", None),
@@ -1388,6 +1416,247 @@ class DiscordInterface:
                 log_warning(
                     f"[discord_interface] message_discord_bot called but no valid routing info (interface_path/target) found in payload: {payload}"
                 )
+
+        elif action_type == "join_voice_discord":
+            payload = action.get("payload", {})
+            channel_id = payload.get("channel_id")
+
+            # Fallback: use the sender's current voice channel from the wrapped message
+            # (original_message is the SimpleNamespace built in _process_message)
+            if not channel_id and original_message is not None:
+                vc_id = getattr(original_message, "voice_channel_id", None)
+                if vc_id:
+                    channel_id = str(vc_id)
+                    log_info(
+                        f"[discord_interface] join_voice_discord: auto-resolved "
+                        f"channel_id={channel_id} from sender's voice state"
+                    )
+
+            # Last resort: look up the sender's voice state live via the guild
+            if not channel_id and original_message is not None and self.client:
+                try:
+                    interface_path = payload.get("interface_path") or getattr(
+                        original_message, "interface_path", None
+                    )
+                    if interface_path:
+                        from core.interface_path_utils import parse_interface_path
+
+                        _, levels = parse_interface_path(interface_path)
+                        if levels:
+                            guild = self.client.get_guild(int(levels[0]))
+                            if guild:
+                                sender_id = getattr(
+                                    getattr(original_message, "from_user", None),
+                                    "id",
+                                    None,
+                                )
+                                if sender_id:
+                                    member = guild.get_member(int(sender_id))
+                                    if member and member.voice and member.voice.channel:
+                                        channel_id = str(member.voice.channel.id)
+                                        log_info(
+                                            f"[discord_interface] join_voice_discord: resolved "
+                                            f"channel_id={channel_id} from guild member voice state"
+                                        )
+                except Exception as e:
+                    log_debug(
+                        f"[discord_interface] join_voice_discord: guild voice lookup failed: {e}"
+                    )
+
+            if not channel_id:
+                log_warning(
+                    "[discord_interface] join_voice_discord: Missing channel_id and "
+                    "sender is not in a voice channel"
+                )
+                return
+            result = await self._join_voice(channel_id)
+
+            # Auto-start live voice session after joining
+            if result and result.get("status") == "success":
+                log_info(
+                    f"[discord_interface] join_voice_discord: auto-starting live voice "
+                    f"session in channel {channel_id}"
+                )
+                live_result = await self._start_live_voice(channel_id)
+                if live_result.get("status") != "success":
+                    log_warning(
+                        f"[discord_interface] join_voice_discord: live voice auto-start "
+                        f"failed: {live_result.get('message')}"
+                    )
+
+        elif action_type == "leave_voice_discord":
+            payload = action.get("payload", {})
+            guild_id = payload.get("guild_id")
+            interface_path = payload.get("interface_path")
+
+            if not guild_id and interface_path:
+                try:
+                    from core.interface_path_utils import parse_interface_path
+
+                    _, levels = parse_interface_path(interface_path)
+                    if len(levels) >= 1:
+                        guild_id = levels[0]
+                except Exception:
+                    pass
+
+            if not guild_id:
+                log_warning("[discord_interface] leave_voice_discord: Missing guild_id")
+                return
+            await self._leave_voice(guild_id)
+
+        elif action_type == "audio_discord_bot":
+            payload = action.get("payload", {})
+            audio_path = payload.get("audio")
+            channel_id = payload.get("channel_id")
+            interface_path = payload.get("interface_path")
+            caption = payload.get("caption")
+
+            if not channel_id and interface_path:
+                try:
+                    from core.interface_path_utils import parse_interface_path
+
+                    _, levels = parse_interface_path(interface_path)
+                    if len(levels) >= 2:
+                        channel_id = levels[1]
+                except Exception:
+                    pass
+
+            if channel_id and self.client:
+                try:
+                    channel = self.client.get_channel(int(channel_id))
+                    if not channel:
+                        channel = await self.client.fetch_channel(int(channel_id))
+                    if channel and channel.guild and channel.guild.voice_client:
+                        vc = channel.guild.voice_client
+                        if vc.is_connected():
+                            await self._stream_audio(vc, audio_path)
+                            return
+                except Exception as e:
+                    log_debug(f"[discord_interface] Voice check failed: {e}")
+
+            log_debug(
+                "[discord_interface] Not in voice or lookup failed, sending as file attachment"
+            )
+            await self.send_message(
+                channel_id=channel_id,
+                text=caption,
+                audio=audio_path,
+                interface_path=interface_path,
+            )
+
+        elif action_type == "start_live_voice_discord":
+            payload = action.get("payload", {})
+            channel_id = payload.get("channel_id")
+
+            # Skip if a live session is already running (e.g. auto-started by join_voice_discord)
+            if hasattr(self, "_live_voice_state"):
+                # Resolve guild_id to check active sessions
+                _check_guild_id: int | None = None
+                if channel_id and self.client:
+                    try:
+                        _ch = self.client.get_channel(int(channel_id))
+                        if _ch:
+                            _check_guild_id = _ch.guild.id
+                    except Exception:
+                        pass
+                if not _check_guild_id:
+                    # Try to get guild from interface_path
+                    _ip = payload.get("interface_path") or (
+                        getattr(original_message, "interface_path", None)
+                        if original_message
+                        else None
+                    )
+                    if _ip:
+                        try:
+                            from core.interface_path_utils import parse_interface_path
+
+                            _, _lvls = parse_interface_path(_ip)
+                            if _lvls:
+                                _check_guild_id = int(_lvls[0])
+                        except Exception:
+                            pass
+                if _check_guild_id and _check_guild_id in self._live_voice_state:
+                    log_info(
+                        f"[discord_interface] start_live_voice_discord: session already "
+                        f"active for guild {_check_guild_id}, skipping duplicate start"
+                    )
+                    return
+
+            # Fallback: use the sender's current voice channel from the wrapped message
+            if not channel_id and original_message is not None:
+                vc_id = getattr(original_message, "voice_channel_id", None)
+                if vc_id:
+                    channel_id = str(vc_id)
+                    log_info(
+                        f"[discord_interface] start_live_voice_discord: auto-resolved "
+                        f"channel_id={channel_id} from sender's voice state"
+                    )
+
+            # Last resort: look up the sender's voice state live via the guild
+            if not channel_id and original_message is not None and self.client:
+                try:
+                    interface_path = payload.get("interface_path") or getattr(
+                        original_message, "interface_path", None
+                    )
+                    if interface_path:
+                        from core.interface_path_utils import parse_interface_path
+
+                        _, levels = parse_interface_path(interface_path)
+                        if levels:
+                            guild = self.client.get_guild(int(levels[0]))
+                            if guild:
+                                sender_id = getattr(
+                                    getattr(original_message, "from_user", None),
+                                    "id",
+                                    None,
+                                )
+                                if sender_id:
+                                    member = guild.get_member(int(sender_id))
+                                    if member and member.voice and member.voice.channel:
+                                        channel_id = str(member.voice.channel.id)
+                                        log_info(
+                                            f"[discord_interface] start_live_voice_discord: resolved "
+                                            f"channel_id={channel_id} from guild member voice state"
+                                        )
+                except Exception as e:
+                    log_debug(
+                        f"[discord_interface] start_live_voice_discord: guild voice lookup failed: {e}"
+                    )
+
+            if not channel_id:
+                log_warning(
+                    "[discord_interface] start_live_voice_discord: Missing channel_id and "
+                    "sender is not in a voice channel"
+                )
+                return
+            await self._start_live_voice(channel_id)
+
+        elif action_type == "stop_live_voice_discord":
+            payload = action.get("payload", {})
+            guild_id = payload.get("guild_id")
+            interface_path = payload.get("interface_path")
+
+            if not guild_id and interface_path:
+                try:
+                    from core.interface_path_utils import parse_interface_path
+
+                    _, levels = parse_interface_path(interface_path)
+                    if len(levels) >= 1:
+                        guild_id = levels[0]
+                except Exception:
+                    pass
+
+            if not guild_id:
+                log_warning(
+                    "[discord_interface] stop_live_voice_discord: Missing guild_id"
+                )
+                return
+            await self._stop_live_voice(int(guild_id))
+
+        else:
+            log_warning(
+                f"[discord_interface] execute_action: unknown action_type={action_type}"
+            )
 
     async def add_reaction(self, message, emoji: str) -> bool:
         """Add a reaction to a message.
@@ -1634,16 +1903,20 @@ _DISCORD_FRAME_SIZE = 3840  # 20ms at 48kHz stereo 16-bit = 960*2*2
 
 
 class LiveAudioBuffer:
-    """Thread-safe circular buffer for PCM audio from Gemini → Discord.
+    """Thread-safe buffer for PCM audio from Gemini → Discord.
 
     Receives 24kHz mono PCM from the Live API, resamples to 48kHz stereo
     for Discord voice playback.
+
+    Both ``write`` (called from asyncio) and ``read`` (called from Discord's
+    voice send thread) must be safe across threads — uses a threading lock.
     """
 
     def __init__(self) -> None:
-        self._buffer = io.BytesIO()
-        self._lock = asyncio.Lock()
+        self._chunks: list[bytes] = []
+        self._lock = threading.Lock()
         self._closed = False
+        self._ratecv_state: Any = None  # audioop ratecv state for continuity
 
     def write(self, pcm_24k_mono: bytes) -> None:
         """Write 24kHz mono PCM data, converting to 48kHz stereo."""
@@ -1651,30 +1924,36 @@ class LiveAudioBuffer:
             return
         try:
             # 24kHz → 48kHz (ratio 2:1)
-            upsampled = audioop.ratecv(
+            upsampled, self._ratecv_state = audioop.ratecv(
                 pcm_24k_mono,
                 _DISCORD_SAMPLE_WIDTH,
                 1,
                 _GEMINI_OUTPUT_RATE,
                 _DISCORD_RATE,
-                None,
-            )[0]
+                self._ratecv_state,
+            )
             # Mono → Stereo (duplicate channel)
             stereo = audioop.tostereo(upsampled, _DISCORD_SAMPLE_WIDTH, 1, 1)
-            self._buffer.write(stereo)
-        except Exception:
-            pass
+            with self._lock:
+                self._chunks.append(stereo)
+        except Exception as e:
+            log_warning(f"[live_audio_buffer] Resample/write failed: {e}")
 
     def read(self, nbytes: int) -> bytes:
         """Read up to nbytes of 48kHz stereo PCM for Discord playback."""
-        data = self._buffer.getvalue()
-        if len(data) < nbytes:
-            # Not enough data yet — return silence
-            return b"\x00" * nbytes
-        # Consume the requested amount
+        with self._lock:
+            if not self._chunks:
+                return b""  # No data — signal silence to AudioSource
+            # Join all chunks and split at the requested boundary
+            data = b"".join(self._chunks)
+            self._chunks.clear()
+
+        if len(data) <= nbytes:
+            return data
+        # Return requested amount, put remainder back
         result = data[:nbytes]
-        remaining = data[nbytes:]
-        self._buffer = io.BytesIO(remaining)
+        with self._lock:
+            self._chunks.insert(0, data[nbytes:])
         return result
 
     def close(self) -> None:
@@ -1692,8 +1971,20 @@ class LivePCMAudioSource(discord.AudioSource if discord else object):  # type: i
         self._buffer = buffer
 
     def read(self) -> bytes:
-        """Return 20ms of audio (3840 bytes at 48kHz stereo 16-bit)."""
-        return self._buffer.read(_DISCORD_FRAME_SIZE)
+        """Return 20ms of audio (3840 bytes at 48kHz stereo 16-bit).
+
+        Returns a full silence frame when the buffer is empty so Discord
+        keeps the audio source alive (returning b'' would stop playback).
+        """
+        data = self._buffer.read(_DISCORD_FRAME_SIZE)
+        if not data:
+            # Return silence frame to keep the source alive without
+            # showing the bot as "speaking"
+            return b"\x00" * _DISCORD_FRAME_SIZE
+        if len(data) < _DISCORD_FRAME_SIZE:
+            # Pad partial frame with silence
+            data += b"\x00" * (_DISCORD_FRAME_SIZE - len(data))
+        return data
 
     def is_opus(self) -> bool:
         return False
@@ -1709,12 +2000,24 @@ if _HAS_VOICE_RECV and voice_recv is not None:
 
         Receives 48kHz stereo 16-bit PCM from Discord, converts to 16kHz mono,
         and sends to the Live API session.
+
+        NOTE: The ``write`` callback runs on the voice_recv packet-router thread,
+        **not** the asyncio event loop thread.  We capture the running loop at
+        init time and use ``call_soon_threadsafe`` to schedule coroutines.
         """
 
         def __init__(self, manager: Any, guild_id: int) -> None:
             super().__init__()
             self._manager = manager
             self._guild_id = guild_id
+            # Capture the running event loop from the main thread at construction time
+            self._loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+            self._packet_count: int = 0
+            self._ratecv_state: Any = None  # preserve resampler state across packets
+            # Track the last real user who sent audio so on_turn_complete can
+            # attribute the user-side transcript to the correct Discord account.
+            self._last_speaker_name: str | None = None
+            self._last_speaker_id: str | None = None
 
         def wants_opus(self) -> bool:
             return False  # We want decoded PCM
@@ -1722,34 +2025,60 @@ if _HAS_VOICE_RECV and voice_recv is not None:
         def write(self, user: Any, data: voice_recv.VoiceData) -> None:  # type: ignore[name-defined]
             """Process incoming audio from a Discord user.
 
+            Called from the packet-router thread — must not call asyncio
+            directly; instead schedules the coroutine on the captured loop.
+
             Args:
-                user: The Discord user who spoke.
+                user: The Discord user who spoke. May be None for unmapped SSRCs.
                 data: VoiceData containing PCM audio bytes.
             """
+            # Skip packets with an unmapped SSRC (user is None) — these are
+            # typically the bot's own audio stream reflected by Discord's voice
+            # server, or early packets before the SSRC→user mapping is ready.
+            # Also skip any bot user (including ourselves) to prevent audio
+            # feedback where Gemini hears its own output and loops on it.
+            if user is None or getattr(user, "bot", False):
+                return
+
             pcm_48k_stereo = data.pcm
             if not pcm_48k_stereo:
                 return
+
+            # Update last-speaker info for transcript attribution.
+            self._last_speaker_name = str(
+                getattr(user, "display_name", None)
+                or getattr(user, "name", None)
+                or "[voice_user]"
+            )
+            self._last_speaker_id = str(getattr(user, "id", ""))
+
+            self._packet_count += 1
+            # Log first packet and then every 500 packets (~10s at 50pps)
+            if self._packet_count == 1 or self._packet_count % 500 == 0:
+                log_info(
+                    f"[live_voice_sink] Received packet #{self._packet_count} "
+                    f"from user {user}, {len(pcm_48k_stereo)} bytes"
+                )
 
             try:
                 # Stereo → Mono (mix down)
                 mono = audioop.tomono(pcm_48k_stereo, _DISCORD_SAMPLE_WIDTH, 0.5, 0.5)
                 # 48kHz → 16kHz (ratio 3:1)
-                downsampled = audioop.ratecv(
+                downsampled, self._ratecv_state = audioop.ratecv(
                     mono,
                     _DISCORD_SAMPLE_WIDTH,
                     1,
                     _DISCORD_RATE,
                     _GEMINI_INPUT_RATE,
-                    None,
-                )[0]
-                # Send to Live API (fire-and-forget via the event loop)
-                loop = asyncio.get_event_loop()
-                if loop.is_running():
-                    asyncio.ensure_future(
-                        self._manager.send_audio(self._guild_id, downsampled)
-                    )
-            except Exception:
-                pass
+                    self._ratecv_state,
+                )
+                # Schedule on the main event loop (thread-safe)
+                asyncio.run_coroutine_threadsafe(
+                    self._manager.send_audio(self._guild_id, downsampled),
+                    self._loop,
+                )
+            except Exception as e:
+                log_warning(f"[live_voice_sink] Audio processing failed: {e}")
 
         def cleanup(self) -> None:
             pass

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from core.db import ensure_core_tables, get_conn_ctx

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -4,6 +4,7 @@ import asyncio
 import pytest
 from unittest.mock import AsyncMock
 
+
 def test_aiomysql_import_fails(monkeypatch):
     """Simula l'assenza di 'aiomysql' e verifica che l'import di core.config non fallisca."""
     # Force ImportError when trying to import aiomysql

--- a/tools/database_fix.py
+++ b/tools/database_fix.py
@@ -1,0 +1,883 @@
+#!/usr/bin/env python3
+"""
+create_missing_tables.py — Create all missing tables AND columns in the `synth` database.
+
+Usage:
+    python tools/create_missing_tables.py
+
+Behaviour:
+    1. Reads DB credentials from the project `.env` file.
+    2. Connects to the `synth` database.
+    3. Lists existing tables via SHOW TABLES.
+    4. For every expected table that is NOT present, executes the
+       corresponding CREATE TABLE IF NOT EXISTS statement.
+    5. For every expected table that IS present, checks for missing
+       columns via SHOW COLUMNS and adds them with ALTER TABLE ADD COLUMN.
+    6. Reports what was created/added and what was already present.
+
+Safety:
+    - Uses CREATE TABLE IF NOT EXISTS — will never overwrite or alter
+      existing tables.
+    - Uses ALTER TABLE ADD COLUMN — will never modify existing columns,
+      only add missing ones.
+    - Table schemas are sourced from the codebase's Python definitions
+      (authoritative), with synth-db.sql as fallback for tables only
+      defined there (grillo_beats, settings).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Locate the .env file (one level up from tools/)
+# ---------------------------------------------------------------------------
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_PROJECT_ROOT = _SCRIPT_DIR.parent
+_ENV_FILE = _PROJECT_ROOT / ".env"
+
+
+def _load_dotenv(env_path: Path) -> dict[str, str]:
+    """Minimal .env loader — no external dependencies required."""
+    env_vars: dict[str, str] = {}
+    if not env_path.is_file():
+        return env_vars
+    with open(env_path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip()
+            # Strip optional surrounding quotes
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+                value = value[1:-1]
+            env_vars[key] = value
+    return env_vars
+
+
+# ---------------------------------------------------------------------------
+# Table definitions — CREATE TABLE IF NOT EXISTS
+# ---------------------------------------------------------------------------
+# Each entry is (table_name, sql_statement).
+# The order matters only for readability; all statements are idempotent.
+TABLE_DEFINITIONS: list[tuple[str, str]] = [
+    # ── core tables ──────────────────────────────────────────────
+    (
+        "config",
+        """
+        CREATE TABLE IF NOT EXISTS config (
+            `config_key` VARCHAR(255) PRIMARY KEY,
+            `value` TEXT NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "chat_history_cache",
+        """
+        CREATE TABLE IF NOT EXISTS chat_history_cache (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            interface_path VARCHAR(512) NOT NULL,
+            sender_name VARCHAR(255),
+            sender_id VARCHAR(255),
+            message_text LONGTEXT NOT NULL,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            INDEX idx_interface_path (interface_path),
+            INDEX idx_timestamp (timestamp),
+            UNIQUE KEY uniq_message (interface_path, timestamp)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "chat_session_meta",
+        """
+        CREATE TABLE IF NOT EXISTS chat_session_meta (
+            interface_path VARCHAR(512) PRIMARY KEY,
+            meta LONGTEXT NOT NULL,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            INDEX idx_updated_at (updated_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "chat_archives",
+        """
+        CREATE TABLE IF NOT EXISTS chat_archives (
+            id VARCHAR(64) PRIMARY KEY,
+            session_id VARCHAR(255) DEFAULT NULL,
+            name VARCHAR(255) DEFAULT NULL,
+            messages LONGTEXT NOT NULL,
+            metadata LONGTEXT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            INDEX idx_session (session_id),
+            INDEX idx_created_at (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    # ── plugin tables ────────────────────────────────────────────
+    (
+        "ai_diary",
+        """
+        CREATE TABLE IF NOT EXISTS ai_diary (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            content TEXT NOT NULL COMMENT 'What synth said/did in the interaction',
+            personal_thought TEXT COMMENT 'synth personal reflection about the interaction',
+            emotions TEXT DEFAULT '[]' COMMENT 'synth emotions about this interaction',
+            interaction_summary TEXT COMMENT 'Brief summary of what happened',
+            timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            interface VARCHAR(50),
+            chat_id VARCHAR(255),
+            thread_id VARCHAR(255),
+            user_message TEXT COMMENT 'What the user said that triggered this response',
+            context_tags TEXT DEFAULT '[]' COMMENT 'Tags about the context/topic',
+            involved_users TEXT DEFAULT '[]' COMMENT 'JSON list of users involved in the interaction',
+            INDEX idx_timestamp (timestamp),
+            INDEX idx_interface_chat (interface, chat_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "ai_diary_archive",
+        """
+        CREATE TABLE IF NOT EXISTS ai_diary_archive (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            content TEXT NOT NULL COMMENT 'What synth said/did in the interaction',
+            personal_thought TEXT COMMENT 'synth personal reflection about the interaction',
+            emotions TEXT DEFAULT '[]' COMMENT 'synth emotions about this interaction',
+            interaction_summary TEXT COMMENT 'Brief summary of what happened',
+            timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            interface VARCHAR(50),
+            chat_id VARCHAR(255),
+            thread_id VARCHAR(255),
+            user_message TEXT COMMENT 'What the user said that triggered this response',
+            context_tags TEXT DEFAULT '[]' COMMENT 'Tags about the context/topic',
+            involved_users TEXT DEFAULT '[]' COMMENT 'JSON list of users involved in the interaction',
+            INDEX idx_timestamp (timestamp)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "emotion_state",
+        """
+        CREATE TABLE IF NOT EXISTS emotion_state (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            emotion_name VARCHAR(100) NOT NULL,
+            intensity FLOAT NOT NULL DEFAULT 5.0,
+            timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            INDEX idx_emotion_name (emotion_name),
+            INDEX idx_timestamp (timestamp)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "emotion_diary",
+        """
+        CREATE TABLE IF NOT EXISTS emotion_diary (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            source VARCHAR(100),
+            event VARCHAR(100),
+            emotion VARCHAR(100),
+            intensity FLOAT,
+            state VARCHAR(100),
+            trigger_condition VARCHAR(255),
+            decision_logic TEXT,
+            next_check DATETIME,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            INDEX idx_timestamp (timestamp)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "memories",
+        """
+        CREATE TABLE IF NOT EXISTS memories (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            timestamp DATETIME NOT NULL,
+            content TEXT NOT NULL,
+            author VARCHAR(100),
+            source VARCHAR(100),
+            tags TEXT,
+            scope VARCHAR(50),
+            emotion VARCHAR(50),
+            intensity INT,
+            emotion_state VARCHAR(50)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "bio",
+        """
+        CREATE TABLE IF NOT EXISTS bio (
+            id VARCHAR(255) PRIMARY KEY,
+            known_as TEXT DEFAULT '[]',
+            likes TEXT DEFAULT '[]',
+            not_likes TEXT DEFAULT '[]',
+            information TEXT DEFAULT '',
+            past_events TEXT DEFAULT '[]',
+            feelings TEXT DEFAULT '[]',
+            contacts TEXT DEFAULT '{}',
+            social_accounts TEXT DEFAULT '[]',
+            privacy TEXT DEFAULT 'default',
+            created_at VARCHAR(50),
+            last_accessed VARCHAR(50),
+            last_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            update_count INT DEFAULT 0,
+            user_name VARCHAR(255)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "scheduled_events",
+        """
+        CREATE TABLE IF NOT EXISTS scheduled_events (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            `date` DATE NOT NULL,
+            `time` TIME DEFAULT '00:00',
+            recurrence_type VARCHAR(20) DEFAULT 'none',
+            next_run DATETIME NOT NULL,
+            description TEXT NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            delivered BOOLEAN DEFAULT 0,
+            created_by VARCHAR(100) DEFAULT 'synth'
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "chatlink",
+        """
+        CREATE TABLE IF NOT EXISTS chatlink (
+            int_id INT AUTO_INCREMENT PRIMARY KEY,
+            interface VARCHAR(32) NOT NULL,
+            chat_id TEXT NOT NULL,
+            thread_id TEXT DEFAULT NULL,
+            chat_name TEXT DEFAULT NULL,
+            message_thread_name TEXT DEFAULT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            UNIQUE KEY unique_chat (interface, chat_id(255))
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "message_map",
+        """
+        CREATE TABLE IF NOT EXISTS message_map (
+            trainer_message_id INTEGER PRIMARY KEY,
+            chat_id BIGINT NOT NULL,
+            message_id INTEGER NOT NULL,
+            timestamp DOUBLE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "blocklist",
+        """
+        CREATE TABLE IF NOT EXISTS blocklist (
+            user_id BIGINT PRIMARY KEY,
+            reason TEXT,
+            blocked_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "recent_chats",
+        """
+        CREATE TABLE IF NOT EXISTS recent_chats (
+            chat_id VARCHAR(255) PRIMARY KEY,
+            last_active DOUBLE NOT NULL,
+            metadata TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            INDEX idx_last_active (last_active)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    # ── grillo tables ────────────────────────────────────────────
+    (
+        "grillo_activity_log",
+        """
+        CREATE TABLE IF NOT EXISTS grillo_activity_log (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            beat_type VARCHAR(50) NOT NULL,
+            prompt_text TEXT NOT NULL,
+            response_text LONGTEXT,
+            diary_entry_id INT,
+            executed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            metadata JSON,
+            suppressed_count INT DEFAULT 0,
+            INDEX idx_executed_at (executed_at),
+            INDEX idx_beat_type (beat_type),
+            INDEX idx_diary_entry (diary_entry_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "grillo_action_execs",
+        """
+        CREATE TABLE IF NOT EXISTS grillo_action_execs (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            activity_log_id INT NOT NULL,
+            action_index INT NOT NULL,
+            action_type VARCHAR(150) NOT NULL,
+            payload JSON,
+            status ENUM('pending','processed','failed') NOT NULL DEFAULT 'pending',
+            error_text TEXT,
+            result JSON,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            INDEX idx_activity_log_id (activity_log_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "grillo_beats",
+        # Only defined in synth-db.sql — no Python code references this table.
+        """
+        CREATE TABLE IF NOT EXISTS grillo_beats (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            beat_type VARCHAR(50) NOT NULL,
+            next_beat DATETIME NOT NULL,
+            metadata JSON,
+            enabled TINYINT(1) DEFAULT 1,
+            plugin_enabled TINYINT(1) DEFAULT 1,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    # ── agent tables ─────────────────────────────────────────────
+    # NOTE: agent_activity_log and agent_action_execs schemas are the
+    # union of columns used by BOTH agent_plugin.py and agent_core.py,
+    # which reference slightly different column sets.
+    (
+        "agent_activity_log",
+        """
+        CREATE TABLE IF NOT EXISTS agent_activity_log (
+            id BIGINT AUTO_INCREMENT PRIMARY KEY,
+            command JSON,
+            proposer VARCHAR(255),
+            status ENUM('proposed','approved','rejected','executed','cancelled') NOT NULL DEFAULT 'proposed',
+            trainer_id VARCHAR(100),
+            request_ts DATETIME DEFAULT CURRENT_TIMESTAMP,
+            response_ts DATETIME,
+            response_text LONGTEXT,
+            result LONGTEXT,
+            metadata JSON,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "agent_action_execs",
+        """
+        CREATE TABLE IF NOT EXISTS agent_action_execs (
+            id BIGINT AUTO_INCREMENT PRIMARY KEY,
+            activity_log_id BIGINT NOT NULL,
+            action_index INT NOT NULL DEFAULT 0,
+            action_type VARCHAR(150) DEFAULT NULL,
+            command TEXT,
+            payload JSON,
+            status ENUM('pending','processed','executed','failed') NOT NULL DEFAULT 'pending',
+            error_text TEXT,
+            result JSON,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            INDEX idx_activity_log_id (activity_log_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    (
+        "agent_tasks",
+        """
+        CREATE TABLE IF NOT EXISTS agent_tasks (
+            id BIGINT AUTO_INCREMENT PRIMARY KEY,
+            engine VARCHAR(64),
+            status ENUM('pending','running','waiting_for_approval','paused','completed','failed','cancelled') NOT NULL DEFAULT 'pending',
+            input JSON,
+            iterations_meta JSON,
+            output JSON,
+            trainer_id VARCHAR(64),
+            metadata JSON,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    # ── message_logs (telegram_bot.py — multimodal memory injection) ──
+    (
+        "message_logs",
+        """
+        CREATE TABLE IF NOT EXISTS message_logs (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            chat_id VARCHAR(255) NOT NULL,
+            interface VARCHAR(100),
+            sender_id VARCHAR(255),
+            sender_name VARCHAR(255),
+            content LONGTEXT,
+            role VARCHAR(50) DEFAULT 'user',
+            metadata JSON,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            INDEX idx_chat_id (chat_id),
+            INDEX idx_created_at (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    # ── archived_memories (grillo_compactor.py — compacted memory storage) ──
+    (
+        "archived_memories",
+        """
+        CREATE TABLE IF NOT EXISTS archived_memories (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            tag TEXT COMMENT 'JSON array of tags for the compacted cluster',
+            summary TEXT NOT NULL COMMENT 'LLM-generated summary of the compacted memories',
+            source_ids TEXT COMMENT 'JSON array of source ai_diary entry IDs',
+            source_count INT DEFAULT 0,
+            llm_model VARCHAR(255) COMMENT 'The LLM cortex used for summarisation',
+            confidence FLOAT COMMENT 'LLM confidence score for the summary',
+            notes TEXT COMMENT 'JSON object with justification and detail fields',
+            compaction_level INT DEFAULT 1,
+            total_source_chars INT DEFAULT 0,
+            summary_chars INT DEFAULT 0,
+            created_by VARCHAR(100) DEFAULT 'grillo_compactor',
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            INDEX idx_created_at (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+    # ── settings (only in synth-db.sql, no Python references) ───
+    (
+        "settings",
+        """
+        CREATE TABLE IF NOT EXISTS settings (
+            setting_key VARCHAR(255) PRIMARY KEY,
+            `value` TEXT NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        """,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Expected columns per table — used for ALTER TABLE ADD COLUMN
+# ---------------------------------------------------------------------------
+# Format: table_name -> list of (column_name, ADD COLUMN sql_fragment)
+#
+# These are the FULL column definitions that go after ALTER TABLE <t> ADD COLUMN.
+# Primary-key / auto-increment columns are included so the check is complete;
+# they will simply already exist and be skipped.
+#
+# Sources: same Python files as the CREATE TABLE statements above.
+EXPECTED_COLUMNS: dict[str, list[tuple[str, str]]] = {
+    # ── core ─────────────────────────────────────────────────────
+    "config": [
+        ("config_key", "`config_key` VARCHAR(255) NOT NULL"),
+        ("value",      "`value` TEXT NOT NULL"),
+        ("created_at", "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"),
+        ("updated_at", "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+    ],
+    "chat_history_cache": [
+        ("id",             "id INT AUTO_INCREMENT PRIMARY KEY"),
+        ("interface_path", "interface_path VARCHAR(512) NOT NULL"),
+        ("sender_name",    "sender_name VARCHAR(255)"),
+        ("sender_id",      "sender_id VARCHAR(255)"),
+        ("message_text",   "message_text LONGTEXT NOT NULL"),
+        ("timestamp",      "`timestamp` DATETIME DEFAULT CURRENT_TIMESTAMP"),
+    ],
+    "chat_session_meta": [
+        ("interface_path", "interface_path VARCHAR(512) NOT NULL"),
+        ("meta",           "meta LONGTEXT NOT NULL"),
+        ("updated_at",     "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+    ],
+    "chat_archives": [
+        ("id",         "id VARCHAR(64) NOT NULL"),
+        ("session_id", "session_id VARCHAR(255) DEFAULT NULL"),
+        ("name",       "`name` VARCHAR(255) DEFAULT NULL"),
+        ("messages",   "messages LONGTEXT NOT NULL"),
+        ("metadata",   "metadata LONGTEXT NULL"),
+        ("created_at", "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"),
+    ],
+    # ── plugin ───────────────────────────────────────────────────
+    "ai_diary": [
+        ("id",                  "id INT AUTO_INCREMENT PRIMARY KEY"),
+        ("content",             "content TEXT NOT NULL COMMENT 'What synth said/did in the interaction'"),
+        ("personal_thought",    "personal_thought TEXT COMMENT 'synth personal reflection about the interaction'"),
+        ("emotions",            "emotions TEXT DEFAULT '[]' COMMENT 'synth emotions about this interaction'"),
+        ("interaction_summary", "interaction_summary TEXT COMMENT 'Brief summary of what happened'"),
+        ("timestamp",           "`timestamp` TIMESTAMP DEFAULT CURRENT_TIMESTAMP"),
+        ("interface",           "interface VARCHAR(50)"),
+        ("chat_id",             "chat_id VARCHAR(255)"),
+        ("thread_id",           "thread_id VARCHAR(255)"),
+        ("user_message",        "user_message TEXT COMMENT 'What the user said that triggered this response'"),
+        ("context_tags",        "context_tags TEXT DEFAULT '[]' COMMENT 'Tags about the context/topic'"),
+        ("involved_users",      "involved_users TEXT DEFAULT '[]' COMMENT 'JSON list of users involved in the interaction'"),
+    ],
+    "ai_diary_archive": [
+        ("id",                  "id INT AUTO_INCREMENT PRIMARY KEY"),
+        ("content",             "content TEXT NOT NULL COMMENT 'What synth said/did in the interaction'"),
+        ("personal_thought",    "personal_thought TEXT COMMENT 'synth personal reflection about the interaction'"),
+        ("emotions",            "emotions TEXT DEFAULT '[]' COMMENT 'synth emotions about this interaction'"),
+        ("interaction_summary", "interaction_summary TEXT COMMENT 'Brief summary of what happened'"),
+        ("timestamp",           "`timestamp` TIMESTAMP DEFAULT CURRENT_TIMESTAMP"),
+        ("interface",           "interface VARCHAR(50)"),
+        ("chat_id",             "chat_id VARCHAR(255)"),
+        ("thread_id",           "thread_id VARCHAR(255)"),
+        ("user_message",        "user_message TEXT COMMENT 'What the user said that triggered this response'"),
+        ("context_tags",        "context_tags TEXT DEFAULT '[]' COMMENT 'Tags about the context/topic'"),
+        ("involved_users",      "involved_users TEXT DEFAULT '[]' COMMENT 'JSON list of users involved in the interaction'"),
+    ],
+    "emotion_state": [
+        ("id",           "id INT AUTO_INCREMENT PRIMARY KEY"),
+        ("emotion_name", "emotion_name VARCHAR(100) NOT NULL"),
+        ("intensity",    "intensity FLOAT NOT NULL DEFAULT 5.0"),
+        ("timestamp",    "`timestamp` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP"),
+        ("updated_at",   "updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+    ],
+    "emotion_diary": [
+        ("id",                "id INT AUTO_INCREMENT PRIMARY KEY"),
+        ("source",            "source VARCHAR(100)"),
+        ("event",             "event VARCHAR(100)"),
+        ("emotion",           "emotion VARCHAR(100)"),
+        ("intensity",         "intensity FLOAT"),
+        ("state",             "state VARCHAR(100)"),
+        ("trigger_condition", "trigger_condition VARCHAR(255)"),
+        ("decision_logic",    "decision_logic TEXT"),
+        ("next_check",        "next_check DATETIME"),
+        ("timestamp",         "`timestamp` DATETIME DEFAULT CURRENT_TIMESTAMP"),
+    ],
+    "memories": [
+        ("id",            "id INT AUTO_INCREMENT PRIMARY KEY"),
+        ("timestamp",     "`timestamp` DATETIME NOT NULL"),
+        ("content",       "content TEXT NOT NULL"),
+        ("author",        "author VARCHAR(100)"),
+        ("source",        "source VARCHAR(100)"),
+        ("tags",          "tags TEXT"),
+        ("scope",         "scope VARCHAR(50)"),
+        ("emotion",       "emotion VARCHAR(50)"),
+        ("intensity",     "intensity INT"),
+        ("emotion_state", "emotion_state VARCHAR(50)"),
+    ],
+    "bio": [
+        ("id",              "id VARCHAR(255) NOT NULL"),
+        ("known_as",        "known_as TEXT DEFAULT '[]'"),
+        ("likes",           "likes TEXT DEFAULT '[]'"),
+        ("not_likes",       "not_likes TEXT DEFAULT '[]'"),
+        ("information",     "information TEXT DEFAULT ''"),
+        ("past_events",     "past_events TEXT DEFAULT '[]'"),
+        ("feelings",        "feelings TEXT DEFAULT '[]'"),
+        ("contacts",        "contacts TEXT DEFAULT '{}'"),
+        ("social_accounts", "social_accounts TEXT DEFAULT '[]'"),
+        ("privacy",         "privacy TEXT DEFAULT 'default'"),
+        ("created_at",      "created_at VARCHAR(50)"),
+        ("last_accessed",   "last_accessed VARCHAR(50)"),
+        # Columns added by bio_manager.py migrations:
+        ("last_update",     "last_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP"),
+        ("update_count",    "update_count INT DEFAULT 0"),
+        ("user_name",       "user_name VARCHAR(255)"),
+    ],
+    "scheduled_events": [
+        ("id",              "id INT AUTO_INCREMENT PRIMARY KEY"),
+        ("date",            "`date` DATE NOT NULL"),
+        ("time",            "`time` TIME DEFAULT '00:00'"),
+        ("recurrence_type", "recurrence_type VARCHAR(20) DEFAULT 'none'"),
+        ("next_run",        "next_run DATETIME NOT NULL"),
+        ("description",     "description TEXT NOT NULL"),
+        ("created_at",      "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"),
+        ("delivered",       "delivered BOOLEAN DEFAULT 0"),
+        ("created_by",      "created_by VARCHAR(100) DEFAULT 'synth'"),
+    ],
+    "chatlink": [
+        ("int_id",              "int_id INT AUTO_INCREMENT PRIMARY KEY"),
+        ("interface",           "interface VARCHAR(32) NOT NULL"),
+        ("chat_id",             "chat_id TEXT NOT NULL"),
+        ("thread_id",           "thread_id TEXT DEFAULT NULL"),
+        ("chat_name",           "chat_name TEXT DEFAULT NULL"),
+        ("message_thread_name", "message_thread_name TEXT DEFAULT NULL"),
+        ("created_at",          "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"),
+        ("last_updated",        "last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+    ],
+    "message_map": [
+        ("trainer_message_id", "trainer_message_id INTEGER NOT NULL"),
+        ("chat_id",            "chat_id BIGINT NOT NULL"),
+        ("message_id",         "message_id INTEGER NOT NULL"),
+        ("timestamp",          "`timestamp` DOUBLE"),
+    ],
+    "blocklist": [
+        ("user_id",    "user_id BIGINT NOT NULL"),
+        ("reason",     "reason TEXT"),
+        ("blocked_at", "blocked_at DATETIME DEFAULT CURRENT_TIMESTAMP"),
+    ],
+    "recent_chats": [
+        ("chat_id",     "chat_id VARCHAR(255) NOT NULL"),
+        ("last_active", "last_active DOUBLE NOT NULL"),
+        ("metadata",    "metadata TEXT"),
+        ("created_at",  "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"),
+    ],
+    # ── grillo ───────────────────────────────────────────────────
+    "grillo_activity_log": [
+        ("id",               "id INT AUTO_INCREMENT PRIMARY KEY"),
+        ("beat_type",        "beat_type VARCHAR(50) NOT NULL"),
+        ("prompt_text",      "prompt_text TEXT NOT NULL"),
+        ("response_text",    "response_text LONGTEXT"),
+        ("diary_entry_id",   "diary_entry_id INT"),
+        ("executed_at",      "executed_at DATETIME DEFAULT CURRENT_TIMESTAMP"),
+        ("metadata",         "metadata JSON"),
+        ("suppressed_count", "suppressed_count INT DEFAULT 0"),
+    ],
+    "grillo_action_execs": [
+        ("id",              "id INT AUTO_INCREMENT PRIMARY KEY"),
+        ("activity_log_id", "activity_log_id INT NOT NULL"),
+        ("action_index",    "action_index INT NOT NULL"),
+        ("action_type",     "action_type VARCHAR(150) NOT NULL"),
+        ("payload",         "payload JSON"),
+        ("status",          "status ENUM('pending','processed','failed') NOT NULL DEFAULT 'pending'"),
+        ("error_text",      "error_text TEXT"),
+        ("result",          "`result` JSON"),
+        ("created_at",      "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"),
+        ("updated_at",      "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+    ],
+    "grillo_beats": [
+        ("id",             "id INT AUTO_INCREMENT PRIMARY KEY"),
+        ("beat_type",      "beat_type VARCHAR(50) NOT NULL"),
+        ("next_beat",      "next_beat DATETIME NOT NULL"),
+        ("metadata",       "metadata JSON"),
+        ("enabled",        "enabled TINYINT(1) DEFAULT 1"),
+        ("plugin_enabled", "plugin_enabled TINYINT(1) DEFAULT 1"),
+        ("created_at",     "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"),
+        ("updated_at",     "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+    ],
+    # ── agent ────────────────────────────────────────────────────
+    # Union of columns from agent_plugin.py and agent_core.py
+    "agent_activity_log": [
+        ("id",            "id BIGINT AUTO_INCREMENT PRIMARY KEY"),
+        ("command",       "command JSON"),
+        ("proposer",      "proposer VARCHAR(255)"),
+        ("status",        "status ENUM('proposed','approved','rejected','executed','cancelled') NOT NULL DEFAULT 'proposed'"),
+        ("trainer_id",    "trainer_id VARCHAR(100)"),
+        ("request_ts",    "request_ts DATETIME DEFAULT CURRENT_TIMESTAMP"),
+        ("response_ts",   "response_ts DATETIME"),
+        ("response_text", "response_text LONGTEXT"),
+        ("result",        "`result` LONGTEXT"),
+        ("metadata",      "metadata JSON"),
+        ("created_at",    "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"),
+        ("updated_at",    "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+    ],
+    "agent_action_execs": [
+        ("id",              "id BIGINT AUTO_INCREMENT PRIMARY KEY"),
+        ("activity_log_id", "activity_log_id BIGINT NOT NULL"),
+        ("action_index",    "action_index INT NOT NULL DEFAULT 0"),
+        ("action_type",     "action_type VARCHAR(150) DEFAULT NULL"),
+        ("command",         "command TEXT"),
+        ("payload",         "payload JSON"),
+        ("status",          "status ENUM('pending','processed','executed','failed') NOT NULL DEFAULT 'pending'"),
+        ("error_text",      "error_text TEXT"),
+        ("result",          "`result` JSON"),
+        ("created_at",      "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"),
+        ("updated_at",      "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+    ],
+    "agent_tasks": [
+        ("id",              "id BIGINT AUTO_INCREMENT PRIMARY KEY"),
+        ("engine",          "engine VARCHAR(64)"),
+        ("status",          "status ENUM('pending','running','waiting_for_approval','paused','completed','failed','cancelled') NOT NULL DEFAULT 'pending'"),
+        ("input",           "`input` JSON"),
+        ("iterations_meta", "iterations_meta JSON"),
+        ("output",          "`output` JSON"),
+        ("trainer_id",      "trainer_id VARCHAR(64)"),
+        ("metadata",        "metadata JSON"),
+        ("created_at",      "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"),
+        ("updated_at",      "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+    ],
+    # ── message_logs ─────────────────────────────────────────────
+    "message_logs": [
+        ("id",          "id INT AUTO_INCREMENT PRIMARY KEY"),
+        ("chat_id",     "chat_id VARCHAR(255) NOT NULL"),
+        ("interface",   "interface VARCHAR(100)"),
+        ("sender_id",   "sender_id VARCHAR(255)"),
+        ("sender_name", "sender_name VARCHAR(255)"),
+        ("content",     "content LONGTEXT"),
+        ("role",        "role VARCHAR(50) DEFAULT 'user'"),
+        ("metadata",    "metadata JSON"),
+        ("created_at",  "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"),
+    ],
+    # ── archived_memories ────────────────────────────────────────
+    "archived_memories": [
+        ("id",                 "id INT AUTO_INCREMENT PRIMARY KEY"),
+        ("tag",                "tag TEXT"),
+        ("summary",            "summary TEXT NOT NULL"),
+        ("source_ids",         "source_ids TEXT"),
+        ("source_count",       "source_count INT DEFAULT 0"),
+        ("llm_model",          "llm_model VARCHAR(255)"),
+        ("confidence",         "confidence FLOAT"),
+        ("notes",              "notes TEXT"),
+        ("compaction_level",   "compaction_level INT DEFAULT 1"),
+        ("total_source_chars", "total_source_chars INT DEFAULT 0"),
+        ("summary_chars",      "summary_chars INT DEFAULT 0"),
+        ("created_by",         "created_by VARCHAR(100) DEFAULT 'grillo_compactor'"),
+        ("created_at",         "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"),
+    ],
+    # ── settings ─────────────────────────────────────────────────
+    "settings": [
+        ("setting_key", "setting_key VARCHAR(255) NOT NULL"),
+        ("value",       "`value` TEXT NOT NULL"),
+        ("created_at",  "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"),
+        ("updated_at",  "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Main logic
+# ---------------------------------------------------------------------------
+def main() -> None:
+    # 1. Load .env
+    if not _ENV_FILE.is_file():
+        print(f"[ERROR] .env file not found at {_ENV_FILE}")
+        sys.exit(1)
+
+    env = _load_dotenv(_ENV_FILE)
+
+    db_host = env.get("DB_HOST", os.getenv("DB_HOST", "localhost"))
+    db_port = int(env.get("DB_PORT", os.getenv("DB_PORT", "3306")))
+    db_user = env.get("DB_USER", os.getenv("DB_USER", "root"))
+    db_pass = env.get("DB_PASS", os.getenv("DB_PASS", ""))
+    db_name = env.get("DB_NAME", os.getenv("DB_NAME", "synth"))
+
+    print(f"[INFO] Connecting to {db_user}@{db_host}:{db_port}/{db_name}")
+
+    # 2. Connect (synchronous — pymysql)
+    try:
+        import pymysql
+    except ImportError:
+        print("[ERROR] pymysql is not installed. Install it with: pip install pymysql")
+        sys.exit(1)
+
+    try:
+        conn = pymysql.connect(
+            host=db_host,
+            port=db_port,
+            user=db_user,
+            password=db_pass,
+            database=db_name,
+            charset="utf8mb4",
+            connect_timeout=10,
+        )
+    except Exception as exc:
+        print(f"[ERROR] Failed to connect to MySQL/MariaDB: {exc}")
+        sys.exit(1)
+
+    print("[INFO] Connected successfully.\n")
+
+    # 3. List existing tables
+    with conn.cursor() as cur:
+        cur.execute("SHOW TABLES")
+        existing_tables: set[str] = {row[0] for row in cur.fetchall()}
+
+    print(f"[INFO] Existing tables ({len(existing_tables)}): {', '.join(sorted(existing_tables)) or '(none)'}\n")
+
+    # ── Phase 1: Create missing tables ───────────────────────────
+    print("─── Phase 1: Creating missing tables ───")
+    tables_created: list[str] = []
+    tables_skipped: list[str] = []
+    table_errors: list[tuple[str, str]] = []
+
+    for table_name, ddl in TABLE_DEFINITIONS:
+        if table_name in existing_tables:
+            tables_skipped.append(table_name)
+            continue
+
+        try:
+            with conn.cursor() as cur:
+                cur.execute(ddl)
+            conn.commit()
+            tables_created.append(table_name)
+            existing_tables.add(table_name)       # so Phase 2 can inspect it
+            print(f"  [CREATED] {table_name}")
+        except Exception as exc:
+            table_errors.append((table_name, str(exc)))
+            print(f"  [ERROR]   {table_name}: {exc}")
+
+    if not tables_created and not table_errors:
+        print("  (all tables already present)")
+
+    # ── Phase 2: Add missing columns to existing tables ──────────
+    print("\n─── Phase 2: Adding missing columns ───")
+    columns_added: list[tuple[str, str]] = []       # (table, column)
+    columns_skipped = 0
+    column_errors: list[tuple[str, str, str]] = []  # (table, column, error)
+
+    for table_name, expected_cols in EXPECTED_COLUMNS.items():
+        if table_name not in existing_tables:
+            # Table doesn't exist and wasn't created (error in Phase 1) — skip
+            continue
+
+        # Fetch existing column names for this table
+        with conn.cursor() as cur:
+            cur.execute(f"SHOW COLUMNS FROM `{table_name}`")
+            current_columns: set[str] = {row[0] for row in cur.fetchall()}
+
+        for col_name, col_def in expected_cols:
+            if col_name in current_columns:
+                columns_skipped += 1
+                continue
+
+            # Column is missing — add it
+            alter_sql = f"ALTER TABLE `{table_name}` ADD COLUMN {col_def}"
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(alter_sql)
+                conn.commit()
+                columns_added.append((table_name, col_name))
+                print(f"  [ADDED]  {table_name}.{col_name}")
+            except Exception as exc:
+                err_msg = str(exc)
+                # Duplicate column is not a real error (race / already present)
+                if "Duplicate column" in err_msg:
+                    columns_skipped += 1
+                else:
+                    column_errors.append((table_name, col_name, err_msg))
+                    print(f"  [ERROR]  {table_name}.{col_name}: {err_msg}")
+
+    if not columns_added and not column_errors:
+        print("  (all columns already present)")
+
+    # ── Summary ──────────────────────────────────────────────────
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"  Tables already present : {len(tables_skipped)}")
+    print(f"  Tables created         : {len(tables_created)}")
+    print(f"  Table errors           : {len(table_errors)}")
+    print(f"  Columns already present: {columns_skipped}")
+    print(f"  Columns added          : {len(columns_added)}")
+    print(f"  Column errors          : {len(column_errors)}")
+
+    if tables_created:
+        print(f"\n  Created tables: {', '.join(sorted(tables_created))}")
+    if columns_added:
+        print("\n  Added columns:")
+        for tbl, col in columns_added:
+            print(f"    • {tbl}.{col}")
+    if table_errors:
+        print("\n  Table errors:")
+        for tbl, err in table_errors:
+            print(f"    • {tbl}: {err}")
+    if column_errors:
+        print("\n  Column errors:")
+        for tbl, col, err in column_errors:
+            print(f"    • {tbl}.{col}: {err}")
+
+    conn.close()
+    print("\n[INFO] Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Completes the Live API voice pipeline so that everything said in a voice session is persisted and surfaced in future context, and fixes several audio/transcript issues found during testing.

What's new

Context ingestion — each turn now writes both sides of the conversation to chat_history_cache, ai_diary, and the memories table. Grillo's introspection picks up voice turns automatically via load_global_chat_history.
Speaker attribution — LiveVoiceAudioSink tracks the last speaking Discord user; their real display name and ID are stored in chat_history_cache instead of the [voice_user] placeholder.
Voice selection — output voice is now configurable via LIVE_VOICE_NAME in .env or persona config (default: Aoede).
Transcript cleaning — fragments are joined without extra separators, {emotion …} persona tags are stripped, and double spaces are normalised.
Audio feedback fix — LiveVoiceAudioSink now drops packets where user is None (unmapped SSRC) or user.bot, preventing the bot's own audio from being echoed back to Gemini and causing infinite response loops.
History sort — load_chat_history secondary-sorts by id ASC so same-second user/model pairs always load in insertion order.
Documentation update