### PR TITLE
Feat/openrouter, fixes to stop wasting api tokens

### DIFF
--- a/core/cortex_api_logger.py
+++ b/core/cortex_api_logger.py
@@ -1,0 +1,170 @@
+# core/cortex_api_logger.py
+"""Human-readable logger for cortex LLM API requests and responses.
+
+Writes a dedicated log file (``logs/cortex_api.log``) that records every
+request/response cycle for any cortex engine.  The format is designed to
+be easy to read when tailing or opening in an editor:
+
+    ═══ REQUEST  [2026-03-03 14:05:12] engine=openrouter model=x-ai/grok-4.1-fast ═══
+    ... payload ...
+    ─── RESPONSE [2026-03-03 14:05:14] status=200 tokens=483 ────────────────────────
+    ... response body ...
+
+Usage from any cortex engine::
+
+    from core.cortex_api_logger import log_cortex_request, log_cortex_response
+
+    log_cortex_request("openrouter", model=model, payload=payload)
+    # ... perform HTTP call ...
+    log_cortex_response("openrouter", model=model, status=200, body=data, usage=usage)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import textwrap
+from datetime import datetime, timezone
+from logging.handlers import RotatingFileHandler
+from typing import Any
+
+_DEFAULT_LOG_DIR = os.path.join(os.getcwd(), "logs")
+_LOG_DIR = os.getenv("LOG_DIR", _DEFAULT_LOG_DIR)
+_LOG_FILE = os.path.join(_LOG_DIR, "cortex_api.log")
+
+_logger: logging.Logger | None = None
+
+# Separator widths
+_WIDTH = 90
+
+
+def _get_logger() -> logging.Logger:
+    """Lazily initialise and return the cortex-API file logger."""
+    global _logger
+    if _logger is not None:
+        return _logger
+
+    os.makedirs(_LOG_DIR, exist_ok=True)
+
+    logger = logging.getLogger("synth.cortex_api")
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False  # don't bubble into the main synth logger
+
+    if not logger.handlers:
+        handler = RotatingFileHandler(
+            _LOG_FILE,
+            maxBytes=10 * 1024 * 1024,  # 10 MB per file
+            backupCount=5,
+            encoding="utf-8",
+        )
+        handler.setLevel(logging.DEBUG)
+        # Minimal formatter — the visual separators already carry timestamps.
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+
+    _logger = logger
+    return logger
+
+
+def _ts() -> str:
+    """Return a human-readable UTC timestamp."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def _pretty_json(obj: Any, *, redact_keys: set[str] | None = None) -> str:
+    """Pretty-print a JSON-serialisable object, optionally redacting secrets."""
+    if redact_keys is None:
+        redact_keys = {"authorization", "api_key", "apikey", "token"}
+
+    def _redact(o: Any) -> Any:
+        if isinstance(o, dict):
+            return {
+                k: ("***" if redact_keys and k.lower() in redact_keys else _redact(v))
+                for k, v in o.items()
+            }
+        if isinstance(o, list):
+            return [_redact(i) for i in o]
+        return o
+
+    try:
+        return json.dumps(_redact(obj), indent=2, ensure_ascii=False, default=str)
+    except Exception:
+        return str(obj)
+
+
+# ── Public helpers ────────────────────────────────────────────────────────
+
+
+def log_cortex_request(
+    engine: str,
+    *,
+    model: str = "",
+    url: str = "",
+    headers: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    """Log a cortex API request in human-readable form."""
+    logger = _get_logger()
+    tag = f"engine={engine} model={model}"
+    sep = "═" * _WIDTH
+    lines = [
+        f"\n{sep}",
+        f"  REQUEST  [{_ts()}]  {tag}",
+        f"{sep}",
+    ]
+    if url:
+        lines.append(f"URL: {url}")
+    if headers:
+        lines.append(f"Headers: {_pretty_json(headers)}")
+    if payload:
+        lines.append(f"Payload:\n{_pretty_json(payload)}")
+    logger.debug("\n".join(lines))
+
+
+def log_cortex_response(
+    engine: str,
+    *,
+    model: str = "",
+    status: int | None = None,
+    body: dict[str, Any] | str | None = None,
+    usage: dict[str, Any] | None = None,
+    error: str | None = None,
+    elapsed_ms: float | None = None,
+) -> None:
+    """Log a cortex API response in human-readable form."""
+    logger = _get_logger()
+    parts = [f"engine={engine}"]
+    if model:
+        parts.append(f"model={model}")
+    if status is not None:
+        parts.append(f"status={status}")
+    if elapsed_ms is not None:
+        parts.append(f"elapsed={elapsed_ms:.0f}ms")
+    if usage:
+        prompt_tok = usage.get("prompt_tokens", "?")
+        comp_tok = usage.get("completion_tokens", "?")
+        cache_read = usage.get("prompt_tokens_details", {}).get(
+            "cached_tokens"
+        ) or usage.get("cache_read_input_tokens")
+        tok_str = f"prompt={prompt_tok} completion={comp_tok}"
+        if cache_read:
+            tok_str += f" cache_read={cache_read}"
+        parts.append(f"tokens=[{tok_str}]")
+
+    tag = "  ".join(parts)
+    sep = "─" * _WIDTH
+    lines = [
+        f"{sep}",
+        f"  RESPONSE [{_ts()}]  {tag}",
+        f"{sep}",
+    ]
+    if error:
+        lines.append(f"ERROR: {error}")
+    if body:
+        if isinstance(body, str):
+            # Likely the raw LLM content string — wrap for readability
+            lines.append(textwrap.fill(body, width=120))
+        else:
+            lines.append(_pretty_json(body))
+    logger.debug("\n".join(lines))

--- a/core/message_queue.py
+++ b/core/message_queue.py
@@ -686,9 +686,13 @@ async def _consumer_loop() -> None:
             )
             llm_name = plugin.__class__.__module__.split(".")[-1]
 
-            # Check if user is trainer for this interface
+            # Check if user is trainer for this interface.
+            # NOTE: interface_id lives on the queue item (final["interface"]),
+            # NOT on the message object itself.
             registry = get_interface_registry()
-            interface_id = getattr(user_msg, "interface_id", "unknown")
+            interface_id = final.get("interface") or getattr(
+                user_msg, "interface_id", "unknown"
+            )
             is_trainer = registry.is_trainer(interface_id, user_id)
 
             if not is_trainer and not rate_limit.is_allowed(
@@ -779,6 +783,11 @@ async def _consumer_loop() -> None:
                         # Propagate explicit request_tts flag (e.g. from handle_media_live wrap)
                         if getattr(_queued_msg, "request_tts", False):
                             context["request_tts"] = True
+                        # Propagate trainer flag so plugin_instance can route
+                        # to TRAINER_CORTEX when a scope override is configured.
+                        if is_trainer:
+                            context["is_trainer"] = True
+
                         # Propagate per-message history_scope when present so prompt_engine/history_engine can honour it
                         hs = final.get("history_scope")
                         if hs is not None:

--- a/core/plugin_instance.py
+++ b/core/plugin_instance.py
@@ -477,17 +477,18 @@ async def handle_incoming_message(
 
         # Unified multimodal extraction (extract BEFORE prompt building so
         # attachments flow through the pipeline with full context).
-        # Skip extraction when the message originated from STT voice transcription:
-        # the audio has already been converted to text, so re-downloading the voice
-        # file as an attachment would send a raw audio blob to the LLM alongside the
-        # transcription — causing confused/duplicate reasoning or failed routing.
+        # Skip extraction ONLY when the voice was already transcribed to text
+        # (e.g. by Auris STT). If the message has is_voice_input=True but NO
+        # text, it means transcription failed/was skipped and we need the raw
+        # audio attachment so the LLM engine can process it natively.
         _is_voice_input = isinstance(context_memory_or_prompt, dict) and bool(
             context_memory_or_prompt.get("is_voice_input", False)
         )
-        if _is_voice_input:
+        _has_transcribed_text = bool(getattr(message, "text", None))
+        if _is_voice_input and _has_transcribed_text:
             attachments: list[dict] = []
             log_debug(
-                "[plugin_instance] Skipping multimodal extraction: is_voice_input=True (message already transcribed)"
+                "[plugin_instance] Skipping multimodal extraction: is_voice_input=True and text present (already transcribed)"
             )
         else:
             attachments = await _extract_multimodal_attachments(
@@ -646,12 +647,53 @@ async def handle_incoming_message(
             f"[flow] -> LLM plugin: handing off chat_id={getattr(message, 'chat_id', None)} interface={interface}"
         )
 
+    # ── Scope-based engine resolution ───────────────────────────────
+    # Determine whether this request should be routed to a different
+    # cortex engine than the globally-loaded one (e.g. TRAINER_CORTEX).
+    effective_plugin = plugin
     try:
-        if plugin is None:
+        _scope: str | None = None
+        if isinstance(context_memory_or_prompt, dict):
+            if context_memory_or_prompt.get("is_trainer"):
+                _scope = "trainer"
+            elif context_memory_or_prompt.get("grillo_beat"):
+                _scope = "grillo"
+
+        log_debug(
+            f"[plugin_instance] Scope routing: _scope={_scope}, "
+            f"is_trainer={context_memory_or_prompt.get('is_trainer') if isinstance(context_memory_or_prompt, dict) else 'N/A'}, "
+            f"global_plugin={plugin.__class__.__name__ if plugin else None}"
+        )
+
+        if _scope is not None:
+            from core.config import get_active_cortex_engine
+
+            scope_engine_name = await get_active_cortex_engine(scope=_scope)
+            global_engine_name = (
+                plugin.__class__.__module__.split(".")[-1] if plugin is not None else ""
+            )
+            if scope_engine_name and scope_engine_name != global_engine_name:
+                reg = get_cortex_registry()
+                scope_engine = reg.get_engine(scope_engine_name)
+                if scope_engine is None:
+                    scope_engine = reg.load_engine(scope_engine_name)
+                if scope_engine is not None:
+                    effective_plugin = scope_engine
+                    log_info(
+                        f"[plugin_instance] Scope override: using '{scope_engine_name}' "
+                        f"for scope='{_scope}' instead of global '{global_engine_name}'"
+                    )
+    except Exception as scope_exc:
+        log_warning(
+            f"[plugin_instance] Scope routing failed, falling back to global plugin: {scope_exc}"
+        )
+
+    try:
+        if effective_plugin is None:
             log_error("[plugin_instance] No LLM plugin loaded, cannot process message")
             raise ValueError("No LLM plugin loaded")
 
-        result = await plugin.handle_incoming_message(bot, message, prompt)
+        result = await effective_plugin.handle_incoming_message(bot, message, prompt)
         try:
             _log_llm_traffic(prompt, result, interface)
         except Exception as e:

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -179,13 +179,19 @@ async def build_json_prompt(
             resolve_tone,
         )
 
-        recon_contributions = await gather_recon_contributions(
-            message=message,
-            context_memory=context_memory,
-            text=text,
-            tags=expanded_tags,
-            keywords=None,
-        )
+        if is_grillo_internal:
+            # Grillo internal beats have fixed language/tone defaults —
+            # skip the LLM recon call to avoid wasting API tokens.
+            log_debug("[json_prompt] Skipping recon LLM call for Grillo internal beat")
+            recon_contributions = []
+        else:
+            recon_contributions = await gather_recon_contributions(
+                message=message,
+                context_memory=context_memory,
+                text=text,
+                tags=expanded_tags,
+                keywords=None,
+            )
 
         for c in recon_contributions:
             ctype = c.get("type")

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -166,11 +166,19 @@ async def build_json_prompt(
     resolved_message_tone = None
     resolved_conversation_tone = None
 
-    is_grillo_internal = bool(
+    _is_grillo_beat = bool(
         getattr(message, "grillo_beat", False)
         or (isinstance(context_memory, dict) and context_memory.get("grillo_beat"))
         or (interface_path and str(interface_path).startswith("grillo"))
     )
+    # Outreach beats target an external interface (e.g. telegram_bot) —
+    # they need recon (memory search) and should NOT be treated as internal.
+    _beat_type = (
+        (isinstance(context_memory, dict) and context_memory.get("beat_type"))
+        or getattr(message, "beat_type", None)
+        or ""
+    )
+    is_grillo_internal = _is_grillo_beat and _beat_type != "outreach"
 
     try:
         from core.recon import (

--- a/core/validation_registry.py
+++ b/core/validation_registry.py
@@ -58,7 +58,14 @@ class ValidationRegistry:
     def __init__(self):
         self._rules: Dict[str, List[ValidationRule]] = {}
         self._registered_components: Set[str] = set()
-        self._response_metadata_keys: Set[str] = set()
+        # Common LLM response metadata keys that should be silently
+        # ignored rather than treated as actions (e.g. "meta", "message").
+        self._response_metadata_keys: Set[str] = {
+            "meta",
+            "metadata",
+            "rationale",
+            "thoughtSignature",
+        }
         self._response_metadata_by_component: Dict[str, Set[str]] = {}
         # Alias mapping: alias_name -> resolver(payload) -> Optional[canonical_action_type]
         # Resolvers are callables that receive the action payload and return a

--- a/core/webui.py
+++ b/core/webui.py
@@ -528,6 +528,8 @@ class SynthWebUIInterface:
         self.app.post("/api/components/cortex")(self.set_cortex_engine)
         # Login control for Selenium-based engines
         self.app.post("/api/components/cortex/login")(self.cortex_login)
+        # Model selection for cortex engines
+        self.app.post("/api/components/cortex/model")(self.set_cortex_model)
         # Run component actions on demand (e.g., Run Now button)
         self.app.post("/api/components/run")(self.run_component)
         self.app.get("/api/logchat/info")(self.get_logchat_info)
@@ -6778,6 +6780,39 @@ class SynthWebUIInterface:
                 # If SeleniumLLMBase is not importable, just skip enrichment
                 pass
 
+            # Gather model information from engines that expose it
+            supported_models: list[str] = []
+            current_model: str | None = None
+            if instance is not None:
+                try:
+                    if hasattr(instance, "get_supported_models"):
+                        supported_models = instance.get_supported_models() or []
+                except Exception:
+                    pass
+                try:
+                    if hasattr(instance, "get_current_model"):
+                        current_model = instance.get_current_model()
+                except Exception:
+                    pass
+
+            # Re-evaluate health dynamically for loaded engines (init-time status
+            # may be stale, e.g. API key set after engine was first loaded)
+            engine_status = meta["status"]
+            engine_details = meta["details"]
+            engine_error = meta["error"]
+            if instance is not None and hasattr(instance, "get_health_status"):
+                try:
+                    ok, err_msg = core_initializer._evaluate_cortex_health(instance)
+                    if ok:
+                        engine_status = "success"
+                        engine_details = f"Cortex engine: {instance.__class__.__name__}"
+                        engine_error = ""
+                    else:
+                        engine_status = "failed"
+                        engine_error = err_msg or "Engine not ready"
+                except Exception:
+                    pass
+
             cortex_engines.append(
                 {
                     "name": engine_name,
@@ -6788,9 +6823,9 @@ class SynthWebUIInterface:
                     "label": cortex_reg._engine_meta.get(engine_name, {}).get(
                         "label", ""
                     ),
-                    "status": meta["status"],
-                    "details": meta["details"],
-                    "error": meta["error"],
+                    "status": engine_status,
+                    "details": engine_details,
+                    "error": engine_error,
                     "login_state": login_state,
                     "logged_in": logged_in,
                     "login_url": login_url,
@@ -6798,6 +6833,8 @@ class SynthWebUIInterface:
                     "cortex": cortex_reg._engine_meta.get(engine_name, {}).get(
                         "cortex", "llm_provider"
                     ),
+                    "supported_models": supported_models,
+                    "current_model": current_model,
                 }
             )
         interfaces_data: List[dict] = []
@@ -7149,6 +7186,75 @@ class SynthWebUIInterface:
             ) from exc
 
         return JSONResponse({"status": "ok", "active": name})
+
+    async def set_cortex_model(self, request: Request) -> JSONResponse:
+        """Set the active model for the currently loaded cortex engine.
+
+        Expects JSON: ``{"engine": "openrouter", "model": "anthropic/claude-sonnet-4"}``
+        """
+        try:
+            data = await request.json()
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail="Invalid JSON payload") from exc
+
+        engine_name = str(data.get("engine") or "").strip()
+        model_name = str(data.get("model") or "").strip()
+        if not engine_name or not model_name:
+            raise HTTPException(status_code=400, detail="Missing 'engine' or 'model'")
+
+        try:
+            from core.cortex_registry import get_cortex_registry
+
+            registry = get_cortex_registry()
+            instance = registry.get_engine(engine_name)
+        except Exception as exc:
+            log_error(f"{LOG_PREFIX} unable to access Cortex registry: {exc}")
+            raise HTTPException(
+                status_code=500, detail="Unable to access Cortex registry"
+            ) from exc
+
+        if instance is None:
+            raise HTTPException(
+                status_code=404, detail=f"Engine '{engine_name}' not loaded"
+            )
+
+        if not hasattr(instance, "set_current_model"):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Engine '{engine_name}' does not support model selection",
+            )
+
+        try:
+            instance.set_current_model(model_name)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except Exception as exc:
+            log_error(
+                f"{LOG_PREFIX} failed to set model '{model_name}' on {engine_name}: {exc}"
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to set model: {exc}",
+            ) from exc
+
+        # Also persist to the relevant config key if available
+        try:
+            model_config_keys = {
+                "openrouter": "OPENROUTER_DEFAULT_MODEL",
+                "gemini_api": "GEMINI_MODEL",
+            }
+            config_key = model_config_keys.get(engine_name)
+            if config_key:
+                config_registry.set_value(config_key, model_name)
+        except Exception as exc:
+            log_warning(
+                f"{LOG_PREFIX} model set on engine but config persist failed: {exc}"
+            )
+
+        log_info(f"{LOG_PREFIX} Model for '{engine_name}' set to '{model_name}'")
+        return JSONResponse(
+            {"status": "ok", "engine": engine_name, "model": model_name}
+        )
 
     async def cortex_login(self, request: Request):
         """Start the login flow for a Selenium-based Cortex engine (non-blocking).

--- a/core/webui.py
+++ b/core/webui.py
@@ -513,6 +513,13 @@ class SynthWebUIInterface:
         self.app.get("/api/skins")(self.list_skins)
         self.app.post("/api/skins/{skin_name}/activate")(self.activate_skin)
         self.app.post("/api/skins/uploaded/clear")(self.clear_uploaded_vrm)
+        # Skin editor endpoints
+        self.app.post("/api/skins")(self.create_skin)
+        self.app.post("/api/skins/upload")(self.upload_skin_zip)
+        self.app.post("/api/skins/{skin_name}/vrm")(self.upload_skin_vrm)
+        self.app.post("/api/skins/{skin_name}/preview")(self.upload_skin_preview)
+        self.app.get("/api/skins/{skin_name}/download")(self.download_skin)
+        self.app.delete("/api/skins/{skin_name}")(self.delete_skin)
         self.app.get("/api/components")(self.components_summary)
         self.app.post("/api/components/reload")(self.reload_component)
         self.app.post("/api/components/dev/toggle")(self.toggle_dev_components)
@@ -8442,6 +8449,285 @@ class SynthWebUIInterface:
             raise HTTPException(status_code=500, detail="Failed to activate skin")
 
         return JSONResponse({"status": "ok", "name": target.name}, status_code=201)
+
+    # ------------------------------------------------------------------
+    # Skin editor endpoints
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _sanitize_skin_folder_name(name: str) -> str:
+        """Sanitize a skin name into a safe folder name."""
+        safe = "".join(
+            ch for ch in name if ch.isalnum() or ch in ("-", "_", " ")
+        ).strip()
+        # Replace spaces with underscores
+        safe = safe.replace(" ", "_")
+        if not safe:
+            safe = f"skin_{uuid.uuid4().hex[:8]}"
+        return safe
+
+    async def create_skin(self, request: Request) -> JSONResponse:
+        """Create a new skin folder with a persona.json.
+
+        Expects JSON body: {name, author?, version?, appearance?}
+        """
+        try:
+            body = await request.json()
+        except Exception:
+            raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+        name = (body.get("name") or "").strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="Skin name is required")
+
+        author = (body.get("author") or "").strip()
+        version = (body.get("version") or "1.0").strip()
+        appearance = (body.get("appearance") or "").strip()
+
+        folder_name = self._sanitize_skin_folder_name(name)
+        skins_dir = Path(__file__).resolve().parent.parent / "skins"
+        skin_path = skins_dir / folder_name
+
+        if skin_path.exists():
+            raise HTTPException(
+                status_code=409,
+                detail=f"A skin folder '{folder_name}' already exists",
+            )
+
+        try:
+            skin_path.mkdir(parents=True, exist_ok=False)
+            persona = {
+                "name": name,
+                "description": f"Custom skin: {name}",
+                "version": version,
+                "author": author,
+                "attributes": {"appearance": appearance} if appearance else {},
+            }
+            persona_path = skin_path / "persona.json"
+            persona_path.write_text(json.dumps(persona, indent=4), encoding="utf-8")
+        except HTTPException:
+            raise
+        except Exception as exc:
+            log_error(f"{LOG_PREFIX} Failed to create skin '{name}': {exc}")
+            raise HTTPException(status_code=500, detail="Failed to create skin")
+
+        log_info(f"{LOG_PREFIX} Created new skin '{name}' at {skin_path}")
+        return JSONResponse(
+            {"status": "ok", "folder": folder_name, "name": name}, status_code=201
+        )
+
+    async def upload_skin_vrm(
+        self, skin_name: str, file: UploadFile = File(...)
+    ) -> JSONResponse:
+        """Upload a VRM file into an existing skin folder."""
+        if not file.filename or not file.filename.lower().endswith(".vrm"):
+            raise HTTPException(status_code=400, detail="Only .vrm files are accepted")
+
+        skins_dir = Path(__file__).resolve().parent.parent / "skins"
+        skin_path = skins_dir / Path(skin_name).name
+        if not skin_path.exists() or not skin_path.is_dir():
+            raise HTTPException(status_code=404, detail="Skin not found")
+
+        # Remove any existing VRM files in the skin folder
+        for existing_vrm in skin_path.glob("*.vrm"):
+            try:
+                existing_vrm.unlink()
+            except Exception:
+                pass
+
+        target = skin_path / "model.vrm"
+        try:
+            with target.open("wb") as f:
+                while True:
+                    chunk = await file.read(1 << 20)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+        finally:
+            await file.close()
+
+        log_info(f"{LOG_PREFIX} Uploaded VRM to skin '{skin_name}'")
+        return JSONResponse({"status": "ok", "skin": skin_name}, status_code=201)
+
+    async def upload_skin_preview(
+        self, skin_name: str, file: UploadFile = File(...)
+    ) -> JSONResponse:
+        """Upload a preview image into an existing skin folder."""
+        if not file.filename:
+            raise HTTPException(status_code=400, detail="No file provided")
+
+        lower = file.filename.lower()
+        if not any(lower.endswith(ext) for ext in (".png", ".jpg", ".jpeg", ".webp")):
+            raise HTTPException(
+                status_code=400,
+                detail="Only image files (.png, .jpg, .jpeg, .webp) are accepted",
+            )
+
+        skins_dir = Path(__file__).resolve().parent.parent / "skins"
+        skin_path = skins_dir / Path(skin_name).name
+        if not skin_path.exists() or not skin_path.is_dir():
+            raise HTTPException(status_code=404, detail="Skin not found")
+
+        target = skin_path / "preview.png"
+        try:
+            with target.open("wb") as f:
+                while True:
+                    chunk = await file.read(1 << 20)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+        finally:
+            await file.close()
+
+        log_info(f"{LOG_PREFIX} Uploaded preview to skin '{skin_name}'")
+        return JSONResponse({"status": "ok", "skin": skin_name}, status_code=201)
+
+    async def download_skin(self, skin_name: str) -> FileResponse:
+        """Download a skin folder as a .zip archive."""
+        import shutil
+        import tempfile
+
+        skins_dir = Path(__file__).resolve().parent.parent / "skins"
+        skin_path = skins_dir / Path(skin_name).name
+        if not skin_path.exists() or not skin_path.is_dir():
+            raise HTTPException(status_code=404, detail="Skin not found")
+
+        try:
+            tmp_dir = tempfile.mkdtemp()
+            archive_base = Path(tmp_dir) / skin_path.name
+            archive_path = shutil.make_archive(
+                str(archive_base),
+                "zip",
+                root_dir=str(skins_dir),
+                base_dir=skin_path.name,
+            )
+            return FileResponse(
+                path=archive_path,
+                filename=f"{skin_path.name}.zip",
+                media_type="application/zip",
+            )
+        except Exception as exc:
+            log_error(
+                f"{LOG_PREFIX} Failed to create skin archive for '{skin_name}': {exc}"
+            )
+            raise HTTPException(status_code=500, detail="Failed to create skin archive")
+
+    async def upload_skin_zip(self, file: UploadFile = File(...)) -> JSONResponse:
+        """Upload a .zip skin pack and extract it into skins/."""
+        import shutil
+        import tempfile
+        import zipfile
+
+        if not file.filename or not file.filename.lower().endswith(".zip"):
+            raise HTTPException(status_code=400, detail="Only .zip files are accepted")
+
+        skins_dir = Path(__file__).resolve().parent.parent / "skins"
+        skins_dir.mkdir(parents=True, exist_ok=True)
+
+        # Save to temp file
+        tmp_dir = tempfile.mkdtemp()
+        temp_path = Path(tmp_dir) / "upload.zip"
+        try:
+            with temp_path.open("wb") as f:
+                while True:
+                    chunk = await file.read(1 << 20)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+        finally:
+            await file.close()
+
+        try:
+            with zipfile.ZipFile(temp_path, "r") as zf:
+                # Determine root folder from archive
+                names = zf.namelist()
+                if not names:
+                    raise HTTPException(status_code=400, detail="Empty zip file")
+
+                # Find root folder(s)
+                root_candidates = {n.split("/")[0] for n in names if "/" in n}
+                if len(root_candidates) == 1:
+                    root = root_candidates.pop()
+                else:
+                    root = Path(file.filename).stem
+
+                dest = skins_dir / root
+                if dest.exists():
+                    # Overwrite existing skin (except Rei)
+                    if root == "Rei":
+                        raise HTTPException(
+                            status_code=403,
+                            detail="Cannot overwrite the default Rei skin",
+                        )
+                    shutil.rmtree(dest)
+
+                zf.extractall(skins_dir)
+
+                # Validate: must have at least a persona.json or .vrm
+                has_persona = (dest / "persona.json").exists()
+                has_vrm = any(dest.glob("*.vrm"))
+                if not has_persona and not has_vrm:
+                    # Check one level deeper (zip might have nested structure)
+                    nested = list(dest.iterdir())
+                    if len(nested) == 1 and nested[0].is_dir():
+                        inner = nested[0]
+                        has_persona = (inner / "persona.json").exists()
+                        has_vrm = any(inner.glob("*.vrm"))
+                        if has_persona or has_vrm:
+                            # Move inner contents up
+                            for item in inner.iterdir():
+                                shutil.move(str(item), str(dest / item.name))
+                            inner.rmdir()
+
+                if not (dest / "persona.json").exists() and not any(dest.glob("*.vrm")):
+                    shutil.rmtree(dest, ignore_errors=True)
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Invalid skin pack: must contain persona.json or a .vrm file",
+                    )
+
+        except zipfile.BadZipFile:
+            raise HTTPException(status_code=400, detail="Invalid zip file")
+        except HTTPException:
+            raise
+        except Exception as exc:
+            log_error(f"{LOG_PREFIX} Failed to extract skin zip: {exc}")
+            raise HTTPException(status_code=500, detail="Failed to extract skin pack")
+        finally:
+            # Clean up temp file
+            try:
+                temp_path.unlink(missing_ok=True)
+                Path(tmp_dir).rmdir()
+            except Exception:
+                pass
+
+        log_info(f"{LOG_PREFIX} Uploaded skin pack '{root}'")
+        return JSONResponse({"status": "ok", "folder": root}, status_code=201)
+
+    async def delete_skin(self, skin_name: str) -> JSONResponse:
+        """Delete a skin folder. Rei is protected and cannot be deleted."""
+        import shutil
+
+        safe_name = Path(skin_name).name
+        if safe_name == "Rei":
+            raise HTTPException(
+                status_code=403,
+                detail="The default skin 'Rei' cannot be deleted",
+            )
+
+        skins_dir = Path(__file__).resolve().parent.parent / "skins"
+        skin_path = skins_dir / safe_name
+        if not skin_path.exists() or not skin_path.is_dir():
+            raise HTTPException(status_code=404, detail="Skin not found")
+
+        try:
+            shutil.rmtree(skin_path)
+        except Exception as exc:
+            log_error(f"{LOG_PREFIX} Failed to delete skin '{safe_name}': {exc}")
+            raise HTTPException(status_code=500, detail="Failed to delete skin")
+
+        log_info(f"{LOG_PREFIX} Deleted skin '{safe_name}'")
+        return JSONResponse({"status": "ok", "deleted": safe_name})
 
     # ------------------------------------------------------------------
     # WebSocket logic

--- a/core/webui_templates/sections/components.html
+++ b/core/webui_templates/sections/components.html
@@ -16,6 +16,13 @@
                     <select id="cortex-engine-select" style="padding:10px 14px; background:var(--background); color:var(--text); border:2px solid var(--primary); border-radius:10px; font-weight:700; min-width:360px; font-size:1rem;">
                     </select>
 
+                    <!-- Model selector (populated dynamically from engine's supported_models) -->
+                    <div id="cortex-model-picker" style="position:relative; display:none;">
+                        <input id="cortex-model-search" type="text" placeholder="Search models…" autocomplete="off"
+                            style="padding:10px 14px; background:var(--background); color:var(--text); border:2px solid var(--primary); border-radius:10px; font-weight:700; font-size:1rem; min-width:320px;">
+                        <div id="cortex-model-dropdown" style="display:none; position:absolute; top:100%; left:0; right:0; max-height:300px; overflow-y:auto; border:1px solid var(--border); border-radius:8px; background:var(--bg-card,#1a1a2e); z-index:999; margin-top:2px;"></div>
+                    </div>
+
                     <div id="cortex-engine-info" class="meta" style="min-width:260px;">
                         <div style="font-weight:600;" id="cortex-engine-model">model: –</div>
                         <div style="font-size:0.9rem; color:var(--muted);" id="cortex-engine-label">—</div>

--- a/core/webui_templates/sections/skins.html
+++ b/core/webui_templates/sections/skins.html
@@ -3,10 +3,46 @@
         <article class="card">
             <h2>Skins</h2>
             <p>Manage installed skins. Each skin should include at least one <code>.vrm</code> file. If a skin lacks animations, Rei will be used as fallback.</p>
-            <div style="margin-top:0.6rem; margin-bottom:0.6rem;">
-                <label for="skin-vrm-upload" class="pill">Select a skin or load a single VRM file</label>
-                <input type="file" id="skin-vrm-upload" accept=".vrm" style="display:inline-block; margin-left:0.6rem;" />
+
+            <div style="margin-top:0.6rem; margin-bottom:0.6rem; display:flex; gap:0.6rem; flex-wrap:wrap; align-items:center;">
+                <button class="pill" id="btn-new-skin">New Skin</button>
+                <label class="pill secondary" style="cursor:pointer;">
+                    Upload Skin (.zip)
+                    <input type="file" id="skin-zip-upload" accept=".zip" style="display:none;" />
+                </label>
+                <label for="skin-vrm-upload" class="pill secondary" style="cursor:pointer;">
+                    Load single VRM
+                    <input type="file" id="skin-vrm-upload" accept=".vrm" style="display:none;" />
+                </label>
             </div>
+
+            <!-- New Skin Form (hidden by default) -->
+            <div id="skin-editor-form" class="skin-editor-form" style="display:none;">
+                <h3>Create New Skin</h3>
+                <div class="skin-form-grid">
+                    <div class="skin-form-field">
+                        <label>Name <span style="color:var(--error)">*</span></label>
+                        <input type="text" id="skin-form-name" placeholder="My Skin" maxlength="64" />
+                    </div>
+                    <div class="skin-form-field">
+                        <label>Author</label>
+                        <input type="text" id="skin-form-author" placeholder="Your name" maxlength="64" />
+                    </div>
+                    <div class="skin-form-field">
+                        <label>Version</label>
+                        <input type="text" id="skin-form-version" placeholder="1.0" maxlength="16" value="1.0" />
+                    </div>
+                </div>
+                <div class="skin-form-field" style="margin-top:0.5rem;">
+                    <label>Physical Appearance</label>
+                    <textarea id="skin-form-appearance" rows="3" placeholder="Describe the avatar's physical appearance..."></textarea>
+                </div>
+                <div style="margin-top:0.75rem; display:flex; gap:0.5rem;">
+                    <button class="pill" id="btn-skin-create">Create</button>
+                    <button class="btn-ghost" id="btn-skin-cancel">Cancel</button>
+                </div>
+            </div>
+
             <div id="skins-grid" class="skins-grid">
                 <div class="meta">Loading skins...</div>
             </div>
@@ -15,5 +51,4 @@
             </div>
         </article>
     </div>
-    <script src="/js/skins.js"></script>
 </section>

--- a/core/webui_templates/synth_webui_shell.html
+++ b/core/webui_templates/synth_webui_shell.html
@@ -700,6 +700,60 @@
             display: flex;
             gap: 0.5rem;
             margin-top: auto;
+            flex-wrap: wrap;
+        }
+        .skin-actions-editor {
+            margin-top: 0.25rem;
+        }
+        .skin-actions-editor .btn-ghost {
+            font-size: 0.78rem;
+            padding: 0.3rem 0.6rem;
+        }
+        .btn-danger {
+            color: var(--error) !important;
+            border-color: var(--error) !important;
+        }
+        .btn-danger:hover {
+            background: rgba(255, 123, 147, 0.12) !important;
+        }
+        .skin-editor-form {
+            background: var(--surface-alt);
+            border: 1px solid var(--border);
+            border-radius: 16px;
+            padding: 1.2rem;
+            margin-bottom: 1rem;
+        }
+        .skin-editor-form h3 {
+            margin: 0 0 0.75rem 0;
+            font-size: 1rem;
+        }
+        .skin-form-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+            gap: 0.75rem;
+        }
+        .skin-form-field label {
+            display: block;
+            font-size: 0.82rem;
+            color: var(--text-soft);
+            margin-bottom: 0.25rem;
+        }
+        .skin-form-field input,
+        .skin-form-field textarea {
+            width: 100%;
+            background: rgba(255,255,255,0.05);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            color: var(--text);
+            padding: 0.45rem 0.65rem;
+            font-family: inherit;
+            font-size: 0.88rem;
+            resize: vertical;
+        }
+        .skin-form-field input:focus,
+        .skin-form-field textarea:focus {
+            outline: none;
+            border-color: var(--accent);
         }
         .btn-primary {
             background: var(--accent);

--- a/cortex/llm_provider/gemini_api.py
+++ b/cortex/llm_provider/gemini_api.py
@@ -914,11 +914,17 @@ class GeminiAPIPlugin(AIPluginBase):
         is_grillo = interface == "grillo" or (
             isinstance(prompt_dict, dict) and prompt_dict.get("grillo_beat")
         )
+        # Outreach beats are grillo-initiated but MUST produce message_*
+        # actions to reach the target interface (e.g. telegram_bot).
+        is_grillo_internal = is_grillo and (
+            not isinstance(prompt_dict, dict)
+            or prompt_dict.get("beat_type", "internal") != "outreach"
+        )
 
         # Minimal system instruction - the prompt itself contains full action schemas
         # We just need to remind the model to output valid JSON
-        if is_grillo:
-            # Grillo internal beats should NEVER produce message_* actions
+        if is_grillo_internal:
+            # Internal beats (tag_elaboration, self_reflection, etc.)
             interface_hint = (
                 "CURRENT INTERFACE: grillo (INTERNAL)\n"
                 "This is an internal introspection beat. Do NOT output any message_* actions.\n"

--- a/cortex/llm_provider/gemini_api.py
+++ b/cortex/llm_provider/gemini_api.py
@@ -17,9 +17,11 @@ from __future__ import annotations
 
 from core.ai_plugin_base import AIPluginBase
 from core.config_manager import config_registry
+from core.cortex_api_logger import log_cortex_request, log_cortex_response
 from core.logging_utils import log_debug, log_info, log_warning, log_error
 import json
 import asyncio
+import time as _time
 import requests
 import base64
 import mimetypes
@@ -437,12 +439,12 @@ class GeminiAPIPlugin(AIPluginBase):
             # Correction: gemini-3-flash-preview supports audio/video in generate_content
             # If it fails, we can fallback, but it should work.
 
-            prompt = "You are listening/watching a message from the user. Respond naturally and concisely in text."
+            prompt = (
+                "Transcribe the following audio/video message exactly as spoken. "
+                "Output ONLY the transcribed text — no commentary, no timestamps, "
+                "no formatting. If the audio is unclear or empty, output an empty string."
+            )
 
-            # Using raw API via google-genai
-            # content = [text, media]
-
-            # We must use proper Part objects
             from google.genai import types
 
             response = await self.client.aio.models.generate_content(
@@ -460,7 +462,11 @@ class GeminiAPIPlugin(AIPluginBase):
                     )
                 ],
                 config=types.GenerateContentConfig(
-                    system_instruction="You are a helpful AI assistant. Respond strictly with the text of your reply. Do not output JSON.",
+                    system_instruction=(
+                        "You are a speech-to-text transcription system. "
+                        "Output ONLY the exact words spoken. Do not add any "
+                        "interpretation, response, or JSON."
+                    ),
                     response_mime_type="text/plain",
                 ),
             )
@@ -905,8 +911,25 @@ class GeminiAPIPlugin(AIPluginBase):
         }
         message_action = interface_to_action.get(interface, f"message_{interface}")
 
+        is_grillo = interface == "grillo" or (
+            isinstance(prompt_dict, dict) and prompt_dict.get("grillo_beat")
+        )
+
         # Minimal system instruction - the prompt itself contains full action schemas
         # We just need to remind the model to output valid JSON
+        if is_grillo:
+            # Grillo internal beats should NEVER produce message_* actions
+            interface_hint = (
+                "CURRENT INTERFACE: grillo (INTERNAL)\n"
+                "This is an internal introspection beat. Do NOT output any message_* actions.\n"
+                "Use ONLY internal actions like 'create_personal_diary_entry', 'set_emotion', etc."
+            )
+        else:
+            interface_hint = (
+                f"CURRENT INTERFACE: {interface}\n"
+                f"TO SEND A MESSAGE TO THE USER: Use action type '{message_action}'"
+            )
+
         system_instruction = (
             "You are part of the 'Synthetic Heart' AI system.\n"
             "\n"
@@ -916,8 +939,7 @@ class GeminiAPIPlugin(AIPluginBase):
             '3. Use this structure: {"actions": [{"type": "action_name", "payload": {...}}]}\n'
             "4. NO markdown code blocks, NO explanations outside JSON\n"
             "\n"
-            f"CURRENT INTERFACE: {interface}\n"
-            f"TO SEND A MESSAGE TO THE USER: Use action type '{message_action}'\n"
+            f"{interface_hint}\n"
             "\n"
             "The prompt contains a complete action schema with available actions.\n"
             "Follow those instructions precisely.\n"
@@ -993,6 +1015,15 @@ class GeminiAPIPlugin(AIPluginBase):
                 },
             ],
         }
+
+        # ── Log the outgoing request ──────────────────────────────────
+        log_cortex_request(
+            "gemini_api",
+            model=self._current_model,
+            url=url,
+            payload=payload,
+        )
+        _req_start = _time.monotonic()
 
         def _do_request():
             return requests.post(
@@ -1093,6 +1124,21 @@ class GeminiAPIPlugin(AIPluginBase):
                 }
             )
 
+        # Log error responses from the API
+        if "error" in data:
+            _elapsed = (_time.monotonic() - _req_start) * 1000
+            err = data["error"]
+            err_msg = (
+                err.get("message", str(err)) if isinstance(err, dict) else str(err)
+            )
+            log_cortex_response(
+                "gemini_api",
+                model=self._current_model,
+                status=response.status_code if response else None,
+                error=err_msg,
+                elapsed_ms=_elapsed,
+            )
+
         candidates = data.get("candidates") or []
         if not candidates:
             log_error(f"[gemini_api] HTTP response missing candidates: {data}")
@@ -1129,6 +1175,23 @@ class GeminiAPIPlugin(AIPluginBase):
                     ]
                 }
             )
+
+        # ── Log the response ────────────────────────────────────────────
+        _elapsed = (_time.monotonic() - _req_start) * 1000
+        usage_meta = data.get("usageMetadata") or {}
+        log_cortex_response(
+            "gemini_api",
+            model=self._current_model,
+            status=response.status_code if response else None,
+            body=response_text,
+            usage={
+                "prompt_tokens": usage_meta.get("promptTokenCount"),
+                "completion_tokens": usage_meta.get("candidatesTokenCount"),
+            }
+            if usage_meta
+            else None,
+            elapsed_ms=_elapsed,
+        )
 
         return response_text
 

--- a/cortex/llm_provider/openapi.py
+++ b/cortex/llm_provider/openapi.py
@@ -1,0 +1,1463 @@
+# cortex/llm_provider/openapi.py
+"""Generic OpenAPI LLM Engine for Synthetic Heart.
+
+This engine connects to ANY OpenAI-compatible endpoint (Ollama, LM Studio,
+vLLM, custom endpoints) to use external LLM services or custom skills.
+
+Key features:
+- Configurable base URL and optional API key authentication
+- Auto-discovery from /v1/models endpoint OR manual model catalog
+- Multimodal support (images, audio) with toggle flags
+- Custom headers for special endpoint requirements
+- Simplified implementation (no provider-specific features)
+
+Use cases:
+- Connect to local LLMs (Ollama, LM Studio)
+- Use remote vLLM deployments
+- Access custom tool-calling endpoints
+- Integrate external AI services
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import copy
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from core.ai_plugin_base import AIPluginBase
+from core.config_manager import config_registry
+from core.cortex_api_logger import log_cortex_request, log_cortex_response
+from core.logging_utils import log_debug, log_error, log_info, log_warning
+
+ENGINE_LABEL = "Generic OpenAPI — connect to any OpenAI-compatible endpoint"
+
+# ---------------------------------------------------------------------------
+# WebUI variable registration (always visible so keys can be set before use)
+# ---------------------------------------------------------------------------
+try:
+    from core.variables_engine import register_exposed_var
+
+    # Core settings
+    register_exposed_var(
+        "OPENAPI_BASE_URL",
+        label="OpenAPI Base URL",
+        default="http://localhost:11434/v1",
+        value_type=str,
+        ui_type="string",
+        description="Base URL for the OpenAI-compatible endpoint (e.g., http://localhost:11434/v1 for Ollama).",
+        scope="llm",
+        component="openapi",
+        tags=["cortex_engine"],
+        needs_component_reload=True,
+    )
+    register_exposed_var(
+        "OPENAPI_API_KEY",
+        label="API Key (Optional)",
+        default="",
+        value_type=str,
+        ui_type="password",
+        description="Bearer token for authentication (leave empty for local endpoints like Ollama).",
+        scope="llm",
+        component="openapi",
+        tags=["cortex_engine", "sensitive"],
+        needs_component_reload=True,
+    )
+    register_exposed_var(
+        "OPENAPI_DEFAULT_MODEL",
+        label="Default Model",
+        default="llama3",
+        value_type=str,
+        ui_type="combobox",
+        description="Model name to use (e.g., llama3 for Ollama, local-model for LM Studio).",
+        scope="llm",
+        component="openapi",
+        tags=["cortex_engine"],
+        needs_component_reload=False,
+    )
+
+    # Advanced settings
+    register_exposed_var(
+        "OPENAPI_TIMEOUT",
+        label="Request Timeout (seconds)",
+        default="120",
+        value_type=int,
+        ui_type="number",
+        description="HTTP request timeout in seconds.",
+        scope="llm",
+        component="openapi",
+        tags=["cortex_engine"],
+        advanced=True,
+    )
+    register_exposed_var(
+        "OPENAPI_MAX_RETRIES",
+        label="Max Retries",
+        default="3",
+        value_type=int,
+        ui_type="number",
+        description="Number of retry attempts for transient errors.",
+        scope="llm",
+        component="openapi",
+        tags=["cortex_engine"],
+        advanced=True,
+    )
+    register_exposed_var(
+        "OPENAPI_CUSTOM_HEADERS",
+        label="Custom Headers",
+        default="{}",
+        value_type="json",
+        ui_type="json",
+        description='Additional HTTP headers as JSON object (e.g., {"X-Organization": "myorg"}).',
+        scope="llm",
+        component="openapi",
+        tags=["cortex_engine"],
+        advanced=True,
+    )
+
+    # Model management
+    register_exposed_var(
+        "OPENAPI_MODEL_CATALOG",
+        label="Manual Model Catalog",
+        default="[]",
+        value_type="json",
+        ui_type="json",
+        description='Manual model list as JSON array (e.g., [{"id": "model-1", "name": "Model 1", "context_length": 32000}]).',
+        scope="llm",
+        component="openapi",
+        tags=["cortex_engine"],
+        advanced=True,
+    )
+    register_exposed_var(
+        "OPENAPI_AUTO_DISCOVER",
+        label="Auto-Discover Models",
+        default="true",
+        value_type=bool,
+        ui_type="bool",
+        description="Automatically fetch models from /v1/models endpoint.",
+        scope="llm",
+        component="openapi",
+        tags=["cortex_engine"],
+        advanced=True,
+    )
+    register_exposed_var(
+        "OPENAPI_CATALOG_REFRESH",
+        label="Catalog Refresh (minutes)",
+        default="60",
+        value_type=int,
+        ui_type="number",
+        description="Minutes between model catalog refreshes.",
+        scope="llm",
+        component="openapi",
+        tags=["cortex_engine"],
+        advanced=True,
+    )
+
+    # Capabilities
+    register_exposed_var(
+        "OPENAPI_SUPPORTS_VISION",
+        label="Enable Vision Support",
+        default="false",
+        value_type=bool,
+        ui_type="bool",
+        description="Enable image/vision inputs (endpoint must support it).",
+        scope="llm",
+        component="openapi",
+        tags=["cortex_engine"],
+        advanced=True,
+    )
+    register_exposed_var(
+        "OPENAPI_SUPPORTS_AUDIO",
+        label="Enable Audio Support",
+        default="false",
+        value_type=bool,
+        ui_type="bool",
+        description="Enable audio inputs (endpoint must support it).",
+        scope="llm",
+        component="openapi",
+        tags=["cortex_engine"],
+        advanced=True,
+    )
+    register_exposed_var(
+        "OPENAPI_SUPPORTS_TOOLS",
+        label="Enable Tool/Function Calling",
+        default="false",
+        value_type=bool,
+        ui_type="bool",
+        description="Enable tool/function calling (endpoint must support it).",
+        scope="llm",
+        component="openapi",
+        tags=["cortex_engine"],
+        advanced=True,
+    )
+
+    # Context limits (fallback)
+    register_exposed_var(
+        "OPENAPI_DEFAULT_CONTEXT",
+        label="Default Context Window (chars)",
+        default="128000",
+        value_type=int,
+        ui_type="number",
+        description="Default context window in characters (used if endpoint doesn't provide it).",
+        scope="llm",
+        component="openapi",
+        tags=["cortex_engine"],
+        advanced=True,
+    )
+    register_exposed_var(
+        "OPENAPI_DEFAULT_MAX_TOKENS",
+        label="Default Max Output Tokens",
+        default="4096",
+        value_type=int,
+        ui_type="number",
+        description="Default max output tokens (used if endpoint doesn't provide it).",
+        scope="llm",
+        component="openapi",
+        tags=["cortex_engine"],
+        advanced=True,
+    )
+except Exception:
+    pass
+
+# ---------------------------------------------------------------------------
+# Config variables (auto-updating)
+# ---------------------------------------------------------------------------
+OPENAPI_BASE_URL = config_registry.get_var(
+    "OPENAPI_BASE_URL",
+    "http://localhost:11434/v1",
+    label="OpenAPI Base URL",
+    description="Base URL for the OpenAI-compatible endpoint.",
+    group="llm",
+    component="openapi",
+)
+
+OPENAPI_API_KEY = config_registry.get_var(
+    "OPENAPI_API_KEY",
+    "",
+    label="API Key (Optional)",
+    description="Bearer token for authentication.",
+    group="llm",
+    component="openapi",
+    sensitive=True,
+)
+
+OPENAPI_DEFAULT_MODEL = config_registry.get_var(
+    "OPENAPI_DEFAULT_MODEL",
+    "llama3",
+    label="Default Model",
+    description="Model name to use.",
+    group="llm",
+    component="openapi",
+)
+
+OPENAPI_TIMEOUT = config_registry.get_var(
+    "OPENAPI_TIMEOUT",
+    120,
+    label="Request Timeout",
+    description="HTTP request timeout in seconds.",
+    group="llm",
+    component="openapi",
+    value_type=int,
+    advanced=True,
+)
+
+OPENAPI_MAX_RETRIES = config_registry.get_var(
+    "OPENAPI_MAX_RETRIES",
+    3,
+    label="Max Retries",
+    description="Number of retry attempts.",
+    group="llm",
+    component="openapi",
+    value_type=int,
+    advanced=True,
+)
+
+OPENAPI_CUSTOM_HEADERS = config_registry.get_var(
+    "OPENAPI_CUSTOM_HEADERS",
+    "{}",
+    label="Custom Headers",
+    description="Additional HTTP headers as JSON.",
+    group="llm",
+    component="openapi",
+    value_type="json",
+    advanced=True,
+)
+
+OPENAPI_MODEL_CATALOG = config_registry.get_var(
+    "OPENAPI_MODEL_CATALOG",
+    "[]",
+    label="Manual Model Catalog",
+    description="Manual model list as JSON array.",
+    group="llm",
+    component="openapi",
+    value_type="json",
+    advanced=True,
+)
+
+OPENAPI_AUTO_DISCOVER = config_registry.get_var(
+    "OPENAPI_AUTO_DISCOVER",
+    True,
+    label="Auto-Discover Models",
+    description="Automatically fetch models from /v1/models endpoint.",
+    group="llm",
+    component="openapi",
+    value_type=bool,
+    advanced=True,
+)
+
+OPENAPI_CATALOG_REFRESH = config_registry.get_var(
+    "OPENAPI_CATALOG_REFRESH",
+    60,
+    label="Catalog Refresh (minutes)",
+    description="Minutes between model catalog refreshes.",
+    group="llm",
+    component="openapi",
+    value_type=int,
+    advanced=True,
+)
+
+OPENAPI_SUPPORTS_VISION = config_registry.get_var(
+    "OPENAPI_SUPPORTS_VISION",
+    False,
+    label="Enable Vision Support",
+    description="Enable image/vision inputs.",
+    group="llm",
+    component="openapi",
+    value_type=bool,
+    advanced=True,
+)
+
+OPENAPI_SUPPORTS_AUDIO = config_registry.get_var(
+    "OPENAPI_SUPPORTS_AUDIO",
+    False,
+    label="Enable Audio Support",
+    description="Enable audio inputs.",
+    group="llm",
+    component="openapi",
+    value_type=bool,
+    advanced=True,
+)
+
+OPENAPI_SUPPORTS_TOOLS = config_registry.get_var(
+    "OPENAPI_SUPPORTS_TOOLS",
+    False,
+    label="Enable Tool/Function Calling",
+    description="Enable tool/function calling.",
+    group="llm",
+    component="openapi",
+    value_type=bool,
+    advanced=True,
+)
+
+OPENAPI_DEFAULT_CONTEXT = config_registry.get_var(
+    "OPENAPI_DEFAULT_CONTEXT",
+    128000,
+    label="Default Context Window",
+    description="Default context window in characters.",
+    group="llm",
+    component="openapi",
+    value_type=int,
+    advanced=True,
+)
+
+OPENAPI_DEFAULT_MAX_TOKENS = config_registry.get_var(
+    "OPENAPI_DEFAULT_MAX_TOKENS",
+    4096,
+    label="Default Max Output Tokens",
+    description="Default max output tokens.",
+    group="llm",
+    component="openapi",
+    value_type=int,
+    advanced=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+@dataclass
+class OpenAPIModel:
+    """Simple model info structure."""
+
+    id: str
+    name: str
+    context_length: int = 128000
+    max_completion_tokens: int = 4096
+
+    @classmethod
+    def from_api(cls, data: dict[str, Any]) -> OpenAPIModel:
+        """Parse model entry from /v1/models response."""
+        model_id = data.get("id", "unknown")
+        name = data.get("name", model_id)
+
+        # Try to extract context length from various possible fields
+        ctx = 128000  # default
+        if "context_length" in data:
+            ctx = int(data["context_length"]) if data["context_length"] else ctx
+        elif "max_model_len" in data:
+            ctx = int(data["max_model_len"]) if data["max_model_len"] else ctx
+
+        # Try to extract max tokens
+        max_tokens = 4096  # default
+        if "max_tokens" in data:
+            max_tokens = int(data["max_tokens"]) if data["max_tokens"] else max_tokens
+        elif "max_completion_tokens" in data:
+            max_tokens = (
+                int(data["max_completion_tokens"])
+                if data["max_completion_tokens"]
+                else max_tokens
+            )
+
+        return cls(
+            id=model_id,
+            name=name,
+            context_length=ctx,
+            max_completion_tokens=max_tokens,
+        )
+
+    @classmethod
+    def from_manual(cls, data: dict[str, Any]) -> OpenAPIModel:
+        """Parse model entry from manual catalog config."""
+        return cls(
+            id=data.get("id", "unknown"),
+            name=data.get("name", data.get("id", "unknown")),
+            context_length=int(data.get("context_length", 128000)),
+            max_completion_tokens=int(data.get("max_completion_tokens", 4096)),
+        )
+
+
+@dataclass
+class _ModelCatalog:
+    """In-memory cache of model catalog."""
+
+    models: dict[str, OpenAPIModel] = field(default_factory=dict)
+    last_fetched: float = 0.0
+    _refresh_task: asyncio.Task[None] | None = field(default=None, repr=False)
+
+    def get(self, model_id: str) -> OpenAPIModel | None:
+        return self.models.get(model_id)
+
+    def list_ids(self) -> list[str]:
+        return sorted(self.models.keys())
+
+    def is_stale(self, max_age_minutes: int = 60) -> bool:
+        if not self.models:
+            return True
+        return (time.monotonic() - self.last_fetched) > max_age_minutes * 60
+
+    def update(self, models: dict[str, OpenAPIModel]) -> None:
+        self.models = models
+        self.last_fetched = time.monotonic()
+        log_info(f"[openapi] Model catalog updated: {len(models)} models")
+        # Update exposed variable options
+        try:
+            from core.variables_engine import exposed_vars
+
+            defn = exposed_vars.get_definition("OPENAPI_DEFAULT_MODEL")
+            if defn is not None:
+                defn.options = sorted(models.keys())
+        except Exception:
+            pass
+
+
+# Module-level catalog singleton
+_catalog = _ModelCatalog()
+
+
+def _fetch_catalog_sync(base_url: str, api_key: str = "") -> dict[str, OpenAPIModel]:
+    """Fetch model catalog from endpoint (blocking)."""
+    url = f"{base_url.rstrip('/')}/models"
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    try:
+        resp = requests.get(url, headers=headers, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        log_warning(f"[openapi] Failed to fetch model catalog: {exc}")
+        return {}
+
+    models: dict[str, OpenAPIModel] = {}
+    model_list = data.get("data", []) if isinstance(data, dict) else []
+    for entry in model_list:
+        try:
+            m = OpenAPIModel.from_api(entry)
+            models[m.id] = m
+        except Exception as exc:
+            log_debug(f"[openapi] Skipping model entry: {exc}")
+
+    return models
+
+
+def _parse_manual_catalog(raw: Any) -> dict[str, OpenAPIModel]:
+    """Parse manual model catalog from config."""
+    if not isinstance(raw, list):
+        try:
+            parsed = json.loads(str(raw)) if isinstance(raw, str) else raw
+            if not isinstance(parsed, list):
+                return {}
+            raw = parsed
+        except (json.JSONDecodeError, ValueError):
+            return {}
+
+    models: dict[str, OpenAPIModel] = {}
+    for entry in raw:
+        if isinstance(entry, dict):
+            try:
+                m = OpenAPIModel.from_manual(entry)
+                models[m.id] = m
+            except Exception as exc:
+                log_debug(f"[openapi] Skipping manual model entry: {exc}")
+
+    return models
+
+
+async def _refresh_catalog(base_url: str, api_key: str = "") -> None:
+    """Refresh catalog in background thread."""
+    loop = asyncio.get_event_loop()
+    models = await loop.run_in_executor(None, _fetch_catalog_sync, base_url, api_key)
+    if models:
+        _catalog.update(models)
+
+
+async def _catalog_refresh_loop(
+    base_url: str, api_key: str, interval_minutes: int
+) -> None:
+    """Periodically refresh model catalog."""
+    while True:
+        try:
+            await asyncio.sleep(interval_minutes * 60)
+            await _refresh_catalog(base_url, api_key)
+        except asyncio.CancelledError:
+            break
+        except Exception as exc:
+            log_warning(f"[openapi] Catalog refresh failed: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Supported image MIME types for OpenAI vision format
+_VISION_MIME_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
+
+# Supported audio MIME types — sent as input_audio content parts (OpenAI format)
+_AUDIO_MIME_TYPES: dict[str, str] = {
+    "audio/ogg": "ogg",
+    "audio/mpeg": "mp3",
+    "audio/mp3": "mp3",
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+    "audio/mp4": "mp4",
+    "audio/webm": "webm",
+    "audio/flac": "flac",
+}
+
+
+def _parse_json(raw: Any) -> Any:
+    """Safely parse JSON from config (may be str or dict/list)."""
+    if isinstance(raw, (dict, list)):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+class OpenAPIPlugin(AIPluginBase):
+    """Generic OpenAPI LLM Engine using OpenAI-compatible REST API."""
+
+    display_name = "OpenAPI"
+
+    def __init__(self, notify_fn: Any = None) -> None:
+        from core.notifier import set_notifier
+
+        if notify_fn:
+            set_notifier(notify_fn)
+            self._notify_fn = notify_fn
+        else:
+            self._notify_fn = lambda chat_id, message: log_info(
+                f"[NOTIFY fallback] {message}"
+            )
+            set_notifier(self._notify_fn)
+
+        self._current_model: str = str(OPENAPI_DEFAULT_MODEL) or "default"
+        self._current_request_meta: dict[str, Any] | None = None
+
+        # Model limits map for plugin_instance.py compatibility
+        self.model_limits_map: dict[str, int] = {
+            "default": int(OPENAPI_DEFAULT_CONTEXT)
+        }
+
+        # Validate config on startup
+        base_url = str(OPENAPI_BASE_URL).strip()
+        if not base_url:
+            log_error("[openapi] OPENAPI_BASE_URL not configured")
+        elif not base_url.startswith(("http://", "https://")):
+            log_warning(f"[openapi] Unusual base URL format: {base_url}")
+
+        if not self._current_model or self._current_model == "":
+            log_warning("[openapi] OPENAPI_DEFAULT_MODEL not set, using 'default'")
+            self._current_model = "default"
+
+        # Kick off initial catalog fetch
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                asyncio.ensure_future(self._start_catalog())
+            else:
+                base = str(OPENAPI_BASE_URL).strip()
+                api_key = str(OPENAPI_API_KEY).strip()
+                loop.run_until_complete(_refresh_catalog(base, api_key))
+        except Exception as exc:
+            log_warning(f"[openapi] Catalog fetch on init failed: {exc}")
+
+        log_info(f"[openapi] Initialized with model: {self._current_model}")
+
+    async def _start_catalog(self) -> None:
+        """Start catalog refresh and schedule periodic updates."""
+        # Initial fetch
+        if bool(OPENAPI_AUTO_DISCOVER):
+            base_url = str(OPENAPI_BASE_URL).strip()
+            api_key = str(OPENAPI_API_KEY).strip()
+            await _refresh_catalog(base_url, api_key)
+        else:
+            # Use manual catalog
+            manual_models = _parse_manual_catalog(OPENAPI_MODEL_CATALOG.value)
+            if manual_models:
+                _catalog.update(manual_models)
+
+        # Schedule periodic refresh
+        if bool(OPENAPI_AUTO_DISCOVER):
+            interval = int(OPENAPI_CATALOG_REFRESH) if OPENAPI_CATALOG_REFRESH else 60
+            if _catalog._refresh_task is None or _catalog._refresh_task.done():
+                base_url = str(OPENAPI_BASE_URL).strip()
+                api_key = str(OPENAPI_API_KEY).strip()
+                _catalog._refresh_task = asyncio.create_task(
+                    _catalog_refresh_loop(base_url, api_key, interval)
+                )
+
+    # ------------------------------------------------------------------
+    # AIPluginBase interface
+    # ------------------------------------------------------------------
+
+    def get_health_status(self) -> tuple[bool, str]:
+        """Return (ok, error_message) indicating whether engine is ready."""
+        base_url = str(OPENAPI_BASE_URL).strip()
+        if not base_url:
+            return (
+                False,
+                "OPENAPI_BASE_URL not configured. Please set it to your endpoint URL (e.g., http://localhost:11434/v1 for Ollama).",
+            )
+
+        # Quick connectivity check
+        try:
+            resp = requests.get(f"{base_url.rstrip('/')}/models", timeout=5)
+            if resp.status_code == 401 and not str(OPENAPI_API_KEY).strip():
+                return (
+                    False,
+                    "Endpoint requires authentication. Please set OPENAPI_API_KEY.",
+                )
+            if resp.status_code in (200, 401, 403):
+                return True, ""
+        except requests.exceptions.ConnectionError:
+            return (
+                False,
+                f"Cannot connect to endpoint {base_url}. Verify the URL and ensure the service is running.",
+            )
+        except requests.exceptions.Timeout:
+            return (
+                False,
+                f"Timeout connecting to {base_url}. The endpoint may be slow or unreachable.",
+            )
+        except Exception as exc:
+            return False, f"Error connecting to endpoint: {exc}"
+
+        return True, ""
+
+    def get_supported_models(self) -> list[str]:
+        """Return available model IDs from catalog."""
+        ids = _catalog.list_ids()
+        if ids:
+            return ids
+        return [self._current_model]
+
+    def get_current_model(self) -> str:
+        return self._current_model
+
+    def set_current_model(self, name: str) -> None:
+        self._current_model = name
+        # Update limits from catalog
+        model = _catalog.get(name)
+        if model:
+            self.model_limits_map["default"] = model.context_length
+        log_info(f"[openapi] Active model updated: {name}")
+
+    def get_rate_limit(self) -> tuple[int, int, float]:
+        return (60, 60, 0.5)
+
+    def get_interface_limits(self) -> dict[str, Any]:
+        model = _catalog.get(self._current_model)
+        ctx = model.context_length if model else int(OPENAPI_DEFAULT_CONTEXT)
+        max_out = (
+            model.max_completion_tokens if model else int(OPENAPI_DEFAULT_MAX_TOKENS)
+        )
+        return {
+            "max_prompt_chars": ctx,
+            "max_response_chars": max_out,
+            "supports_images": bool(OPENAPI_SUPPORTS_VISION),
+            "supports_functions": bool(OPENAPI_SUPPORTS_TOOLS),
+            "supports_voice_interaction": False,
+            "model_name": self._current_model,
+        }
+
+    # --- Agent hooks ---
+    def supports_agent(self) -> bool:
+        return True
+
+    def agent_execute(self, action_dict: dict, context: dict | None = None) -> dict:
+        try:
+            from core.core_initializer import PLUGIN_REGISTRY
+
+            agent_plugin = (
+                PLUGIN_REGISTRY.get("agent")
+                if isinstance(PLUGIN_REGISTRY, dict)
+                else None
+            )
+            if agent_plugin and hasattr(agent_plugin, "execute_action"):
+                res = agent_plugin.execute_action(
+                    action_dict, context or {}, None, None
+                )
+                if hasattr(res, "__await__"):
+                    return {
+                        "status": "pending_async",
+                        "note": "Agent plugin returned coroutine",
+                    }
+                return res or {"status": "ok"}
+        except Exception as exc:
+            log_warning(f"[openapi] agent_execute adapter failed: {exc}")
+        return {"status": "unsupported", "reason": "agent plugin not available"}
+
+    # ------------------------------------------------------------------
+    # Main entry points
+    # ------------------------------------------------------------------
+
+    async def handle_incoming_message(self, bot: Any, message: Any, prompt: Any) -> str:
+        """Process a message using a pre-built prompt.
+
+        Returns the LLM response text. The message_chain handles JSON parsing,
+        action execution, diary entries, emotion extraction, and DB persistence.
+        """
+        from core.notifier import notify_trainer
+
+        try:
+            self._current_request_meta = {
+                "bot": bot,
+                "message": message,
+                "interface": getattr(message, "interface", None)
+                or getattr(message, "interface_path", None),
+                "chat_id": getattr(message, "chat_id", None),
+                "interface_path": getattr(message, "interface_path", None),
+            }
+
+            log_debug(
+                f"[openapi] Processing message from chat_id="
+                f"{getattr(message, 'chat_id', 'unknown')}"
+            )
+
+            response = await self.generate_response(prompt)
+
+            if response:
+                preview = response[:200] + "..." if len(response) > 200 else response
+                log_info(f"[openapi] Generated response: {preview}")
+
+            return response
+
+        except Exception as exc:
+            log_error(f"[openapi] Error in handle_incoming_message: {exc!r}")
+            notify_trainer(f"OpenAPI error:\n{exc}")
+            return f"Error during response generation: {exc}"
+        finally:
+            self._current_request_meta = None
+
+    async def generate_response(self, prompt):  # type: ignore[override]
+        """Send prompt to OpenAPI endpoint and return response text."""
+        base_url = str(OPENAPI_BASE_URL).strip()
+        if not base_url:
+            log_warning("[openapi] OPENAPI_BASE_URL not configured")
+            return "OpenAPI Base URL not configured. Please set OPENAPI_BASE_URL in settings."
+
+        try:
+            # Handle correction prompts
+            if isinstance(prompt, dict) and "system_message" in prompt:
+                sm = prompt.get("system_message", {})
+                sm_type = sm.get("type", "") if isinstance(sm, dict) else ""
+                if sm_type in (
+                    "error",
+                    "correction",
+                    "invalid_json",
+                    "validation_error",
+                ):
+                    return await self._handle_correction_prompt(prompt)
+                log_debug(
+                    f"[openapi] Processing system_message type '{sm_type}' as normal prompt"
+                )
+            elif isinstance(prompt, str):
+                try:
+                    parsed = json.loads(prompt)
+                    if isinstance(parsed, dict) and "system_message" in parsed:
+                        sm = parsed.get("system_message", {})
+                        sm_type = sm.get("type", "") if isinstance(sm, dict) else ""
+                        if sm_type in (
+                            "error",
+                            "correction",
+                            "invalid_json",
+                            "validation_error",
+                        ):
+                            return await self._handle_correction_prompt(parsed)
+                except (json.JSONDecodeError, ValueError):
+                    pass
+
+            # Normalize prompt to text
+            if isinstance(prompt, dict):
+                prompt_text = json.dumps(prompt, indent=2, ensure_ascii=False)
+            elif isinstance(prompt, str):
+                prompt_text = prompt
+            else:
+                prompt_text = str(prompt)
+
+            # Extract and redact multimodal parts
+            multimodal_parts = []
+            if bool(OPENAPI_SUPPORTS_VISION) or bool(OPENAPI_SUPPORTS_AUDIO):
+                multimodal_parts = self._extract_multimodal_parts(prompt)
+
+            if isinstance(prompt, dict) and multimodal_parts:
+                redacted = self._copy_and_redact_data(prompt)
+                prompt_text = json.dumps(redacted, indent=2, ensure_ascii=False)
+
+            log_debug(
+                f"[openapi] Sending prompt ({len(prompt_text)} chars) to {self._current_model}"
+            )
+
+            system_instruction = self._build_system_instruction(prompt)
+
+            model = _catalog.get(self._current_model)
+            max_tokens = (
+                model.max_completion_tokens
+                if model
+                else int(OPENAPI_DEFAULT_MAX_TOKENS)
+            )
+
+            response_text = await self._openai_chat_completion(
+                prompt_text=prompt_text,
+                system_instruction=system_instruction,
+                max_tokens=max_tokens,
+                multimodal_parts=multimodal_parts if multimodal_parts else None,
+            )
+
+            log_debug(f"[openapi] Received response ({len(response_text)} chars)")
+            return response_text
+
+        except Exception as exc:
+            log_error(f"[openapi] Generation failed: {exc}")
+            return json.dumps(
+                {
+                    "actions": [
+                        {
+                            "type": "system_message",
+                            "payload": {"text": f"OpenAPI endpoint error: {exc}"},
+                        }
+                    ]
+                }
+            )
+
+    # ------------------------------------------------------------------
+    # OpenAI-compatible chat completion
+    # ------------------------------------------------------------------
+
+    async def _openai_chat_completion(
+        self,
+        prompt_text: str,
+        system_instruction: str,
+        max_tokens: int,
+        multimodal_parts: list[dict[str, Any]] | None = None,
+    ) -> str:
+        """Send chat completion request to OpenAPI endpoint."""
+        base_url = str(OPENAPI_BASE_URL).strip()
+        url = f"{base_url.rstrip('/')}/chat/completions"
+
+        # Build messages
+        messages: list[dict[str, Any]] = [
+            {"role": "system", "content": system_instruction}
+        ]
+
+        # User message with optional multimodal content
+        if multimodal_parts:
+            has_vision = bool(OPENAPI_SUPPORTS_VISION)
+            content_parts: list[dict[str, Any]] = []
+
+            if has_vision:
+                for part in multimodal_parts:
+                    content_parts.append(part)
+            elif multimodal_parts:
+                log_warning(
+                    f"[openapi] Vision disabled; skipping {len(multimodal_parts)} image part(s)"
+                )
+
+            content_parts.append({"type": "text", "text": prompt_text})
+            messages.append({"role": "user", "content": content_parts})
+        else:
+            messages.append({"role": "user", "content": prompt_text})
+
+        # Build headers
+        headers = self._build_headers()
+
+        payload: dict[str, Any] = {
+            "model": self._current_model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+        }
+
+        # Log outgoing request
+        log_cortex_request(
+            "openapi",
+            model=self._current_model,
+            url=url,
+            headers=headers,
+            payload=payload,
+        )
+        _req_start = time.monotonic()
+
+        def _do_request() -> requests.Response:
+            timeout = int(OPENAPI_TIMEOUT) if OPENAPI_TIMEOUT else 120
+            return requests.post(url, headers=headers, json=payload, timeout=timeout)
+
+        retryable_statuses = {429, 500, 503, 504}
+        max_attempts = int(OPENAPI_MAX_RETRIES) if OPENAPI_MAX_RETRIES else 3
+        response: requests.Response | None = None
+
+        for attempt in range(max_attempts):
+            try:
+                loop = asyncio.get_event_loop()
+                resp: requests.Response = await loop.run_in_executor(None, _do_request)
+                response = resp
+            except Exception as exc:
+                if attempt < max_attempts - 1:
+                    delay = min(8, 1 * (2**attempt))
+                    log_warning(
+                        f"[openapi] HTTP request failed (attempt {attempt + 1}/{max_attempts}): "
+                        f"{exc}. Retrying in {delay}s"
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                log_error(f"[openapi] HTTP request failed: {exc}")
+                return json.dumps(
+                    {
+                        "actions": [
+                            {
+                                "type": "system_message",
+                                "payload": {
+                                    "text": f"OpenAPI HTTP request failed: {exc}"
+                                },
+                            }
+                        ]
+                    }
+                )
+
+            status = int(resp.status_code)  # type: ignore[arg-type]
+            if status >= 400:
+                if status in retryable_statuses and attempt < max_attempts - 1:
+                    delay = min(8, 1 * (2**attempt))
+                    log_warning(
+                        f"[openapi] HTTP error {status} "
+                        f"(attempt {attempt + 1}/{max_attempts}). Retrying in {delay}s"
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                log_error(f"[openapi] HTTP error {status}: {resp.text}")
+                return json.dumps(
+                    {
+                        "actions": [
+                            {
+                                "type": "system_message",
+                                "payload": {
+                                    "text": f"OpenAPI HTTP error {status}: {resp.text[:200]}"
+                                },
+                            }
+                        ]
+                    }
+                )
+            break
+
+        if response is None:
+            return json.dumps(
+                {
+                    "actions": [
+                        {
+                            "type": "system_message",
+                            "payload": {
+                                "text": "OpenAPI HTTP request failed: no response"
+                            },
+                        }
+                    ]
+                }
+            )
+
+        try:
+            data = response.json()
+        except Exception as exc:
+            log_error(f"[openapi] Response JSON parse failed: {exc}")
+            return json.dumps(
+                {
+                    "actions": [
+                        {
+                            "type": "system_message",
+                            "payload": {"text": "OpenAPI response was not valid JSON"},
+                        }
+                    ]
+                }
+            )
+
+        # Handle error responses
+        if "error" in data:
+            error_msg = data["error"]
+            if isinstance(error_msg, dict):
+                error_msg = error_msg.get("message", str(error_msg))
+            log_error(f"[openapi] API error: {error_msg}")
+            _elapsed = (time.monotonic() - _req_start) * 1000
+            log_cortex_response(
+                "openapi",
+                model=self._current_model,
+                status=int(getattr(response, "status_code", 0) or 0),
+                error=str(error_msg),
+                elapsed_ms=_elapsed,
+            )
+            return json.dumps(
+                {
+                    "actions": [
+                        {
+                            "type": "system_message",
+                            "payload": {"text": f"OpenAPI endpoint error: {error_msg}"},
+                        }
+                    ]
+                }
+            )
+
+        choices = data.get("choices") or []
+        if not choices:
+            log_error(f"[openapi] Response missing choices: {data}")
+            return json.dumps(
+                {
+                    "actions": [
+                        {
+                            "type": "system_message",
+                            "payload": {"text": "OpenAPI response missing choices"},
+                        }
+                    ]
+                }
+            )
+
+        content = choices[0].get("message", {}).get("content", "")
+        if not content:
+            log_error(f"[openapi] Response contained no content: {data}")
+            return json.dumps(
+                {
+                    "actions": [
+                        {
+                            "type": "system_message",
+                            "payload": {
+                                "text": "OpenAPI response contained no content"
+                            },
+                        }
+                    ]
+                }
+            )
+
+        # Log usage if available
+        usage = data.get("usage")
+        if usage:
+            log_debug(
+                f"[openapi] Usage: prompt_tokens={usage.get('prompt_tokens')}, "
+                f"completion_tokens={usage.get('completion_tokens')}"
+            )
+
+        # Log response
+        _elapsed = (time.monotonic() - _req_start) * 1000
+        log_cortex_response(
+            "openapi",
+            model=data.get("model", self._current_model),
+            status=int(getattr(response, "status_code", 0) or 0),
+            body=content.strip(),
+            usage=usage,
+            elapsed_ms=_elapsed,
+        )
+
+        return content.strip()
+
+    def _build_headers(self) -> dict[str, str]:
+        """Build HTTP headers with optional auth and custom headers."""
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+
+        # Optional bearer token auth
+        api_key = str(OPENAPI_API_KEY).strip()
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        # Custom headers from JSON config
+        custom = _parse_json(
+            OPENAPI_CUSTOM_HEADERS.value
+            if hasattr(OPENAPI_CUSTOM_HEADERS, "value")
+            else str(OPENAPI_CUSTOM_HEADERS)
+        )
+        if isinstance(custom, dict):
+            headers.update(custom)
+
+        return headers
+
+    # ------------------------------------------------------------------
+    # System instruction
+    # ------------------------------------------------------------------
+
+    def _build_system_instruction(self, prompt: Any) -> str:
+        """Build the system instruction based on prompt context."""
+        interface = "unknown"
+        verbose_instructions = None
+        prompt_dict: dict[str, Any] | None = None
+
+        if isinstance(prompt, dict):
+            prompt_dict = prompt
+        elif isinstance(prompt, str):
+            try:
+                parsed = json.loads(prompt)
+                if isinstance(parsed, dict):
+                    prompt_dict = parsed
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+        if isinstance(prompt_dict, dict):
+            interface = prompt_dict.get("interface") or prompt_dict.get(
+                "current_interface"
+            )
+            verbose_instructions = prompt_dict.get("instructions_verbose")
+
+            if not interface or interface == "unknown":
+                input_section = prompt_dict.get("input", {})
+                if isinstance(input_section, dict):
+                    source = input_section.get("source", {})
+                    if isinstance(source, dict):
+                        interface = source.get("interface") or interface
+            if not interface or interface == "unknown":
+                input_section = prompt_dict.get("input", {})
+                if isinstance(input_section, dict):
+                    interface = input_section.get("interface") or interface
+
+        if not interface:
+            interface = "unknown"
+
+        interface_to_action = {
+            "synth_webui": "message_synth_webui",
+            "telegram_bot": "message_telegram_bot",
+            "discord_bot": "message_discord_bot",
+            "ollama_serve": "message_ollama_serve",
+        }
+        message_action = interface_to_action.get(interface, f"message_{interface}")
+
+        is_grillo = interface == "grillo" or (
+            isinstance(prompt_dict, dict) and prompt_dict.get("grillo_beat")
+        )
+        is_grillo_internal = is_grillo and (
+            not isinstance(prompt_dict, dict)
+            or prompt_dict.get("beat_type", "internal") != "outreach"
+        )
+
+        if is_grillo_internal:
+            interface_hint = (
+                "CURRENT INTERFACE: grillo (INTERNAL)\n"
+                "This is an internal introspection beat. Do NOT output any message_* actions.\n"
+                "Use ONLY internal actions like 'create_personal_diary_entry', 'set_emotion', etc."
+            )
+        else:
+            interface_hint = (
+                f"CURRENT INTERFACE: {interface}\n"
+                f"TO SEND A MESSAGE TO THE USER: Use action type '{message_action}'"
+            )
+
+        system_instruction = (
+            "You are part of the 'Synthetic Heart' AI system.\n"
+            "\n"
+            "CRITICAL OUTPUT FORMAT:\n"
+            "1. Respond with ONLY valid JSON - nothing before or after\n"
+            "2. Your response MUST start with { and end with }\n"
+            '3. Use this structure: {"actions": [{"type": "action_name", "payload": {...}}]}\n'
+            "4. NO markdown code blocks, NO explanations outside JSON\n"
+            "\n"
+            f"{interface_hint}\n"
+            "\n"
+            "The prompt contains a complete action schema with available actions.\n"
+            "Follow those instructions precisely.\n"
+            "\n"
+            "Remember: Output ONLY valid JSON. The system will parse your JSON and execute the actions."
+        )
+
+        if verbose_instructions:
+            system_instruction = f"{verbose_instructions}\n\n{system_instruction}"
+
+        return system_instruction
+
+    # ------------------------------------------------------------------
+    # Correction handling
+    # ------------------------------------------------------------------
+
+    async def _handle_correction_prompt(self, prompt: dict[str, Any]) -> str:
+        """Handle a correction/system_message prompt."""
+        system_message = prompt.get("system_message", {})
+        error_type = system_message.get("type", "error")
+        error_message = system_message.get("message", "Unknown error")
+        original_user_message = system_message.get("original_user_message", "")
+        your_reply = system_message.get("your_reply", "")
+        required_format = system_message.get("required_format", {})
+
+        interface = (
+            system_message.get("target_interface")
+            or system_message.get("interface")
+            or prompt.get("interface")
+            or None
+        )
+
+        if not interface:
+            action_hint = system_message.get("action_type_hint", "")
+            if "message_telegram_bot" in action_hint:
+                interface = "telegram_bot"
+            elif "message_discord_bot" in action_hint:
+                interface = "discord_bot"
+            elif "message_synth_webui" in action_hint:
+                interface = "synth_webui"
+            else:
+                interface = "synth_webui"
+
+        # Grillo beats are internal
+        if interface == "grillo":
+            log_debug("[openapi] Grillo beat detected — internal, no interface routing")
+            correction_prompt = (
+                f"CORRECTION REQUIRED - INTERNAL BEAT\n\n"
+                f"Error: {error_message}\n\n"
+                f"This is an internal Grillo beat. You should NOT output any message action.\n"
+                f"Just output valid JSON with internal actions like 'create_personal_diary_entry'.\n\n"
+                f"Your previous (invalid) reply:\n"
+                f"{your_reply[:500] if your_reply else '(none)'}...\n\n"
+                f"Respond with ONLY valid JSON containing internal actions.\n"
+                f"Do NOT include any message_* actions."
+            )
+            return await self._openai_chat_completion(
+                prompt_text=correction_prompt,
+                system_instruction=(
+                    "You are a JSON correction assistant for internal Grillo beats. "
+                    "Output ONLY valid JSON with internal actions like 'create_personal_diary_entry'. "
+                    "Do NOT output any message_* actions."
+                ),
+                max_tokens=4096,
+            )
+
+        interface_to_action = {
+            "synth_webui": "message_synth_webui",
+            "telegram_bot": "message_telegram_bot",
+            "discord_bot": "message_discord_bot",
+            "ollama_serve": "message_ollama_serve",
+        }
+        message_action = interface_to_action.get(interface, f"message_{interface}")
+
+        correction_prompt = f"CORRECTION REQUIRED\n\nError: {error_message}\n\n"
+        if original_user_message:
+            correction_prompt += f'Original user message you should respond to:\n"{original_user_message}"\n\n'
+        if your_reply:
+            correction_prompt += (
+                f"Your previous (invalid) reply:\n{your_reply[:500]}...\n\n"
+            )
+        correction_prompt += (
+            f"REQUIREMENTS:\n"
+            f"1. Respond with ONLY valid JSON\n"
+            f"2. Follow this exact structure:\n"
+            f"{json.dumps(required_format, indent=2)}\n"
+            f"\n"
+            f"IMPORTANT: To send a message to the user, use action type '{message_action}'\n"
+            f"\n"
+            f"Respond NOW with valid JSON only."
+        )
+
+        log_warning(f"[openapi] Handling correction prompt: {error_type}")
+        return await self._openai_chat_completion(
+            prompt_text=correction_prompt,
+            system_instruction=(
+                "You are a JSON correction assistant. "
+                "Your ONLY task is to output valid JSON following the exact structure shown. "
+                f"CURRENT INTERFACE: {interface}. "
+                f"TO SEND A MESSAGE TO THE USER: Use action type '{message_action}'. "
+                "NO explanations. NO markdown. ONLY valid JSON starting with {{ and ending with }}."
+            ),
+            max_tokens=8192,
+        )
+
+    # ------------------------------------------------------------------
+    # Multimodal support (reused from openrouter with simplification)
+    # ------------------------------------------------------------------
+
+    def _extract_multimodal_parts(self, prompt: Any) -> list[dict[str, Any]]:
+        """Extract image/audio parts from prompt for OpenAI format.
+
+        Returns a list of OpenAI content parts.
+        """
+        parts: list[dict[str, Any]] = []
+
+        if isinstance(prompt, str):
+            try:
+                prompt = json.loads(prompt)
+            except (json.JSONDecodeError, ValueError):
+                return parts
+
+        if not isinstance(prompt, dict):
+            return parts
+
+        multimodal_keys = {"attachments", "images", "audio", "documents", "videos"}
+        attachments: list[dict[str, Any]] = []
+
+        def collect_recursive(container: Any) -> None:
+            if isinstance(container, dict):
+                for key in multimodal_keys:
+                    if key in container:
+                        items = container[key]
+                        if isinstance(items, list):
+                            for item in items:
+                                if isinstance(item, dict):
+                                    attachments.append(item)
+                                elif isinstance(item, str):
+                                    default_mime = {
+                                        "images": "image/jpeg",
+                                        "audio": "audio/mpeg",
+                                        "videos": "video/mp4",
+                                        "documents": "application/pdf",
+                                    }.get(key, "application/octet-stream")
+                                    attachments.append(
+                                        {"path": item, "mime_type": default_mime}
+                                    )
+                        elif isinstance(items, dict):
+                            attachments.append(items)
+                for value in container.values():
+                    collect_recursive(value)
+            elif isinstance(container, list):
+                for item in container:
+                    collect_recursive(item)
+
+        collect_recursive(prompt)
+
+        for att in attachments:
+            if not isinstance(att, dict):
+                continue
+
+            mime_type = att.get("mime_type") or att.get("mimeType", "")
+            file_path = att.get("path") or att.get("file_path", "")
+
+            if file_path and not mime_type:
+                import mimetypes as mt
+
+                mime_type, _ = mt.guess_type(str(file_path))
+                mime_type = mime_type or "application/octet-stream"
+
+            is_image = mime_type in _VISION_MIME_TYPES
+            is_audio = mime_type in _AUDIO_MIME_TYPES
+
+            if not is_image and not is_audio:
+                if mime_type and not mime_type.startswith("application/octet"):
+                    log_debug(f"[openapi] Skipping unsupported attachment: {mime_type}")
+                continue
+
+            b64_data = att.get("data") or att.get("base64", "")
+            if not b64_data and file_path:
+                try:
+                    p = Path(file_path)
+                    if p.exists():
+                        b64_data = base64.b64encode(p.read_bytes()).decode("utf-8")
+                except Exception as exc:
+                    log_warning(f"[openapi] Failed to read file {file_path}: {exc}")
+                    continue
+
+            if not b64_data:
+                continue
+
+            if is_image and bool(OPENAPI_SUPPORTS_VISION):
+                parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:{mime_type};base64,{b64_data}"},
+                    }
+                )
+                log_debug(f"[openapi] Added image part: {mime_type}")
+            elif is_audio and bool(OPENAPI_SUPPORTS_AUDIO):
+                audio_fmt = _AUDIO_MIME_TYPES[mime_type]
+                parts.append(
+                    {
+                        "type": "input_audio",
+                        "input_audio": {"data": b64_data, "format": audio_fmt},
+                    }
+                )
+                log_debug(f"[openapi] Added audio part: {mime_type} -> {audio_fmt}")
+
+        return parts
+
+    def _copy_and_redact_data(self, prompt: dict[str, Any]) -> dict[str, Any]:
+        """Deep copy prompt and redact heavy base64 data."""
+        try:
+            redacted = copy.deepcopy(prompt)
+            multimodal_keys = {"attachments", "images", "audio", "documents", "videos"}
+            data_fields = {"data", "base64"}
+            attachment_fields = {
+                "mime_type",
+                "mimeType",
+                "path",
+                "file_path",
+                "data",
+                "base64",
+            }
+
+            def redact_item(item: dict[str, Any]) -> None:
+                if not isinstance(item, dict) or not (item.keys() & attachment_fields):
+                    return
+                for fld in data_fields:
+                    if fld in item:
+                        item[fld] = f"<redacted: {len(str(item[fld]))} chars>"
+
+            def redact_recursive(container: Any) -> None:
+                if isinstance(container, dict):
+                    for key in multimodal_keys:
+                        if key in container:
+                            items = container[key]
+                            if isinstance(items, list):
+                                for item in items:
+                                    redact_item(item)
+                            elif isinstance(items, dict):
+                                redact_item(items)
+                    for value in container.values():
+                        redact_recursive(value)
+                elif isinstance(container, list):
+                    for item in container:
+                        redact_recursive(item)
+
+            redact_recursive(redacted)
+            return redacted
+        except Exception as exc:
+            log_warning(f"[openapi] Failed to redact prompt data: {exc}")
+            return prompt
+
+
+PLUGIN_CLASS = OpenAPIPlugin

--- a/cortex/llm_provider/openrouter.py
+++ b/cortex/llm_provider/openrouter.py
@@ -1119,8 +1119,14 @@ class OpenRouterPlugin(AIPluginBase):
         is_grillo = interface == "grillo" or (
             isinstance(prompt_dict, dict) and prompt_dict.get("grillo_beat")
         )
+        # Outreach beats are grillo-initiated but MUST produce message_*
+        # actions to reach the target interface (e.g. telegram_bot).
+        is_grillo_internal = is_grillo and (
+            not isinstance(prompt_dict, dict)
+            or prompt_dict.get("beat_type", "internal") != "outreach"
+        )
 
-        if is_grillo:
+        if is_grillo_internal:
             interface_hint = (
                 "CURRENT INTERFACE: grillo (INTERNAL)\n"
                 "This is an internal introspection beat. Do NOT output any message_* actions.\n"

--- a/cortex/llm_provider/openrouter.py
+++ b/cortex/llm_provider/openrouter.py
@@ -1,0 +1,1269 @@
+# cortex/llm_provider/openrouter.py
+"""OpenRouter LLM Engine for Synthetic Heart.
+
+This engine uses the OpenRouter API (OpenAI-compatible) to communicate with
+a wide range of LLM providers through a single unified endpoint.
+
+Key features:
+- Auto-fetches model catalog with capabilities (modality, context, pricing)
+- Multi-model routing: different models per scope and action type
+- Multimodal support: images for vision-capable models
+- Full bidirectional context injection via standard SyntH engine contract
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import copy
+import fnmatch
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from core.ai_plugin_base import AIPluginBase
+from core.config_manager import config_registry
+from core.logging_utils import log_debug, log_error, log_info, log_warning
+
+ENGINE_LABEL = "OpenRouter — multi-provider LLM gateway (OpenAI-compatible)"
+
+# ---------------------------------------------------------------------------
+# WebUI variable registration (always visible so keys can be set before use)
+# ---------------------------------------------------------------------------
+try:
+    from core.variables_engine import register_exposed_var
+
+    register_exposed_var(
+        "OPENROUTER_API_KEY",
+        label="OpenRouter API Key",
+        default="",
+        value_type=str,
+        ui_type="password",
+        description="API key for OpenRouter (https://openrouter.ai/keys).",
+        scope="llm",
+        component="openrouter",
+        tags=["cortex_engine", "sensitive"],
+        needs_component_reload=True,
+    )
+    register_exposed_var(
+        "OPENROUTER_BASE_URL",
+        label="OpenRouter Base URL",
+        default="https://openrouter.ai/api/v1",
+        value_type=str,
+        ui_type="string",
+        description="Base URL for the OpenRouter API.",
+        scope="llm",
+        component="openrouter",
+        tags=["cortex_engine"],
+        advanced=True,
+        needs_component_reload=True,
+    )
+    register_exposed_var(
+        "OPENROUTER_DEFAULT_MODEL",
+        label="Default Model",
+        default="x-ai/grok-4.1-fast",
+        value_type=str,
+        ui_type="combobox",
+        description="Default OpenRouter model used when no scope/action override matches.",
+        scope="llm",
+        component="openrouter",
+        tags=["cortex_engine"],
+        needs_component_reload=False,
+    )
+    register_exposed_var(
+        "OPENROUTER_SITE_URL",
+        label="Site URL (Referer)",
+        default="",
+        value_type=str,
+        ui_type="string",
+        description="Sent as HTTP-Referer header. Used for OpenRouter rankings.",
+        scope="llm",
+        component="openrouter",
+        tags=["cortex_engine"],
+        advanced=True,
+    )
+    register_exposed_var(
+        "OPENROUTER_APP_NAME",
+        label="App Name (X-Title)",
+        default="Synthetic Heart",
+        value_type=str,
+        ui_type="string",
+        description="Sent as X-Title header. Shown on OpenRouter rankings.",
+        scope="llm",
+        component="openrouter",
+        tags=["cortex_engine"],
+        advanced=True,
+    )
+    register_exposed_var(
+        "OPENROUTER_MODEL_ROUTES",
+        label="Model Routes",
+        default="{}",
+        value_type="json",
+        ui_type="json",
+        description=(
+            "JSON mapping of scopes and action types to models. "
+            'Example: {"scopes": {"grillo": "anthropic/claude-haiku-3.5"}, '
+            '"actions": {"create_personal_diary_entry": "anthropic/claude-haiku-3.5"}}'
+        ),
+        scope="llm",
+        component="openrouter",
+        tags=["cortex_engine"],
+        advanced=True,
+    )
+    register_exposed_var(
+        "OPENROUTER_CATALOG_REFRESH_MINUTES",
+        label="Catalog Refresh (min)",
+        default="30",
+        value_type=int,
+        ui_type="number",
+        description="How often to refresh the model catalog from OpenRouter (minutes).",
+        scope="llm",
+        component="openrouter",
+        tags=["cortex_engine"],
+        advanced=True,
+    )
+except Exception:
+    pass
+
+# ---------------------------------------------------------------------------
+# Config variables (auto-updating)
+# ---------------------------------------------------------------------------
+OPENROUTER_API_KEY = config_registry.get_var(
+    "OPENROUTER_API_KEY",
+    "",
+    label="OpenRouter API Key",
+    description="API key for OpenRouter.",
+    group="llm",
+    component="openrouter",
+    sensitive=True,
+)
+
+OPENROUTER_BASE_URL = config_registry.get_var(
+    "OPENROUTER_BASE_URL",
+    "https://openrouter.ai/api/v1",
+    label="OpenRouter Base URL",
+    description="Base URL for the OpenRouter API.",
+    group="llm",
+    component="openrouter",
+    advanced=True,
+)
+
+OPENROUTER_DEFAULT_MODEL = config_registry.get_var(
+    "OPENROUTER_DEFAULT_MODEL",
+    "x-ai/grok-4.1-fast",
+    label="Default Model",
+    description="Default OpenRouter model.",
+    group="llm",
+    component="openrouter",
+)
+
+OPENROUTER_SITE_URL = config_registry.get_var(
+    "OPENROUTER_SITE_URL",
+    "",
+    label="Site URL",
+    description="HTTP-Referer header for OpenRouter.",
+    group="llm",
+    component="openrouter",
+    advanced=True,
+)
+
+OPENROUTER_APP_NAME = config_registry.get_var(
+    "OPENROUTER_APP_NAME",
+    "Synthetic Heart",
+    label="App Name",
+    description="X-Title header for OpenRouter.",
+    group="llm",
+    component="openrouter",
+    advanced=True,
+)
+
+OPENROUTER_MODEL_ROUTES = config_registry.get_var(
+    "OPENROUTER_MODEL_ROUTES",
+    "{}",
+    label="Model Routes",
+    description="Per-scope and per-action model overrides (JSON).",
+    group="llm",
+    component="openrouter",
+    value_type="json",
+    advanced=True,
+)
+
+OPENROUTER_CATALOG_REFRESH_MINUTES = config_registry.get_var(
+    "OPENROUTER_CATALOG_REFRESH_MINUTES",
+    30,
+    label="Catalog Refresh (min)",
+    description="Model catalog refresh interval in minutes.",
+    group="llm",
+    component="openrouter",
+    value_type=int,
+    advanced=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+@dataclass
+class OpenRouterModel:
+    """Parsed model entry from the OpenRouter /models endpoint."""
+
+    id: str
+    name: str
+    context_length: int = 4096
+    max_completion_tokens: int = 4096
+    modality: str = "text->text"
+    supports_vision: bool = False
+    supports_audio: bool = False
+    supports_tool_use: bool = False
+    pricing_prompt: float = 0.0
+    pricing_completion: float = 0.0
+
+    @classmethod
+    def from_api(cls, data: dict[str, Any]) -> OpenRouterModel:
+        """Parse a single model entry from the OpenRouter /models response."""
+        model_id = data.get("id", "unknown")
+        name = data.get("name", model_id)
+
+        arch = data.get("architecture", {}) or {}
+        modality = arch.get("modality", "text->text") or "text->text"
+
+        # Parse modality string: "text+image->text", "text+image+audio->text", etc.
+        input_side = modality.split("->")[0] if "->" in modality else modality
+        supports_vision = "image" in input_side
+        supports_audio = "audio" in input_side
+
+        top = data.get("top_provider", {}) or {}
+        ctx = data.get("context_length", 4096) or 4096
+        max_completion = top.get("max_completion_tokens") or 4096
+
+        pricing = data.get("pricing", {}) or {}
+        try:
+            p_prompt = float(pricing.get("prompt", "0") or "0")
+        except (ValueError, TypeError):
+            p_prompt = 0.0
+        try:
+            p_completion = float(pricing.get("completion", "0") or "0")
+        except (ValueError, TypeError):
+            p_completion = 0.0
+
+        # Tool use: check supported_parameters or known model families
+        supported_params = data.get("supported_parameters", []) or []
+        supports_tools = (
+            "tools" in supported_params or "tool_choice" in supported_params
+        )
+
+        return cls(
+            id=model_id,
+            name=name,
+            context_length=ctx,
+            max_completion_tokens=max_completion,
+            modality=modality,
+            supports_vision=supports_vision,
+            supports_audio=supports_audio,
+            supports_tool_use=supports_tools,
+            pricing_prompt=p_prompt,
+            pricing_completion=p_completion,
+        )
+
+
+@dataclass
+class _ModelCatalog:
+    """In-memory cache of the OpenRouter model catalog."""
+
+    models: dict[str, OpenRouterModel] = field(default_factory=dict)
+    last_fetched: float = 0.0
+    _refresh_task: asyncio.Task[None] | None = field(default=None, repr=False)
+
+    def get(self, model_id: str) -> OpenRouterModel | None:
+        return self.models.get(model_id)
+
+    def list_ids(self) -> list[str]:
+        return sorted(self.models.keys())
+
+    def is_stale(self, max_age_minutes: int = 30) -> bool:
+        if not self.models:
+            return True
+        return (time.monotonic() - self.last_fetched) > max_age_minutes * 60
+
+    def update(self, models: dict[str, OpenRouterModel]) -> None:
+        self.models = models
+        self.last_fetched = time.monotonic()
+        log_info(f"[openrouter] Model catalog updated: {len(models)} models")
+        # Push model IDs into the exposed variable options for the WebUI
+        try:
+            from core.variables_engine import exposed_vars
+
+            defn = exposed_vars.get_definition("OPENROUTER_DEFAULT_MODEL")
+            if defn is not None:
+                defn.options = sorted(models.keys())
+        except Exception:
+            pass
+
+
+# Module-level catalog singleton
+_catalog = _ModelCatalog()
+
+
+def _fetch_catalog_sync(base_url: str) -> dict[str, OpenRouterModel]:
+    """Fetch the model catalog from OpenRouter (blocking)."""
+    url = f"{base_url.rstrip('/')}/models"
+    try:
+        resp = requests.get(url, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        log_warning(f"[openrouter] Failed to fetch model catalog: {exc}")
+        return {}
+
+    models: dict[str, OpenRouterModel] = {}
+    for entry in data.get("data", []):
+        try:
+            m = OpenRouterModel.from_api(entry)
+            models[m.id] = m
+        except Exception as exc:
+            log_debug(f"[openrouter] Skipping model entry: {exc}")
+    return models
+
+
+async def _refresh_catalog(base_url: str) -> None:
+    """Refresh the catalog in a background thread."""
+    loop = asyncio.get_event_loop()
+    models = await loop.run_in_executor(None, _fetch_catalog_sync, base_url)
+    if models:
+        _catalog.update(models)
+
+
+async def _catalog_refresh_loop(base_url: str, interval_minutes: int) -> None:
+    """Periodically refresh the model catalog."""
+    while True:
+        try:
+            await asyncio.sleep(interval_minutes * 60)
+            await _refresh_catalog(base_url)
+        except asyncio.CancelledError:
+            break
+        except Exception as exc:
+            log_warning(f"[openrouter] Catalog refresh failed: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Supported image MIME types for OpenAI vision format
+_VISION_MIME_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
+
+
+def _parse_routes(raw: Any) -> dict[str, Any]:
+    """Safely parse model routes from config (may be str or dict)."""
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                return parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+class OpenRouterPlugin(AIPluginBase):
+    """OpenRouter LLM Engine using the OpenAI-compatible REST API."""
+
+    display_name = "OpenRouter"
+
+    def __init__(self, notify_fn: Any = None) -> None:
+        from core.notifier import set_notifier
+
+        if notify_fn:
+            set_notifier(notify_fn)
+            self._notify_fn = notify_fn
+        else:
+            self._notify_fn = lambda chat_id, message: log_info(
+                f"[NOTIFY fallback] {message}"
+            )
+            set_notifier(self._notify_fn)
+
+        self._current_model: str = str(OPENROUTER_DEFAULT_MODEL) or "x-ai/grok-4.1-fast"
+        self._current_request_meta: dict[str, Any] | None = None
+
+        # Model limits map for plugin_instance.py compatibility
+        self.model_limits_map: dict[str, int] = {"default": 200000}
+
+        # Kick off initial catalog fetch
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                base = (
+                    str(OPENROUTER_BASE_URL).strip() or "https://openrouter.ai/api/v1"
+                )
+                asyncio.ensure_future(self._start_catalog(base))
+            else:
+                base = (
+                    str(OPENROUTER_BASE_URL).strip() or "https://openrouter.ai/api/v1"
+                )
+                loop.run_until_complete(_refresh_catalog(base))
+        except Exception as exc:
+            log_warning(f"[openrouter] Catalog fetch on init failed: {exc}")
+
+        log_info(f"[openrouter] Initialized with default model: {self._current_model}")
+
+    async def _start_catalog(self, base_url: str) -> None:
+        """Start the catalog refresh and schedule periodic updates."""
+        await _refresh_catalog(base_url)
+        interval = (
+            int(OPENROUTER_CATALOG_REFRESH_MINUTES)
+            if OPENROUTER_CATALOG_REFRESH_MINUTES
+            else 30
+        )
+        if _catalog._refresh_task is None or _catalog._refresh_task.done():
+            _catalog._refresh_task = asyncio.create_task(
+                _catalog_refresh_loop(base_url, interval)
+            )
+
+    # ------------------------------------------------------------------
+    # AIPluginBase interface
+    # ------------------------------------------------------------------
+
+    def get_health_status(self) -> tuple[bool, str]:
+        """Return (ok, error_message) indicating whether the engine is ready."""
+        if not OPENROUTER_API_KEY or not str(OPENROUTER_API_KEY).strip():
+            return False, "OPENROUTER_API_KEY not configured"
+        return True, ""
+
+    def get_supported_models(self) -> list[str]:
+        """Return available model IDs from catalog, falling back to current."""
+        ids = _catalog.list_ids()
+        if ids:
+            return ids
+        return [self._current_model]
+
+    def get_current_model(self) -> str:
+        return self._current_model
+
+    def set_current_model(self, name: str) -> None:
+        self._current_model = name
+        # Update limits from catalog
+        model = _catalog.get(name)
+        if model:
+            self.model_limits_map["default"] = (
+                model.context_length * 3
+            )  # chars ≈ 3× tokens
+        log_info(f"[openrouter] Active model updated: {name}")
+
+    def get_rate_limit(self) -> tuple[int, int, float]:
+        return (60, 60, 0.5)
+
+    def get_interface_limits(self) -> dict[str, Any]:
+        model = _catalog.get(self._current_model)
+        ctx = model.context_length if model else 128000
+        max_out = model.max_completion_tokens if model else 4096
+        has_vision = model.supports_vision if model else False
+        return {
+            "max_prompt_chars": ctx * 3,
+            "max_response_chars": max_out,
+            "supports_images": has_vision,
+            "supports_functions": True,
+            "supports_voice_interaction": False,
+            "model_name": self._current_model,
+        }
+
+    # --- Agent hooks ---
+    def supports_agent(self) -> bool:
+        return True
+
+    def agent_execute(self, action_dict: dict, context: dict | None = None) -> dict:
+        try:
+            from core.core_initializer import PLUGIN_REGISTRY
+
+            agent_plugin = (
+                PLUGIN_REGISTRY.get("agent")
+                if isinstance(PLUGIN_REGISTRY, dict)
+                else None
+            )
+            if agent_plugin and hasattr(agent_plugin, "execute_action"):
+                res = agent_plugin.execute_action(
+                    action_dict, context or {}, None, None
+                )
+                if hasattr(res, "__await__"):
+                    return {
+                        "status": "pending_async",
+                        "note": "Agent plugin returned coroutine",
+                    }
+                return res or {"status": "ok"}
+        except Exception as exc:
+            log_warning(f"[openrouter] agent_execute adapter failed: {exc}")
+        return {"status": "unsupported", "reason": "agent plugin not available"}
+
+    # ------------------------------------------------------------------
+    # Model resolution
+    # ------------------------------------------------------------------
+
+    def _resolve_model(
+        self, scope: str | None = None, action_type: str | None = None
+    ) -> str:
+        """Resolve which model to use based on routes config.
+
+        Priority: per-action override > per-scope override > default model.
+        """
+        routes = _parse_routes(
+            OPENROUTER_MODEL_ROUTES.value
+            if hasattr(OPENROUTER_MODEL_ROUTES, "value")
+            else str(OPENROUTER_MODEL_ROUTES)
+        )
+
+        # 1. Per-action override (supports glob patterns like "message_*")
+        if action_type and "actions" in routes:
+            action_routes = routes["actions"]
+            if isinstance(action_routes, dict):
+                # Exact match first
+                if action_type in action_routes:
+                    return action_routes[action_type]
+                # Glob match
+                for pattern, model_id in action_routes.items():
+                    if fnmatch.fnmatch(action_type, pattern):
+                        return model_id
+
+        # 2. Per-scope override
+        if scope and "scopes" in routes:
+            scope_routes = routes["scopes"]
+            if isinstance(scope_routes, dict) and scope in scope_routes:
+                return scope_routes[scope]
+
+        # 3. Default
+        return self._current_model
+
+    # ------------------------------------------------------------------
+    # Main entry points
+    # ------------------------------------------------------------------
+
+    async def handle_incoming_message(self, bot: Any, message: Any, prompt: Any) -> str:
+        """Process a message using a pre-built prompt.
+
+        Returns the LLM response text. The message_chain handles JSON parsing,
+        action execution, diary entries, emotion extraction, and DB persistence.
+        """
+        from core.notifier import notify_trainer
+
+        try:
+            self._current_request_meta = {
+                "bot": bot,
+                "message": message,
+                "interface": getattr(message, "interface", None)
+                or getattr(message, "interface_path", None),
+                "chat_id": getattr(message, "chat_id", None),
+                "interface_path": getattr(message, "interface_path", None),
+            }
+
+            log_debug(
+                f"[openrouter] Processing message from chat_id="
+                f"{getattr(message, 'chat_id', 'unknown')}"
+            )
+
+            response = await self.generate_response(prompt)
+
+            if response:
+                preview = response[:200] + "..." if len(response) > 200 else response
+                log_info(f"[openrouter] Generated response: {preview}")
+
+            return response
+
+        except Exception as exc:
+            log_error(f"[openrouter] Error in handle_incoming_message: {exc!r}")
+            notify_trainer(f"OpenRouter error:\n{exc}")
+            return f"Error during response generation: {exc}"
+        finally:
+            self._current_request_meta = None
+
+    async def generate_response(self, prompt):  # type: ignore[override]
+        """Send prompt to OpenRouter and return the response text."""
+        if not OPENROUTER_API_KEY:
+            log_warning("[openrouter] OPENROUTER_API_KEY not configured")
+            return "OpenRouter API Key not configured. Please set OPENROUTER_API_KEY in settings or .env"
+
+        try:
+            # Handle correction prompts
+            if isinstance(prompt, dict) and "system_message" in prompt:
+                sm = prompt.get("system_message", {})
+                sm_type = sm.get("type", "") if isinstance(sm, dict) else ""
+                if sm_type in (
+                    "error",
+                    "correction",
+                    "invalid_json",
+                    "validation_error",
+                ):
+                    return await self._handle_correction_prompt(prompt)
+                log_debug(
+                    f"[openrouter] Processing system_message type '{sm_type}' as normal prompt"
+                )
+            elif isinstance(prompt, str):
+                try:
+                    parsed = json.loads(prompt)
+                    if isinstance(parsed, dict) and "system_message" in parsed:
+                        sm = parsed.get("system_message", {})
+                        sm_type = sm.get("type", "") if isinstance(sm, dict) else ""
+                        if sm_type in (
+                            "error",
+                            "correction",
+                            "invalid_json",
+                            "validation_error",
+                        ):
+                            return await self._handle_correction_prompt(parsed)
+                except (json.JSONDecodeError, ValueError):
+                    pass
+
+            # Normalize prompt to text
+            if isinstance(prompt, dict):
+                prompt_text = json.dumps(prompt, indent=2, ensure_ascii=False)
+            elif isinstance(prompt, str):
+                prompt_text = prompt
+            else:
+                prompt_text = str(prompt)
+
+            # Extract and redact multimodal parts
+            multimodal_parts = self._extract_multimodal_parts(prompt)
+
+            if isinstance(prompt, dict):
+                redacted = self._copy_and_redact_data(prompt)
+                prompt_text = json.dumps(redacted, indent=2, ensure_ascii=False)
+
+            log_debug(
+                f"[openrouter] Sending prompt ({len(prompt_text)} chars) to {self._current_model}"
+            )
+
+            system_instruction = self._build_system_instruction(prompt)
+
+            # Determine scope from prompt context
+            scope = None
+            if isinstance(prompt, dict):
+                scope = prompt.get("scope") or prompt.get("action_scope")
+
+            model = self._resolve_model(scope=scope)
+            model_info = _catalog.get(model)
+            max_tokens = model_info.max_completion_tokens if model_info else 4096
+
+            response_text = await self._openai_chat_completion(
+                prompt_text=prompt_text,
+                system_instruction=system_instruction,
+                max_tokens=max_tokens,
+                model=model,
+                multimodal_parts=multimodal_parts if multimodal_parts else None,
+            )
+
+            log_debug(f"[openrouter] Received response ({len(response_text)} chars)")
+            return response_text
+
+        except Exception as exc:
+            log_error(f"[openrouter] Generation failed: {exc}")
+            return json.dumps(
+                {
+                    "actions": [
+                        {
+                            "type": "system_message",
+                            "payload": {"text": f"OpenRouter API error: {exc}"},
+                        }
+                    ]
+                }
+            )
+
+    # ------------------------------------------------------------------
+    # OpenAI-compatible chat completion
+    # ------------------------------------------------------------------
+
+    async def _openai_chat_completion(
+        self,
+        prompt_text: str,
+        system_instruction: str,
+        max_tokens: int,
+        model: str | None = None,
+        multimodal_parts: list[dict[str, Any]] | None = None,
+    ) -> str:
+        """Send a chat completion request to OpenRouter."""
+        base_url = str(OPENROUTER_BASE_URL).strip() or "https://openrouter.ai/api/v1"
+        api_key = str(OPENROUTER_API_KEY).strip()
+        url = f"{base_url.rstrip('/')}/chat/completions"
+
+        resolved_model = model or self._current_model
+
+        # Build messages — use multipart format with cache_control on the
+        # system message so providers that support explicit prompt caching
+        # (Anthropic, Gemini) can cache the large static system instruction.
+        # Grok/xAI caching is automatic and ignores this harmlessly.
+        messages: list[dict[str, Any]] = [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": system_instruction,
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            },
+        ]
+
+        # User message — with optional vision content
+        if multimodal_parts:
+            # Check if model supports vision
+            model_info = _catalog.get(resolved_model)
+            has_vision = model_info.supports_vision if model_info else False
+
+            content_parts: list[dict[str, Any]] = []
+            if has_vision:
+                for part in multimodal_parts:
+                    content_parts.append(part)
+            elif multimodal_parts:
+                log_warning(
+                    f"[openrouter] Model {resolved_model} does not support vision; "
+                    f"skipping {len(multimodal_parts)} image part(s)"
+                )
+            content_parts.append({"type": "text", "text": prompt_text})
+            messages.append({"role": "user", "content": content_parts})
+        else:
+            messages.append({"role": "user", "content": prompt_text})
+
+        # Build headers
+        headers: dict[str, str] = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        site_url = str(OPENROUTER_SITE_URL).strip()
+        if site_url:
+            headers["HTTP-Referer"] = site_url
+        app_name = str(OPENROUTER_APP_NAME).strip()
+        if app_name:
+            headers["X-Title"] = app_name
+
+        payload: dict[str, Any] = {
+            "model": resolved_model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            # Disable safety filters for providers that support it (Gemini).
+            # Grok has no adjustable safety — it's already minimally filtered.
+            "safety_settings": [
+                {
+                    "category": "HARM_CATEGORY_HARASSMENT",
+                    "threshold": "BLOCK_NONE",
+                },
+                {
+                    "category": "HARM_CATEGORY_HATE_SPEECH",
+                    "threshold": "BLOCK_NONE",
+                },
+                {
+                    "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+                    "threshold": "BLOCK_NONE",
+                },
+                {
+                    "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+                    "threshold": "BLOCK_NONE",
+                },
+            ],
+        }
+
+        def _do_request() -> requests.Response:
+            return requests.post(url, headers=headers, json=payload, timeout=120)
+
+        retryable_statuses = {429, 500, 503, 504}
+        max_attempts = 3
+        response: requests.Response | None = None  # narrowed after loop
+
+        for attempt in range(max_attempts):
+            try:
+                loop = asyncio.get_event_loop()
+                resp: requests.Response = await loop.run_in_executor(None, _do_request)
+                response = resp
+            except Exception as exc:
+                if attempt < max_attempts - 1:
+                    delay = min(8, 1 * (2**attempt))
+                    log_warning(
+                        f"[openrouter] HTTP request failed (attempt {attempt + 1}/{max_attempts}): "
+                        f"{exc}. Retrying in {delay}s"
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                log_error(f"[openrouter] HTTP request failed: {exc}")
+                return json.dumps(
+                    {
+                        "actions": [
+                            {
+                                "type": "system_message",
+                                "payload": {
+                                    "text": f"OpenRouter HTTP request failed: {exc}"
+                                },
+                            }
+                        ]
+                    }
+                )
+
+            status = int(resp.status_code)  # type: ignore[arg-type]
+            if status >= 400:
+                if status in retryable_statuses and attempt < max_attempts - 1:
+                    delay = min(8, 1 * (2**attempt))
+                    log_warning(
+                        f"[openrouter] HTTP error {status} "
+                        f"(attempt {attempt + 1}/{max_attempts}). Retrying in {delay}s"
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                log_error(f"[openrouter] HTTP error {status}: {resp.text}")
+                return json.dumps(
+                    {
+                        "actions": [
+                            {
+                                "type": "system_message",
+                                "payload": {
+                                    "text": f"OpenRouter HTTP error {status}: {resp.text}"
+                                },
+                            }
+                        ]
+                    }
+                )
+            break
+
+        if response is None:
+            return json.dumps(
+                {
+                    "actions": [
+                        {
+                            "type": "system_message",
+                            "payload": {
+                                "text": "OpenRouter HTTP request failed: no response"
+                            },
+                        }
+                    ]
+                }
+            )
+
+        try:
+            data = response.json()
+        except Exception as exc:
+            log_error(f"[openrouter] Response JSON parse failed: {exc}")
+            return json.dumps(
+                {
+                    "actions": [
+                        {
+                            "type": "system_message",
+                            "payload": {
+                                "text": "OpenRouter response was not valid JSON"
+                            },
+                        }
+                    ]
+                }
+            )
+
+        # Handle OpenRouter error responses
+        if "error" in data:
+            error_msg = data["error"]
+            if isinstance(error_msg, dict):
+                error_msg = error_msg.get("message", str(error_msg))
+            log_error(f"[openrouter] API error: {error_msg}")
+            return json.dumps(
+                {
+                    "actions": [
+                        {
+                            "type": "system_message",
+                            "payload": {"text": f"OpenRouter API error: {error_msg}"},
+                        }
+                    ]
+                }
+            )
+
+        choices = data.get("choices") or []
+        if not choices:
+            log_error(f"[openrouter] Response missing choices: {data}")
+            return json.dumps(
+                {
+                    "actions": [
+                        {
+                            "type": "system_message",
+                            "payload": {"text": "OpenRouter response missing choices"},
+                        }
+                    ]
+                }
+            )
+
+        content = choices[0].get("message", {}).get("content", "")
+        if not content:
+            log_error(f"[openrouter] Response contained no content: {data}")
+            return json.dumps(
+                {
+                    "actions": [
+                        {
+                            "type": "system_message",
+                            "payload": {
+                                "text": "OpenRouter response contained no content"
+                            },
+                        }
+                    ]
+                }
+            )
+
+        # Log usage if available
+        usage = data.get("usage")
+        if usage:
+            log_debug(
+                f"[openrouter] Usage: prompt_tokens={usage.get('prompt_tokens')}, "
+                f"completion_tokens={usage.get('completion_tokens')}, "
+                f"model={data.get('model', resolved_model)}"
+            )
+
+        return content.strip()
+
+    # ------------------------------------------------------------------
+    # System instruction
+    # ------------------------------------------------------------------
+
+    def _build_system_instruction(self, prompt: Any) -> str:
+        """Build the system instruction based on prompt context."""
+        interface = "unknown"
+        verbose_instructions = None
+        prompt_dict: dict[str, Any] | None = None
+
+        if isinstance(prompt, dict):
+            prompt_dict = prompt
+        elif isinstance(prompt, str):
+            try:
+                parsed = json.loads(prompt)
+                if isinstance(parsed, dict):
+                    prompt_dict = parsed
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+        if isinstance(prompt_dict, dict):
+            interface = prompt_dict.get("interface") or prompt_dict.get(
+                "current_interface"
+            )
+            verbose_instructions = prompt_dict.get("instructions_verbose")
+
+            if not interface or interface == "unknown":
+                input_section = prompt_dict.get("input", {})
+                if isinstance(input_section, dict):
+                    source = input_section.get("source", {})
+                    if isinstance(source, dict):
+                        interface = source.get("interface") or interface
+            if not interface or interface == "unknown":
+                input_section = prompt_dict.get("input", {})
+                if isinstance(input_section, dict):
+                    interface = input_section.get("interface") or interface
+
+        if not interface:
+            interface = "unknown"
+
+        interface_to_action = {
+            "synth_webui": "message_synth_webui",
+            "telegram_bot": "message_telegram_bot",
+            "discord_bot": "message_discord_bot",
+            "ollama_serve": "message_ollama_serve",
+        }
+        message_action = interface_to_action.get(interface, f"message_{interface}")
+
+        system_instruction = (
+            "You are part of the 'Synthetic Heart' AI system.\n"
+            "\n"
+            "CRITICAL OUTPUT FORMAT:\n"
+            "1. Respond with ONLY valid JSON - nothing before or after\n"
+            "2. Your response MUST start with { and end with }\n"
+            '3. Use this structure: {"actions": [{"type": "action_name", "payload": {...}}]}\n'
+            "4. NO markdown code blocks, NO explanations outside JSON\n"
+            "\n"
+            f"CURRENT INTERFACE: {interface}\n"
+            f"TO SEND A MESSAGE TO THE USER: Use action type '{message_action}'\n"
+            "\n"
+            "The prompt contains a complete action schema with available actions.\n"
+            "Follow those instructions precisely.\n"
+            "\n"
+            "Remember: Output ONLY valid JSON. The system will parse your JSON and execute the actions."
+        )
+
+        if verbose_instructions:
+            system_instruction = f"{verbose_instructions}\n\n{system_instruction}"
+
+        return system_instruction
+
+    # ------------------------------------------------------------------
+    # Correction handling
+    # ------------------------------------------------------------------
+
+    async def _handle_correction_prompt(self, prompt: dict[str, Any]) -> str:
+        """Handle a correction/system_message prompt."""
+        system_message = prompt.get("system_message", {})
+        error_type = system_message.get("type", "error")
+        error_message = system_message.get("message", "Unknown error")
+        original_user_message = system_message.get("original_user_message", "")
+        your_reply = system_message.get("your_reply", "")
+        required_format = system_message.get("required_format", {})
+
+        interface = (
+            system_message.get("target_interface")
+            or system_message.get("interface")
+            or prompt.get("interface")
+            or None
+        )
+
+        if not interface:
+            action_hint = system_message.get("action_type_hint", "")
+            if "message_telegram_bot" in action_hint:
+                interface = "telegram_bot"
+            elif "message_discord_bot" in action_hint:
+                interface = "discord_bot"
+            elif "message_synth_webui" in action_hint:
+                interface = "synth_webui"
+            else:
+                interface = "synth_webui"
+
+        # Grillo beats are internal
+        if interface == "grillo":
+            log_debug(
+                "[openrouter] Grillo beat detected — internal, no interface routing"
+            )
+            correction_prompt = (
+                f"CORRECTION REQUIRED - INTERNAL BEAT\n\n"
+                f"Error: {error_message}\n\n"
+                f"This is an internal Grillo beat. You should NOT output any message action.\n"
+                f"Just output valid JSON with internal actions like 'create_personal_diary_entry'.\n\n"
+                f"Your previous (invalid) reply:\n"
+                f"{your_reply[:500] if your_reply else '(none)'}...\n\n"
+                f"Respond with ONLY valid JSON containing internal actions.\n"
+                f"Do NOT include any message_* actions."
+            )
+            return await self._openai_chat_completion(
+                prompt_text=correction_prompt,
+                system_instruction=(
+                    "You are a JSON correction assistant for internal Grillo beats. "
+                    "Output ONLY valid JSON with internal actions like 'create_personal_diary_entry'. "
+                    "Do NOT output any message_* actions."
+                ),
+                max_tokens=4096,
+            )
+
+        interface_to_action = {
+            "synth_webui": "message_synth_webui",
+            "telegram_bot": "message_telegram_bot",
+            "discord_bot": "message_discord_bot",
+            "ollama_serve": "message_ollama_serve",
+        }
+        message_action = interface_to_action.get(interface, f"message_{interface}")
+
+        correction_prompt = f"CORRECTION REQUIRED\n\nError: {error_message}\n\n"
+        if original_user_message:
+            correction_prompt += f'Original user message you should respond to:\n"{original_user_message}"\n\n'
+        if your_reply:
+            correction_prompt += (
+                f"Your previous (invalid) reply:\n{your_reply[:500]}...\n\n"
+            )
+        correction_prompt += (
+            f"REQUIREMENTS:\n"
+            f"1. Respond with ONLY valid JSON\n"
+            f"2. Follow this exact structure:\n"
+            f"{json.dumps(required_format, indent=2)}\n"
+            f"\n"
+            f"IMPORTANT: To send a message to the user, use action type '{message_action}'\n"
+            f"\n"
+            f"Respond NOW with valid JSON only."
+        )
+
+        log_warning(f"[openrouter] Handling correction prompt: {error_type}")
+        return await self._openai_chat_completion(
+            prompt_text=correction_prompt,
+            system_instruction=(
+                "You are a JSON correction assistant. "
+                "Your ONLY task is to output valid JSON following the exact structure shown. "
+                f"CURRENT INTERFACE: {interface}. "
+                f"TO SEND A MESSAGE TO THE USER: Use action type '{message_action}'. "
+                "NO explanations. NO markdown. ONLY valid JSON starting with {{ and ending with }}."
+            ),
+            max_tokens=8192,
+        )
+
+    # ------------------------------------------------------------------
+    # Multimodal support
+    # ------------------------------------------------------------------
+
+    def _extract_multimodal_parts(self, prompt: Any) -> list[dict[str, Any]]:
+        """Extract image parts from prompt for OpenAI vision format.
+
+        Returns a list of OpenAI content parts:
+        [{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}]
+        """
+        parts: list[dict[str, Any]] = []
+
+        if isinstance(prompt, str):
+            try:
+                prompt = json.loads(prompt)
+            except (json.JSONDecodeError, ValueError):
+                return parts
+
+        if not isinstance(prompt, dict):
+            return parts
+
+        multimodal_keys = {"attachments", "images", "audio", "documents", "videos"}
+        attachments: list[dict[str, Any]] = []
+
+        def collect_recursive(container: Any) -> None:
+            if isinstance(container, dict):
+                for key in multimodal_keys:
+                    if key in container:
+                        items = container[key]
+                        if isinstance(items, list):
+                            for item in items:
+                                if isinstance(item, dict):
+                                    attachments.append(item)
+                                elif isinstance(item, str):
+                                    default_mime = {
+                                        "images": "image/jpeg",
+                                        "audio": "audio/mpeg",
+                                        "videos": "video/mp4",
+                                        "documents": "application/pdf",
+                                    }.get(key, "application/octet-stream")
+                                    attachments.append(
+                                        {"path": item, "mime_type": default_mime}
+                                    )
+                        elif isinstance(items, dict):
+                            attachments.append(items)
+                for value in container.values():
+                    collect_recursive(value)
+            elif isinstance(container, list):
+                for item in container:
+                    collect_recursive(item)
+
+        collect_recursive(prompt)
+
+        for att in attachments:
+            if not isinstance(att, dict):
+                continue
+
+            mime_type = att.get("mime_type") or att.get("mimeType", "")
+            file_path = att.get("path") or att.get("file_path", "")
+
+            if file_path and not mime_type:
+                import mimetypes as mt
+
+                mime_type, _ = mt.guess_type(str(file_path))
+                mime_type = mime_type or "application/octet-stream"
+
+            # Only include images (OpenAI vision format)
+            if mime_type not in _VISION_MIME_TYPES:
+                if mime_type and not mime_type.startswith("application/octet"):
+                    log_debug(
+                        f"[openrouter] Skipping non-image attachment: {mime_type}"
+                    )
+                continue
+
+            b64_data = att.get("data") or att.get("base64", "")
+            if not b64_data and file_path:
+                try:
+                    p = Path(file_path)
+                    if p.exists():
+                        b64_data = base64.b64encode(p.read_bytes()).decode("utf-8")
+                except Exception as exc:
+                    log_warning(f"[openrouter] Failed to read file {file_path}: {exc}")
+                    continue
+
+            if not b64_data:
+                continue
+
+            parts.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{mime_type};base64,{b64_data}"},
+                }
+            )
+            log_debug(f"[openrouter] Added image part: {mime_type}")
+
+        return parts
+
+    def _copy_and_redact_data(self, prompt: dict[str, Any]) -> dict[str, Any]:
+        """Deep copy prompt and redact heavy base64 data."""
+        try:
+            redacted = copy.deepcopy(prompt)
+            multimodal_keys = {"attachments", "images", "audio", "documents", "videos"}
+            data_fields = {"data", "base64"}
+            attachment_fields = {
+                "mime_type",
+                "mimeType",
+                "path",
+                "file_path",
+                "data",
+                "base64",
+            }
+
+            def redact_item(item: dict[str, Any]) -> None:
+                if not isinstance(item, dict) or not (item.keys() & attachment_fields):
+                    return
+                for fld in data_fields:
+                    if fld in item:
+                        item[fld] = f"<redacted: {len(str(item[fld]))} chars>"
+
+            def redact_recursive(container: Any) -> None:
+                if isinstance(container, dict):
+                    for key in multimodal_keys:
+                        if key in container:
+                            items = container[key]
+                            if isinstance(items, list):
+                                for item in items:
+                                    redact_item(item)
+                            elif isinstance(items, dict):
+                                redact_item(items)
+                    for value in container.values():
+                        redact_recursive(value)
+                elif isinstance(container, list):
+                    for item in container:
+                        redact_recursive(item)
+
+            redact_recursive(redacted)
+            return redacted
+        except Exception as exc:
+            log_warning(f"[openrouter] Failed to redact prompt data: {exc}")
+            return prompt
+
+    # ------------------------------------------------------------------
+    # Catalog access (for external consumers)
+    # ------------------------------------------------------------------
+
+    def get_model_capabilities(self, model_id: str | None = None) -> dict[str, Any]:
+        """Return capability info for a model from the catalog."""
+        mid = model_id or self._current_model
+        model = _catalog.get(mid)
+        if not model:
+            return {"model": mid, "available": False}
+        return {
+            "model": model.id,
+            "name": model.name,
+            "available": True,
+            "context_length": model.context_length,
+            "max_completion_tokens": model.max_completion_tokens,
+            "modality": model.modality,
+            "supports_vision": model.supports_vision,
+            "supports_audio": model.supports_audio,
+            "supports_tool_use": model.supports_tool_use,
+            "pricing_prompt": model.pricing_prompt,
+            "pricing_completion": model.pricing_completion,
+        }
+
+    def get_catalog_summary(self) -> dict[str, Any]:
+        """Return a summary of the cached model catalog."""
+        return {
+            "total_models": len(_catalog.models),
+            "last_fetched_ago_s": round(time.monotonic() - _catalog.last_fetched, 1)
+            if _catalog.last_fetched
+            else None,
+            "vision_models": sum(
+                1 for m in _catalog.models.values() if m.supports_vision
+            ),
+            "audio_models": sum(
+                1 for m in _catalog.models.values() if m.supports_audio
+            ),
+            "tool_models": sum(
+                1 for m in _catalog.models.values() if m.supports_tool_use
+            ),
+        }
+
+
+PLUGIN_CLASS = OpenRouterPlugin

--- a/cortex/llm_provider/openrouter.py
+++ b/cortex/llm_provider/openrouter.py
@@ -27,6 +27,7 @@ import requests
 
 from core.ai_plugin_base import AIPluginBase
 from core.config_manager import config_registry
+from core.cortex_api_logger import log_cortex_request, log_cortex_response
 from core.logging_utils import log_debug, log_error, log_info, log_warning
 
 ENGINE_LABEL = "OpenRouter — multi-provider LLM gateway (OpenAI-compatible)"
@@ -356,6 +357,18 @@ async def _catalog_refresh_loop(base_url: str, interval_minutes: int) -> None:
 # Supported image MIME types for OpenAI vision format
 _VISION_MIME_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
 
+# Supported audio MIME types — sent as input_audio content parts (OpenAI format)
+_AUDIO_MIME_TYPES: dict[str, str] = {
+    "audio/ogg": "ogg",
+    "audio/mpeg": "mp3",
+    "audio/mp3": "mp3",
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+    "audio/mp4": "mp4",
+    "audio/webm": "webm",
+    "audio/flac": "flac",
+}
+
 
 def _parse_routes(raw: Any) -> dict[str, Any]:
     """Safely parse model routes from config (may be str or dict)."""
@@ -657,6 +670,37 @@ class OpenRouterPlugin(AIPluginBase):
                 multimodal_parts=multimodal_parts if multimodal_parts else None,
             )
 
+            # ── Audio fallback: transcribe & retry if provider rejects audio ─
+            if (
+                multimodal_parts
+                and "No endpoints found that support input audio" in response_text
+            ):
+                audio_parts = [
+                    p for p in multimodal_parts if p.get("type") == "input_audio"
+                ]
+                if audio_parts:
+                    log_info(
+                        "[openrouter] Provider rejected input_audio — "
+                        "transcribing via Gemini and retrying"
+                    )
+                    transcription = await self._transcribe_audio_via_gemini(audio_parts)
+                    # Keep non-audio parts (images), drop audio
+                    remaining = [
+                        p for p in multimodal_parts if p.get("type") != "input_audio"
+                    ]
+                    # Prepend transcription to the prompt text
+                    prompt_text = (
+                        f"[Voice message transcription]: {transcription}\n\n"
+                        + prompt_text
+                    )
+                    response_text = await self._openai_chat_completion(
+                        prompt_text=prompt_text,
+                        system_instruction=system_instruction,
+                        max_tokens=max_tokens,
+                        model=model,
+                        multimodal_parts=remaining if remaining else None,
+                    )
+
             log_debug(f"[openrouter] Received response ({len(response_text)} chars)")
             return response_text
 
@@ -672,6 +716,85 @@ class OpenRouterPlugin(AIPluginBase):
                     ]
                 }
             )
+
+    # ------------------------------------------------------------------
+    # Audio transcription fallback (via Gemini base cortex)
+    # ------------------------------------------------------------------
+
+    async def _transcribe_audio_via_gemini(
+        self, audio_parts: list[dict[str, Any]]
+    ) -> str:
+        """Transcribe audio content parts using Gemini when OpenRouter
+        rejects ``input_audio``.  Returns concatenated transcription text."""
+        transcriptions: list[str] = []
+        try:
+            from core.cortex_registry import get_cortex_registry
+
+            gemini = get_cortex_registry().get_engine("gemini_api")
+            if gemini is None or not getattr(gemini, "client", None):
+                log_warning(
+                    "[openrouter] Gemini engine not available for audio transcription"
+                )
+                return "[Voice message — audio could not be transcribed]"
+
+            from google.genai import types
+
+            for part in audio_parts:
+                inner = part.get("input_audio", {})
+                b64_data: str = inner.get("data", "")
+                fmt: str = inner.get("format", "ogg")
+                if not b64_data:
+                    continue
+
+                mime_map = {v: k for k, v in _AUDIO_MIME_TYPES.items()}
+                mime = mime_map.get(fmt, f"audio/{fmt}")
+                raw_bytes = base64.b64decode(b64_data)
+
+                log_debug(
+                    f"[openrouter] Transcribing audio ({len(raw_bytes)} bytes, "
+                    f"{mime}) via Gemini"
+                )
+
+                response = await gemini.client.aio.models.generate_content(
+                    model=gemini._current_model,
+                    contents=[
+                        types.Content(
+                            parts=[
+                                types.Part(
+                                    text=(
+                                        "Transcribe the following audio message "
+                                        "exactly as spoken. Output ONLY the "
+                                        "transcribed text."
+                                    )
+                                ),
+                                types.Part(
+                                    inline_data=types.Blob(
+                                        mime_type=mime, data=raw_bytes
+                                    )
+                                ),
+                            ]
+                        )
+                    ],
+                    config=types.GenerateContentConfig(
+                        system_instruction=(
+                            "You are a speech-to-text transcription system. "
+                            "Output ONLY the exact words spoken."
+                        ),
+                        response_mime_type="text/plain",
+                    ),
+                )
+                if response and response.text:
+                    transcriptions.append(response.text.strip())
+
+        except Exception as exc:
+            log_error(f"[openrouter] Audio transcription failed: {exc}")
+            return "[Voice message — audio transcription failed]"
+
+        return (
+            "\n".join(transcriptions)
+            if transcriptions
+            else "[Voice message — no speech detected]"
+        )
 
     # ------------------------------------------------------------------
     # OpenAI-compatible chat completion
@@ -766,6 +889,16 @@ class OpenRouterPlugin(AIPluginBase):
                 },
             ],
         }
+
+        # ── Log the outgoing request ──────────────────────────────────
+        log_cortex_request(
+            "openrouter",
+            model=resolved_model,
+            url=url,
+            headers=headers,
+            payload=payload,
+        )
+        _req_start = time.monotonic()
 
         def _do_request() -> requests.Response:
             return requests.post(url, headers=headers, json=payload, timeout=120)
@@ -864,6 +997,14 @@ class OpenRouterPlugin(AIPluginBase):
             if isinstance(error_msg, dict):
                 error_msg = error_msg.get("message", str(error_msg))
             log_error(f"[openrouter] API error: {error_msg}")
+            _elapsed = (time.monotonic() - _req_start) * 1000
+            log_cortex_response(
+                "openrouter",
+                model=resolved_model,
+                status=int(getattr(response, "status_code", 0) or 0),
+                error=str(error_msg),
+                elapsed_ms=_elapsed,
+            )
             return json.dumps(
                 {
                     "actions": [
@@ -913,6 +1054,17 @@ class OpenRouterPlugin(AIPluginBase):
                 f"completion_tokens={usage.get('completion_tokens')}, "
                 f"model={data.get('model', resolved_model)}"
             )
+
+        # ── Log the response ────────────────────────────────────────────
+        _elapsed = (time.monotonic() - _req_start) * 1000
+        log_cortex_response(
+            "openrouter",
+            model=data.get("model", resolved_model),
+            status=int(getattr(response, "status_code", 0) or 0),
+            body=content.strip(),
+            usage=usage,
+            elapsed_ms=_elapsed,
+        )
 
         return content.strip()
 
@@ -964,6 +1116,22 @@ class OpenRouterPlugin(AIPluginBase):
         }
         message_action = interface_to_action.get(interface, f"message_{interface}")
 
+        is_grillo = interface == "grillo" or (
+            isinstance(prompt_dict, dict) and prompt_dict.get("grillo_beat")
+        )
+
+        if is_grillo:
+            interface_hint = (
+                "CURRENT INTERFACE: grillo (INTERNAL)\n"
+                "This is an internal introspection beat. Do NOT output any message_* actions.\n"
+                "Use ONLY internal actions like 'create_personal_diary_entry', 'set_emotion', etc."
+            )
+        else:
+            interface_hint = (
+                f"CURRENT INTERFACE: {interface}\n"
+                f"TO SEND A MESSAGE TO THE USER: Use action type '{message_action}'"
+            )
+
         system_instruction = (
             "You are part of the 'Synthetic Heart' AI system.\n"
             "\n"
@@ -973,8 +1141,7 @@ class OpenRouterPlugin(AIPluginBase):
             '3. Use this structure: {"actions": [{"type": "action_name", "payload": {...}}]}\n'
             "4. NO markdown code blocks, NO explanations outside JSON\n"
             "\n"
-            f"CURRENT INTERFACE: {interface}\n"
-            f"TO SEND A MESSAGE TO THE USER: Use action type '{message_action}'\n"
+            f"{interface_hint}\n"
             "\n"
             "The prompt contains a complete action schema with available actions.\n"
             "Follow those instructions precisely.\n"
@@ -1148,11 +1315,13 @@ class OpenRouterPlugin(AIPluginBase):
                 mime_type, _ = mt.guess_type(str(file_path))
                 mime_type = mime_type or "application/octet-stream"
 
-            # Only include images (OpenAI vision format)
-            if mime_type not in _VISION_MIME_TYPES:
+            is_image = mime_type in _VISION_MIME_TYPES
+            is_audio = mime_type in _AUDIO_MIME_TYPES
+
+            if not is_image and not is_audio:
                 if mime_type and not mime_type.startswith("application/octet"):
                     log_debug(
-                        f"[openrouter] Skipping non-image attachment: {mime_type}"
+                        f"[openrouter] Skipping unsupported attachment: {mime_type}"
                     )
                 continue
 
@@ -1169,13 +1338,24 @@ class OpenRouterPlugin(AIPluginBase):
             if not b64_data:
                 continue
 
-            parts.append(
-                {
-                    "type": "image_url",
-                    "image_url": {"url": f"data:{mime_type};base64,{b64_data}"},
-                }
-            )
-            log_debug(f"[openrouter] Added image part: {mime_type}")
+            if is_image:
+                parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:{mime_type};base64,{b64_data}"},
+                    }
+                )
+                log_debug(f"[openrouter] Added image part: {mime_type}")
+            else:
+                # Audio — OpenAI input_audio format
+                audio_fmt = _AUDIO_MIME_TYPES[mime_type]
+                parts.append(
+                    {
+                        "type": "input_audio",
+                        "input_audio": {"data": b64_data, "format": audio_fmt},
+                    }
+                )
+                log_debug(f"[openrouter] Added audio part: {mime_type} -> {audio_fmt}")
 
         return parts
 

--- a/interface/discord_interface.py
+++ b/interface/discord_interface.py
@@ -1918,6 +1918,36 @@ class DiscordInterface:
                         live_mgr = None
                     if live_mgr and live_mgr.is_session_active(guild_id):
                         text = content
+
+                        # --- inject text-based file attachments as context ---
+                        _TEXT_MIME_PREFIXES = (
+                            "text/",
+                            "application/json",
+                            "application/xml",
+                        )
+                        for att in getattr(message, "attachments", []):
+                            mime = getattr(att, "content_type", "") or ""
+                            if not any(mime.startswith(p) for p in _TEXT_MIME_PREFIXES):
+                                continue
+                            try:
+                                raw = await att.read()
+                                doc_text = raw.decode("utf-8", errors="replace")
+                                fname = getattr(att, "filename", "document")
+                                await live_mgr.send_context_update(
+                                    guild_id,
+                                    f"[Document: {fname}]\n{doc_text}",
+                                )
+                                log_info(
+                                    f"[discord_interface] Injected attachment "
+                                    f"'{fname}' ({len(doc_text)} chars) into "
+                                    f"live session for guild {guild_id}"
+                                )
+                            except Exception as _att_err:
+                                log_warning(
+                                    f"[discord_interface] Failed to inject "
+                                    f"attachment into live session: {_att_err}"
+                                )
+
                         # forward into live model
                         await live_mgr.send_text(guild_id, text)
                         # replicate in history cache

--- a/interface/message_send_utils.py
+++ b/interface/message_send_utils.py
@@ -720,11 +720,16 @@ async def cortex_response_send(
         json_data = extract_json_from_text(text)
         if json_data:
             log_debug(f"[cortex_response_send] JSON parsed successfully: {json_data}")
-        elif ("{" in text and "}" in text) or ("[" in text and "]" in text):
+        elif text.lstrip().startswith(("{", "[")):
+            # Text genuinely starts with a JSON-like structure but failed to
+            # parse — route through the corrector to attempt recovery.
+            # NOTE: We intentionally do NOT match on braces *anywhere* in the
+            # text (e.g. emotion tags like ``{happy 10}`` or markdown) — only
+            # text that *starts* with ``{`` or ``[`` is treated as potential
+            # malformed JSON.
             log_debug(
-                f"[cortex_response_send] Text contains JSON-like content but failed to parse: {text[:200]}..."
+                f"[cortex_response_send] Text starts with JSON-like content but failed to parse: {text[:200]}..."
             )
-            # Try to process with action parser if available
             try:
                 from types import SimpleNamespace
                 from datetime import datetime
@@ -735,9 +740,6 @@ async def cortex_response_send(
                 message.original_text = text
                 message.thread_id = kwargs.get("thread_id")
                 message.date = datetime.utcnow()
-                # mark origin so corrector will operate on this artificial message
-                # mark origin to indicate AI/cortex output; no need for multiple
-                # legacy flags since we now normalise on "from_cortex" throughout.
                 message.from_cortex = True
 
                 current_interface = "telegram"
@@ -766,17 +768,12 @@ async def cortex_response_send(
                     )
                     return None
                 else:
-                    # If the text looked JSON-like but orchestrator declined to
-                    # handle it (returned None), we should block rather than
-                    # echo the potentially-invalid payload back to the user.
-                    if "{" in (text or "") or "[" in (text or ""):
-                        log_warning(
-                            "[cortex_response_send] corrector_orchestrator returned None on JSON-like text; blocking to prevent invalid send"
-                        )
-                        return None
-                    log_debug(
-                        "[cortex_response_send] corrector_orchestrator returned None -> forwarding as normal text"
+                    # Orchestrator declined — block to prevent sending raw
+                    # malformed JSON to the user.
+                    log_warning(
+                        "[cortex_response_send] corrector_orchestrator returned None on JSON-like text; blocking to prevent invalid send"
                     )
+                    return None
 
             except Exception as e:
                 log_debug(f"[cortex_response_send] corrector_orchestrator failed: {e}")

--- a/interface/ollama_compat_server.py
+++ b/interface/ollama_compat_server.py
@@ -73,7 +73,21 @@ class OllamaCompatServer:
         self.stream_timeout = float(os.getenv("OLLAMA_STREAM_TIMEOUT", "60.0"))
         self.completion_timeout = float(os.getenv("OLLAMA_COMPLETION_TIMEOUT", "0.0"))
 
-        self._schedule_server_startup()
+        # Check if server should be enabled (default: true for backward compatibility)
+        self.server_enabled = os.getenv("OLLAMA_SERVER_ENABLED", "true").lower() in (
+            "true",
+            "1",
+            "yes",
+            "on",
+        )
+
+        if self.server_enabled:
+            self._schedule_server_startup()
+        else:
+            log_info(
+                "[ollama_serve] Server disabled via OLLAMA_SERVER_ENABLED=false. "
+                "Interface actions still available but HTTP server will not start."
+            )
 
     # ------------------------------------------------------------------
     # Interface metadata
@@ -667,6 +681,17 @@ class OllamaCompatServer:
             await server.serve()
         except asyncio.CancelledError:  # pragma: no cover - cancellation path
             log_info("[ollama_serve] HTTP server task cancelled")
+            raise
+        except OSError as exc:  # pragma: no cover - port conflict
+            if "address already in use" in str(exc).lower() or exc.errno == 48:
+                log_error(
+                    f"[ollama_serve] ❌ Port {port} already in use! "
+                    f"Either disable this server with OLLAMA_SERVER_ENABLED=false "
+                    f"or change the port with OLLAMA_PORT=<other_port>. "
+                    f"If you want to CONNECT to llama.cpp/ollama, use the 'openapi' cortex engine instead."
+                )
+            else:
+                log_error(f"[ollama_serve] HTTP server failed to start: {exc}")
             raise
         except Exception as exc:  # pragma: no cover - defensive logging
             log_error(f"[ollama_serve] HTTP server crashed: {exc}")

--- a/interface/telegram_bot.py
+++ b/interface/telegram_bot.py
@@ -737,91 +737,32 @@ async def handle_media_live(update: Update, context: ContextTypes.DEFAULT_TYPE):
             return
 
         # ------------------------------------------------------------------
-        # FALLBACK PATH: LLM live processing (e.g. Gemini Live API)
+        # FALLBACK PATH: Enqueue voice/video through the normal message
+        # pipeline as a multimodal attachment so scope routing, persona
+        # context, and the correct engine (e.g. OpenRouter/Grok) are used.
         # ------------------------------------------------------------------
-        if plugin_instance.plugin:
-            # Check for new method name first, fall back to old if needed (though we updated it)
-            handler_method = getattr(
-                plugin_instance.plugin, "handle_live_processing", None
-            )
+        # We do NOT call handle_live_processing here — that bypasses scope
+        # routing and sends audio to the base engine with a generic prompt.
+        # Instead, the multimodal extraction in plugin_instance picks up the
+        # voice/video attachment and the scope-routed engine handles it with
+        # full bidirectional context (persona, chat history, emotions, etc.).
 
-            if handler_method:
-                # Get TEXT response
-                text_response = await handler_method(
-                    input_path, mime_type_hint=media_type_hint
-                )
-
-                if text_response:
-                    log_info(f"[telegram_bot] Live API Response: {text_response}")
-                    # Send as text reply - this triggers user's local TTS (as per request)
-                    await message.reply_text(text_response)
-
-                    # 🧠 FIRE-AND-FORGET MEMORY INJECTION
-                    # We describe what happened based on the media type
-                    user_action_desc = "User sent a Live Audio message."
-                    if "video" in media_type_hint:
-                        user_action_desc = "User sent a Live Video stream."
-
-                    asyncio.create_task(
-                        _inject_memory_interaction(
-                            message.chat_id,
-                            f"[{user_action_desc}]",
-                            text_response,
-                            f"telegram_bot/{message.chat_id}",
-                        )
-                    )
-                else:
-                    log_warning("[telegram_bot] Live API returned no text.")
-                    await message.reply_text(
-                        "🤔 I listened/watched, but I'm not sure what to say."
-                    )
-
-                return
-
-        # no handler method found; try a small local transcription model
-        # as a last‑ditch attempt before giving up entirely.  This covers
-        # situations where the plugin is a ManualAIPlugin (which lacks
-        # handle_live_processing) or the active cortex engine failed to load.
-        log_warning(
-            "[telegram_bot] no live processing handler available for media; attempting local transcription fallback"
+        log_info(
+            "[telegram_bot] Auris unavailable — enqueuing voice as multimodal "
+            "attachment through normal message chain"
         )
-        try:
-            # import lazily so we don't incur cost when not needed
-            from faster_whisper import WhisperModel
-
-            log_debug("[telegram_bot] loading Whisper tiny for local transcription")
-            model = WhisperModel("tiny", device="cpu")
-            segments, _info = model.transcribe(input_path)
-            text = " ".join(getattr(s, "text", "") for s in segments).strip()
-            if text:
-                log_info(f"[telegram_bot] local transcription result: {text[:120]}")
-                # enqueue exactly like Auris path rather than replying
-                wrapped = MessageWrapper(
-                    message,
-                    text=text,
-                    is_voice_input=True,
-                    request_tts=True,
-                )
-                await message_queue.enqueue(
-                    context.bot,
-                    wrapped,
-                    interface_id="telegram_bot",
-                    original_message=message,
-                    skip_mention_check=True,
-                )
-                return
-            else:
-                log_debug("[telegram_bot] local transcription produced empty text")
-        except ImportError:
-            log_warning(
-                "[telegram_bot] faster-whisper not available for local fallback"
-            )
-        except Exception as e:
-            log_debug(f"[telegram_bot] local transcription failed: {e}")
-
-        # still nothing? give the generic message so the user knows we heard
-        await message.reply_text(
-            "🤔 I received your media, but I couldn't process it right now."
+        wrapped = MessageWrapper(
+            message,
+            text=message.caption or "",
+            is_voice_input=True,
+            request_tts=True,
+        )
+        await message_queue.enqueue(
+            context.bot,
+            wrapped,
+            interface_id="telegram_bot",
+            original_message=message,
+            skip_mention_check=True,
         )
 
     except Exception as e:

--- a/res/synth_webui/js/main.js
+++ b/res/synth_webui/js/main.js
@@ -1387,26 +1387,106 @@ function pickAccentDarkFromHex(hex) { return darkenHex(hex, 0.28); }
                             swatchWrap.appendChild(reset);
                             inputEl = swatchWrap;
 
-                        // --- Combobox: free-text input with datalist suggestions ---
+                        // --- Combobox: free-text input with searchable dropdown ---
                         } else if (item.ui_type === 'combobox') {
-                            const input = document.createElement('input');
-                            input.type = 'text';
-                            input.value = typeof value === 'string' ? value : '';
-                            input.disabled = !isEditable;
-                            if (Array.isArray(item.options) && item.options.length) {
-                                const dlId = `datalist-${item.key}`;
-                                const dl = document.createElement('datalist');
-                                dl.id = dlId;
-                                item.options.forEach((opt) => {
-                                    const o = document.createElement('option');
-                                    o.value = opt;
-                                    dl.appendChild(o);
+                            const opts = Array.isArray(item.options) ? item.options : [];
+                            // Large option sets get a custom searchable dropdown
+                            if (opts.length > 20) {
+                                const wrap = document.createElement('div');
+                                wrap.className = 'searchable-combo';
+                                wrap.style.position = 'relative';
+                                wrap.style.flex = '1';
+                                skipAutoSave = true;
+
+                                const input = document.createElement('input');
+                                input.type = 'text';
+                                input.value = typeof value === 'string' ? value : '';
+                                input.disabled = !isEditable;
+                                input.placeholder = `Search ${opts.length} options...`;
+                                input.autocomplete = 'off';
+
+                                const panel = document.createElement('div');
+                                panel.className = 'combo-dropdown';
+                                panel.style.cssText = 'display:none;position:absolute;top:100%;left:0;right:0;max-height:260px;overflow-y:auto;border:1px solid var(--border);border-radius:8px;background:var(--bg-card,#1a1a2e);z-index:999;margin-top:2px;';
+
+                                const MAX_VISIBLE = 80;
+                                const renderList = (filter) => {
+                                    panel.innerHTML = '';
+                                    const q = (filter || '').toLowerCase();
+                                    let count = 0;
+                                    for (const opt of opts) {
+                                        if (q && !opt.toLowerCase().includes(q)) continue;
+                                        if (++count > MAX_VISIBLE) {
+                                            const more = document.createElement('div');
+                                            more.style.cssText = 'padding:0.35rem 0.6rem;color:var(--text-soft);font-size:0.8rem;';
+                                            more.textContent = `${opts.length - MAX_VISIBLE}+ more — refine your search`;
+                                            panel.appendChild(more);
+                                            break;
+                                        }
+                                        const row = document.createElement('div');
+                                        row.textContent = opt;
+                                        row.style.cssText = 'padding:0.35rem 0.6rem;cursor:pointer;font-size:0.9rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;';
+                                        row.addEventListener('mouseenter', () => { row.style.background = 'var(--accent-dim, rgba(107,254,254,0.12))'; });
+                                        row.addEventListener('mouseleave', () => { row.style.background = ''; });
+                                        row.addEventListener('mousedown', (ev) => {
+                                            ev.preventDefault(); // prevent blur before click
+                                            input.value = opt;
+                                            panel.style.display = 'none';
+                                            persistValue(opt, [input]);
+                                        });
+                                        panel.appendChild(row);
+                                    }
+                                    if (count === 0) {
+                                        const empty = document.createElement('div');
+                                        empty.style.cssText = 'padding:0.5rem 0.6rem;color:var(--text-soft);font-size:0.85rem;';
+                                        empty.textContent = 'No matching models';
+                                        panel.appendChild(empty);
+                                    }
+                                };
+
+                                input.addEventListener('focus', () => {
+                                    renderList(input.value);
+                                    panel.style.display = '';
                                 });
-                                // Ensure unique id by attaching to document.body
-                                document.body.appendChild(dl);
-                                input.setAttribute('list', dlId);
+                                input.addEventListener('input', () => { renderList(input.value); });
+                                input.addEventListener('blur', () => {
+                                    // Delay to allow mousedown on options
+                                    setTimeout(() => { panel.style.display = 'none'; }, 180);
+                                });
+                                input.addEventListener('keydown', (ev) => {
+                                    if (ev.key === 'Enter') {
+                                        ev.preventDefault();
+                                        panel.style.display = 'none';
+                                        persistValue(input.value, [input]);
+                                    } else if (ev.key === 'Escape') {
+                                        panel.style.display = 'none';
+                                        input.blur();
+                                    }
+                                });
+
+                                wrap.appendChild(input);
+                                wrap.appendChild(panel);
+                                inputEl = wrap;
+                            } else {
+                                // Small option sets: use native datalist
+                                const input = document.createElement('input');
+                                input.type = 'text';
+                                input.value = typeof value === 'string' ? value : '';
+                                input.disabled = !isEditable;
+                                if (opts.length) {
+                                    const dlId = `datalist-${item.key}`;
+                                    const dl = document.createElement('datalist');
+                                    dl.id = dlId;
+                                    opts.forEach((opt) => {
+                                        const o = document.createElement('option');
+                                        o.value = opt;
+                                        dl.appendChild(o);
+                                    });
+                                    document.body.appendChild(dl);
+                                    input.setAttribute('list', dlId);
+                                }
+                                inputEl = input;
                             }
-                            inputEl = input;
 
                         // --- Action list: dropdown rows with add/remove ---
                         } else if (item.ui_type === 'action-list') {
@@ -2158,10 +2238,101 @@ function pickAccentDarkFromHex(hex) { return darkenHex(hex, 0.28); }
 
                         // Update info field with active engine for this cortex
                         const active = engines.find(e => e.active) || engines.find(e => e.name === (data.cortex && data.cortex.active_engine)) || engines[0] || null;
-                        if (engineModelLabel) engineModelLabel.textContent = `model: ${active ? (active.display_name || active.name || '—') : '—'}`;
+                        if (engineModelLabel) engineModelLabel.textContent = `model: ${active ? (active.current_model || active.display_name || active.name || '—') : '—'}`;
                         if (engineLabel) engineLabel.textContent = active ? (active.label || active.description || '') : '';
                         const loginState = active ? (active.login_state || (active.logged_in ? 'logged' : 'unlogged')) : '—';
                         if (engineLoginStateLabel) engineLoginStateLabel.textContent = `state: ${loginState}`;
+
+                        // --- Searchable model picker for engines with supported_models ---
+                        const modelPicker = document.getElementById('cortex-model-picker');
+                        const modelSearch = document.getElementById('cortex-model-search');
+                        const modelDropdown = document.getElementById('cortex-model-dropdown');
+                        if (modelPicker && modelSearch && modelDropdown) {
+                            const models = (active && Array.isArray(active.supported_models)) ? active.supported_models : [];
+                            if (models.length > 1) {
+                                modelPicker.style.display = '';
+                                modelSearch.value = active.current_model || '';
+                                modelSearch.placeholder = `Search ${models.length} models…`;
+                                const MAX_VIS = 80;
+                                const renderModelList = (filter) => {
+                                    modelDropdown.innerHTML = '';
+                                    const q = (filter || '').toLowerCase();
+                                    let count = 0;
+                                    for (const m of models) {
+                                        if (q && !m.toLowerCase().includes(q)) continue;
+                                        if (++count > MAX_VIS) {
+                                            const more = document.createElement('div');
+                                            more.style.cssText = 'padding:0.35rem 0.6rem;color:var(--text-soft,#aaa);font-size:0.8rem;';
+                                            more.textContent = `${models.length - MAX_VIS}+ more — refine your search`;
+                                            modelDropdown.appendChild(more);
+                                            break;
+                                        }
+                                        const row = document.createElement('div');
+                                        row.textContent = m;
+                                        row.style.cssText = 'padding:0.4rem 0.7rem;cursor:pointer;font-size:0.9rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;';
+                                        if (m === active.current_model) row.style.fontWeight = '700';
+                                        row.addEventListener('mouseenter', () => { row.style.background = 'var(--accent-dim, rgba(107,254,254,0.12))'; });
+                                        row.addEventListener('mouseleave', () => { row.style.background = ''; });
+                                        row.addEventListener('mousedown', (ev) => {
+                                            ev.preventDefault();
+                                            modelSearch.value = m;
+                                            modelDropdown.style.display = 'none';
+                                            // Persist model selection via API
+                                            fetch('/api/components/cortex/model', {
+                                                method: 'POST',
+                                                headers: { 'Content-Type': 'application/json' },
+                                                body: JSON.stringify({ engine: active.name, model: m })
+                                            }).then((res) => {
+                                                if (!res.ok) throw new Error('HTTP ' + res.status);
+                                                if (engineModelLabel) engineModelLabel.textContent = `model: ${m}`;
+                                            }).catch((err) => {
+                                                console.error('[synth_webui] Failed to set model', err);
+                                                alert('Failed to set model: ' + err.message);
+                                            });
+                                        });
+                                        modelDropdown.appendChild(row);
+                                    }
+                                    if (count === 0) {
+                                        const empty = document.createElement('div');
+                                        empty.style.cssText = 'padding:0.5rem 0.7rem;color:var(--text-soft,#aaa);font-size:0.85rem;';
+                                        empty.textContent = 'No matching models';
+                                        modelDropdown.appendChild(empty);
+                                    }
+                                };
+
+                                // Wire events only once
+                                if (!modelSearch.dataset.bound) {
+                                    modelSearch.addEventListener('focus', () => { renderModelList(modelSearch.value); modelDropdown.style.display = ''; });
+                                    modelSearch.addEventListener('input', () => { renderModelList(modelSearch.value); });
+                                    modelSearch.addEventListener('blur', () => { setTimeout(() => { modelDropdown.style.display = 'none'; }, 180); });
+                                    modelSearch.addEventListener('keydown', (ev) => {
+                                        if (ev.key === 'Enter') {
+                                            ev.preventDefault();
+                                            modelDropdown.style.display = 'none';
+                                            const val = modelSearch.value.trim();
+                                            if (val && active) {
+                                                fetch('/api/components/cortex/model', {
+                                                    method: 'POST',
+                                                    headers: { 'Content-Type': 'application/json' },
+                                                    body: JSON.stringify({ engine: active.name, model: val })
+                                                }).then((res) => {
+                                                    if (!res.ok) throw new Error('HTTP ' + res.status);
+                                                    if (engineModelLabel) engineModelLabel.textContent = `model: ${val}`;
+                                                }).catch((err) => {
+                                                    console.error('[synth_webui] Failed to set model', err);
+                                                });
+                                            }
+                                        } else if (ev.key === 'Escape') {
+                                            modelDropdown.style.display = 'none';
+                                            modelSearch.blur();
+                                        }
+                                    });
+                                    modelSearch.dataset.bound = '1';
+                                }
+                            } else {
+                                modelPicker.style.display = 'none';
+                            }
+                        }
                         const isSeleniumKind = String(kind || '').toLowerCase().includes('selenium');
                         if (engineLoginBtn) {
                             engineLoginBtn.style.display = isSeleniumKind ? '' : 'none';

--- a/res/synth_webui/js/skins-ui.js
+++ b/res/synth_webui/js/skins-ui.js
@@ -1,8 +1,12 @@
-// skins-ui.js — extracted Skins UI helpers (fetch/render/activate/clear)
+// skins-ui.js — Skins UI helpers (fetch/render/activate/clear + skin editor)
 (function(){
     'use strict';
 
     const _apiBase = (window.__getApiBase && window.__getApiBase()) || '';
+
+    // ----------------------------------------------------------------
+    // Core skin list
+    // ----------------------------------------------------------------
 
     async function fetchSkins(){
         const grid = document.getElementById('skins-grid');
@@ -11,7 +15,6 @@
             const res = await fetch(_apiBase + '/api/skins');
             if (!res.ok) throw new Error('Failed to load skins: HTTP ' + res.status);
             const data = await res.json();
-            // The API returns an array of skins
             renderSkins(data || []);
         } catch (e) {
             console.warn('[synth_webui] fetchSkins failed', e);
@@ -29,32 +32,84 @@
         grid.innerHTML = '';
         skins.forEach(s => {
             const card = document.createElement('div'); card.className='skin-card';
+
+            // Preview
             const preview = document.createElement('div'); preview.className='skin-preview';
             if(s.preview_url){
                 const img = document.createElement('img'); img.src = s.preview_url; preview.appendChild(img);
             } else {
                 preview.innerHTML = '<div class="meta">No preview</div>';
             }
-            const title = document.createElement('div'); title.innerHTML = `<strong>${s.name}</strong>`;
 
-            // Build metadata section with version, author, description
+            // Title
+            const title = document.createElement('div'); title.innerHTML = `<strong>${escapeHtml(s.name)}</strong>`;
+
+            // Metadata
             let metaHtml = '';
-            if(s.vrm_version) metaHtml += `<div class="skin-vrm-version"><small>VRM ${s.vrm_version}</small></div>`;
-            if(s.version) metaHtml += `<div class="skin-version"><small>Skin v${s.version}</small></div>`;
-            if(s.author) metaHtml += `<div class="skin-author"><small>by ${s.author}</small></div>`;
-            if(s.description) metaHtml += `<div class="skin-description"><small>${s.description}</small></div>`;
+            if(s.vrm_version) metaHtml += `<div class="skin-vrm-version"><small>VRM ${escapeHtml(s.vrm_version)}</small></div>`;
+            if(s.version) metaHtml += `<div class="skin-version"><small>Skin v${escapeHtml(s.version)}</small></div>`;
+            if(s.author) metaHtml += `<div class="skin-author"><small>by ${escapeHtml(s.author)}</small></div>`;
+            if(s.description) metaHtml += `<div class="skin-description"><small>${escapeHtml(s.description)}</small></div>`;
             const meta = document.createElement('div'); meta.className='skin-meta'; meta.innerHTML = metaHtml;
 
+            // Actions row 1: Activate + status
             const actions = document.createElement('div'); actions.className='skin-actions';
             const act = document.createElement('button'); act.className='btn-primary'; act.textContent='Activate';
             act.disabled = !s.valid;
             act.addEventListener('click', ()=> activateSkin(s.folder || s.name));
             const info = document.createElement('button'); info.className='btn-ghost'; info.textContent = s.vrm_present? 'Has VRM':'No VRM'; info.disabled=true;
             actions.appendChild(act); actions.appendChild(info);
-            card.appendChild(preview); card.appendChild(title); card.appendChild(meta); card.appendChild(actions);
+
+            // Actions row 2: Download, Upload VRM, Upload Preview, Delete
+            const actions2 = document.createElement('div'); actions2.className='skin-actions skin-actions-editor';
+
+            // Download
+            const dlBtn = document.createElement('button'); dlBtn.className='btn-ghost'; dlBtn.textContent='Download';
+            dlBtn.addEventListener('click', ()=> downloadSkin(s.folder || s.name));
+            actions2.appendChild(dlBtn);
+
+            // Upload VRM
+            const vrmLabel = document.createElement('label'); vrmLabel.className='btn-ghost'; vrmLabel.textContent='+ VRM';
+            vrmLabel.style.cursor='pointer';
+            const vrmInput = document.createElement('input'); vrmInput.type='file'; vrmInput.accept='.vrm'; vrmInput.style.display='none';
+            vrmInput.addEventListener('change', (e) => {
+                if(e.target.files && e.target.files[0]) uploadSkinVrm(s.folder || s.name, e.target.files[0]);
+            });
+            vrmLabel.appendChild(vrmInput);
+            actions2.appendChild(vrmLabel);
+
+            // Upload Preview
+            const prevLabel = document.createElement('label'); prevLabel.className='btn-ghost'; prevLabel.textContent='+ Preview';
+            prevLabel.style.cursor='pointer';
+            const prevInput = document.createElement('input'); prevInput.type='file'; prevInput.accept='.png,.jpg,.jpeg,.webp'; prevInput.style.display='none';
+            prevInput.addEventListener('change', (e) => {
+                if(e.target.files && e.target.files[0]) uploadSkinPreview(s.folder || s.name, e.target.files[0]);
+            });
+            prevLabel.appendChild(prevInput);
+            actions2.appendChild(prevLabel);
+
+            // Delete (hidden for Rei)
+            const folder = s.folder || s.name;
+            if(folder !== 'Rei'){
+                const delBtn = document.createElement('button'); delBtn.className='btn-ghost btn-danger'; delBtn.textContent='Delete';
+                delBtn.addEventListener('click', ()=> deleteSkin(folder));
+                actions2.appendChild(delBtn);
+            }
+
+            card.appendChild(preview); card.appendChild(title); card.appendChild(meta);
+            card.appendChild(actions); card.appendChild(actions2);
             grid.appendChild(card);
-        })
+        });
     }
+
+    function escapeHtml(str) {
+        if (!str) return '';
+        return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+    }
+
+    // ----------------------------------------------------------------
+    // Skin actions
+    // ----------------------------------------------------------------
 
     async function activateSkin(name){
         try{
@@ -62,7 +117,7 @@
             if(!res.ok) throw new Error('Activate failed');
             await fetchSkins();
             if(window.refreshModels) await window.refreshModels();
-        }catch(e){ alert('Error: '+e.message) }
+        }catch(e){ alert('Error: '+e.message); }
     }
 
     async function clearUploaded(){
@@ -72,26 +127,165 @@
             await fetchSkins();
             if(window.refreshModels) await window.refreshModels();
             alert('Restored default Rei VRM');
-        }catch(e){ alert('Error: '+e.message) }
+        }catch(e){ alert('Error: '+e.message); }
     }
+
+    // ----------------------------------------------------------------
+    // Skin editor functions
+    // ----------------------------------------------------------------
+
+    async function createSkin(data){
+        try{
+            const res = await fetch(_apiBase + '/api/skins', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(data)
+            });
+            if(!res.ok){
+                const err = await res.json().catch(()=>({}));
+                throw new Error(err.detail || 'Failed to create skin');
+            }
+            await fetchSkins();
+            return true;
+        }catch(e){ alert('Error: '+e.message); return false; }
+    }
+
+    async function uploadSkinVrm(skinName, file){
+        try{
+            const fd = new FormData();
+            fd.append('file', file);
+            const res = await fetch(_apiBase + `/api/skins/${encodeURIComponent(skinName)}/vrm`, {method:'POST', body:fd});
+            if(!res.ok){
+                const err = await res.json().catch(()=>({}));
+                throw new Error(err.detail || 'Upload failed');
+            }
+            await fetchSkins();
+            if(window.refreshModels) await window.refreshModels();
+        }catch(e){ alert('Error: '+e.message); }
+    }
+
+    async function uploadSkinPreview(skinName, file){
+        try{
+            const fd = new FormData();
+            fd.append('file', file);
+            const res = await fetch(_apiBase + `/api/skins/${encodeURIComponent(skinName)}/preview`, {method:'POST', body:fd});
+            if(!res.ok){
+                const err = await res.json().catch(()=>({}));
+                throw new Error(err.detail || 'Upload failed');
+            }
+            await fetchSkins();
+        }catch(e){ alert('Error: '+e.message); }
+    }
+
+    function downloadSkin(skinName){
+        window.location.href = _apiBase + `/api/skins/${encodeURIComponent(skinName)}/download`;
+    }
+
+    async function uploadSkinZip(file){
+        try{
+            const fd = new FormData();
+            fd.append('file', file);
+            const res = await fetch(_apiBase + '/api/skins/upload', {method:'POST', body:fd});
+            if(!res.ok){
+                const err = await res.json().catch(()=>({}));
+                throw new Error(err.detail || 'Upload failed');
+            }
+            await fetchSkins();
+            if(window.refreshModels) await window.refreshModels();
+        }catch(e){ alert('Error: '+e.message); }
+    }
+
+    async function deleteSkin(skinName){
+        if(!confirm(`Delete skin "${skinName}"? This cannot be undone.`)) return;
+        try{
+            const res = await fetch(_apiBase + `/api/skins/${encodeURIComponent(skinName)}`, {method:'DELETE'});
+            if(!res.ok){
+                const err = await res.json().catch(()=>({}));
+                throw new Error(err.detail || 'Delete failed');
+            }
+            await fetchSkins();
+        }catch(e){ alert('Error: '+e.message); }
+    }
+
+    // ----------------------------------------------------------------
+    // Init: wire up buttons
+    // ----------------------------------------------------------------
 
     function init(){
         try{
+            // Clear uploaded button
             const clearBtn = document.getElementById('clear-uploaded');
             if(clearBtn) clearBtn.addEventListener('click', clearUploaded);
+
+            // Nav skins tab click
             const navSkins = document.getElementById('nav-skins');
             if(navSkins) navSkins.addEventListener('click', function(){ fetchSkins(); });
 
-            // Load skins on page initialization if fetchSkins isn't provided elsewhere
-            try { if (typeof fetchSkins === 'function') fetchSkins(); } catch (e) {}
+            // New Skin form toggle
+            const newBtn = document.getElementById('btn-new-skin');
+            const formEl = document.getElementById('skin-editor-form');
+            if(newBtn && formEl){
+                newBtn.addEventListener('click', ()=>{
+                    formEl.style.display = formEl.style.display === 'none' ? 'block' : 'none';
+                });
+            }
+
+            // Cancel button
+            const cancelBtn = document.getElementById('btn-skin-cancel');
+            if(cancelBtn && formEl){
+                cancelBtn.addEventListener('click', ()=>{
+                    formEl.style.display = 'none';
+                });
+            }
+
+            // Create button
+            const createBtn = document.getElementById('btn-skin-create');
+            if(createBtn){
+                createBtn.addEventListener('click', async ()=>{
+                    const name = (document.getElementById('skin-form-name') || {}).value || '';
+                    if(!name.trim()){ alert('Skin name is required'); return; }
+                    const data = {
+                        name: name.trim(),
+                        author: (document.getElementById('skin-form-author') || {}).value || '',
+                        version: (document.getElementById('skin-form-version') || {}).value || '1.0',
+                        appearance: (document.getElementById('skin-form-appearance') || {}).value || ''
+                    };
+                    const ok = await createSkin(data);
+                    if(ok && formEl){
+                        formEl.style.display = 'none';
+                        // Clear form
+                        const nameEl = document.getElementById('skin-form-name'); if(nameEl) nameEl.value='';
+                        const authorEl = document.getElementById('skin-form-author'); if(authorEl) authorEl.value='';
+                        const versionEl = document.getElementById('skin-form-version'); if(versionEl) versionEl.value='1.0';
+                        const appearanceEl = document.getElementById('skin-form-appearance'); if(appearanceEl) appearanceEl.value='';
+                    }
+                });
+            }
+
+            // Upload skin zip
+            const zipInput = document.getElementById('skin-zip-upload');
+            if(zipInput){
+                zipInput.addEventListener('change', (e)=>{
+                    if(e.target.files && e.target.files[0]){
+                        uploadSkinZip(e.target.files[0]);
+                        e.target.value = ''; // reset for re-upload
+                    }
+                });
+            }
+
+            // Initial load
+            try { fetchSkins(); } catch(e) {}
         } catch (e){ console.warn('[synth_webui] skins-ui init failed', e); }
     }
 
-    // Export for other modules and for backward compatibility
+    // Export for other modules
     window.fetchSkins = window.fetchSkins || fetchSkins;
     window.renderSkins = window.renderSkins || renderSkins;
     window.activateSkin = window.activateSkin || activateSkin;
     window.clearUploadedSkins = window.clearUploadedSkins || clearUploaded;
+    window.createSkin = window.createSkin || createSkin;
+    window.deleteSkin = window.deleteSkin || deleteSkin;
+    window.downloadSkin = window.downloadSkin || downloadSkin;
 
     // Auto-init
     if (document.readyState === 'loading') {

--- a/tests/test_openrouter_engine.py
+++ b/tests/test_openrouter_engine.py
@@ -276,11 +276,24 @@ class TestMultimodalExtraction:
         assert parts[0]["type"] == "image_url"
         assert "data:image/jpeg;base64,AAAA" in parts[0]["image_url"]["url"]
 
-    def test_skips_non_image(self) -> None:
+    def test_extracts_audio_attachment(self) -> None:
         plugin = self._make_plugin()
         prompt = {
             "attachments": [
                 {"mime_type": "audio/mpeg", "data": "BBBB"},
+            ]
+        }
+        parts = plugin._extract_multimodal_parts(prompt)
+        assert len(parts) == 1
+        assert parts[0]["type"] == "input_audio"
+        assert parts[0]["input_audio"]["format"] == "mp3"
+        assert parts[0]["input_audio"]["data"] == "BBBB"
+
+    def test_skips_unsupported_mime(self) -> None:
+        plugin = self._make_plugin()
+        prompt = {
+            "attachments": [
+                {"mime_type": "application/pdf", "data": "CCCC"},
             ]
         }
         parts = plugin._extract_multimodal_parts(prompt)

--- a/tests/test_openrouter_engine.py
+++ b/tests/test_openrouter_engine.py
@@ -1,0 +1,583 @@
+"""Tests for the OpenRouter LLM engine."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+# Minimal OpenRouter /models API response payload
+_SAMPLE_MODELS_RESPONSE: dict[str, Any] = {
+    "data": [
+        {
+            "id": "anthropic/claude-sonnet-4",
+            "name": "Anthropic: Claude Sonnet 4",
+            "context_length": 200000,
+            "top_provider": {"max_completion_tokens": 8192},
+            "architecture": {"modality": "text+image->text", "tokenizer": "Claude"},
+            "pricing": {"prompt": "0.000003", "completion": "0.000015"},
+            "supported_parameters": ["tools", "tool_choice", "temperature"],
+        },
+        {
+            "id": "openai/gpt-4o",
+            "name": "OpenAI: GPT-4o",
+            "context_length": 128000,
+            "top_provider": {"max_completion_tokens": 4096},
+            "architecture": {"modality": "text+image->text", "tokenizer": "GPT"},
+            "pricing": {"prompt": "0.000005", "completion": "0.000015"},
+            "supported_parameters": ["tools", "temperature"],
+        },
+        {
+            "id": "meta-llama/llama-3-70b",
+            "name": "Meta: Llama 3 70B",
+            "context_length": 8192,
+            "top_provider": {"max_completion_tokens": 2048},
+            "architecture": {"modality": "text->text"},
+            "pricing": {"prompt": "0.0000008", "completion": "0.0000008"},
+            "supported_parameters": ["temperature"],
+        },
+    ]
+}
+
+
+def _make_http_response(
+    status_code: int = 200,
+    json_body: dict[str, Any] | None = None,
+    text: str = "",
+) -> MagicMock:
+    """Create a mock requests.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text or json.dumps(json_body or {})
+    resp.json.return_value = json_body or {}
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = Exception(f"HTTP {status_code}")
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Model catalog tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenRouterModel:
+    def test_parse_vision_model(self) -> None:
+        from cortex.llm_provider.openrouter import OpenRouterModel
+
+        data = _SAMPLE_MODELS_RESPONSE["data"][0]
+        m = OpenRouterModel.from_api(data)
+        assert m.id == "anthropic/claude-sonnet-4"
+        assert m.supports_vision is True
+        assert m.supports_audio is False
+        assert m.supports_tool_use is True
+        assert m.context_length == 200000
+        assert m.max_completion_tokens == 8192
+        assert m.pricing_prompt == 0.000003
+
+    def test_parse_text_only_model(self) -> None:
+        from cortex.llm_provider.openrouter import OpenRouterModel
+
+        data = _SAMPLE_MODELS_RESPONSE["data"][2]
+        m = OpenRouterModel.from_api(data)
+        assert m.id == "meta-llama/llama-3-70b"
+        assert m.supports_vision is False
+        assert m.supports_audio is False
+        assert m.supports_tool_use is False
+        assert m.modality == "text->text"
+
+    def test_parse_audio_modality(self) -> None:
+        from cortex.llm_provider.openrouter import OpenRouterModel
+
+        data = {
+            "id": "test/audio-model",
+            "name": "Test Audio",
+            "context_length": 4096,
+            "architecture": {"modality": "text+image+audio->text"},
+            "pricing": {},
+            "supported_parameters": [],
+        }
+        m = OpenRouterModel.from_api(data)
+        assert m.supports_vision is True
+        assert m.supports_audio is True
+
+    def test_parse_missing_fields(self) -> None:
+        from cortex.llm_provider.openrouter import OpenRouterModel
+
+        m = OpenRouterModel.from_api({"id": "minimal/model"})
+        assert m.id == "minimal/model"
+        assert m.context_length == 4096
+        assert m.modality == "text->text"
+        assert m.supports_vision is False
+
+
+class TestModelCatalog:
+    def test_fetch_catalog_sync(self) -> None:
+        from cortex.llm_provider.openrouter import _fetch_catalog_sync
+
+        with patch("cortex.llm_provider.openrouter.requests.get") as mock_get:
+            mock_get.return_value = _make_http_response(
+                json_body=_SAMPLE_MODELS_RESPONSE
+            )
+            models = _fetch_catalog_sync("https://openrouter.ai/api/v1")
+
+        assert len(models) == 3
+        assert "anthropic/claude-sonnet-4" in models
+        assert "meta-llama/llama-3-70b" in models
+        assert models["openai/gpt-4o"].supports_vision is True
+
+    def test_fetch_catalog_failure(self) -> None:
+        from cortex.llm_provider.openrouter import _fetch_catalog_sync
+
+        with patch("cortex.llm_provider.openrouter.requests.get") as mock_get:
+            mock_get.side_effect = Exception("Network error")
+            models = _fetch_catalog_sync("https://openrouter.ai/api/v1")
+
+        assert models == {}
+
+
+# ---------------------------------------------------------------------------
+# Model routes / resolution tests
+# ---------------------------------------------------------------------------
+
+
+class TestModelResolution:
+    def _make_plugin(self) -> Any:
+        """Create a plugin instance with mocked dependencies."""
+        from cortex.llm_provider.openrouter import OpenRouterPlugin
+
+        with patch("cortex.llm_provider.openrouter._refresh_catalog"):
+            with patch("core.notifier.set_notifier"):
+                plugin = OpenRouterPlugin.__new__(OpenRouterPlugin)
+                plugin._current_model = "anthropic/claude-sonnet-4"
+                plugin._current_request_meta = None
+                plugin._notify_fn = lambda *a: None
+                plugin.model_limits_map = {"default": 200000}
+        return plugin
+
+    def test_resolve_default(self) -> None:
+        plugin = self._make_plugin()
+        with patch(
+            "cortex.llm_provider.openrouter.OPENROUTER_MODEL_ROUTES",
+            MagicMock(value="{}"),
+        ):
+            result = plugin._resolve_model()
+        assert result == "anthropic/claude-sonnet-4"
+
+    def test_resolve_scope_override(self) -> None:
+        plugin = self._make_plugin()
+        routes = {"scopes": {"grillo": "anthropic/claude-haiku-3.5"}}
+        mock_var = MagicMock()
+        mock_var.value = routes
+        with patch("cortex.llm_provider.openrouter.OPENROUTER_MODEL_ROUTES", mock_var):
+            result = plugin._resolve_model(scope="grillo")
+        assert result == "anthropic/claude-haiku-3.5"
+
+    def test_resolve_action_override(self) -> None:
+        plugin = self._make_plugin()
+        routes = {"actions": {"create_personal_diary_entry": "meta-llama/llama-3-70b"}}
+        mock_var = MagicMock()
+        mock_var.value = routes
+        with patch("cortex.llm_provider.openrouter.OPENROUTER_MODEL_ROUTES", mock_var):
+            result = plugin._resolve_model(action_type="create_personal_diary_entry")
+        assert result == "meta-llama/llama-3-70b"
+
+    def test_resolve_action_glob(self) -> None:
+        plugin = self._make_plugin()
+        routes = {"actions": {"message_*": "openai/gpt-4o"}}
+        mock_var = MagicMock()
+        mock_var.value = routes
+        with patch("cortex.llm_provider.openrouter.OPENROUTER_MODEL_ROUTES", mock_var):
+            result = plugin._resolve_model(action_type="message_telegram_bot")
+        assert result == "openai/gpt-4o"
+
+    def test_action_override_beats_scope(self) -> None:
+        plugin = self._make_plugin()
+        routes = {
+            "scopes": {"grillo": "anthropic/claude-haiku-3.5"},
+            "actions": {"create_personal_diary_entry": "meta-llama/llama-3-70b"},
+        }
+        mock_var = MagicMock()
+        mock_var.value = routes
+        with patch("cortex.llm_provider.openrouter.OPENROUTER_MODEL_ROUTES", mock_var):
+            result = plugin._resolve_model(
+                scope="grillo", action_type="create_personal_diary_entry"
+            )
+        assert result == "meta-llama/llama-3-70b"
+
+
+# ---------------------------------------------------------------------------
+# System instruction tests
+# ---------------------------------------------------------------------------
+
+
+class TestSystemInstruction:
+    def _make_plugin(self) -> Any:
+        from cortex.llm_provider.openrouter import OpenRouterPlugin
+
+        plugin = OpenRouterPlugin.__new__(OpenRouterPlugin)
+        plugin._current_model = "test/model"
+        return plugin
+
+    def test_extracts_interface(self) -> None:
+        plugin = self._make_plugin()
+        prompt = {
+            "input": {"source": {"interface": "telegram_bot"}},
+        }
+        si = plugin._build_system_instruction(prompt)
+        assert "CURRENT INTERFACE: telegram_bot" in si
+        assert "message_telegram_bot" in si
+
+    def test_includes_verbose_instructions(self) -> None:
+        plugin = self._make_plugin()
+        prompt = {
+            "input": {"interface": "synth_webui"},
+            "instructions_verbose": "CUSTOM PERSONA INSTRUCTIONS",
+        }
+        si = plugin._build_system_instruction(prompt)
+        assert "CUSTOM PERSONA INSTRUCTIONS" in si
+        assert "CRITICAL OUTPUT FORMAT" in si
+
+
+# ---------------------------------------------------------------------------
+# Multimodal extraction tests
+# ---------------------------------------------------------------------------
+
+
+class TestMultimodalExtraction:
+    def _make_plugin(self) -> Any:
+        from cortex.llm_provider.openrouter import OpenRouterPlugin
+
+        plugin = OpenRouterPlugin.__new__(OpenRouterPlugin)
+        return plugin
+
+    def test_extracts_image_attachment(self) -> None:
+        plugin = self._make_plugin()
+        prompt = {
+            "input": {
+                "payload": {"text": "describe this"},
+                "attachments": [
+                    {
+                        "mime_type": "image/jpeg",
+                        "data": "AAAA",  # dummy base64
+                    }
+                ],
+            }
+        }
+        parts = plugin._extract_multimodal_parts(prompt)
+        assert len(parts) == 1
+        assert parts[0]["type"] == "image_url"
+        assert "data:image/jpeg;base64,AAAA" in parts[0]["image_url"]["url"]
+
+    def test_skips_non_image(self) -> None:
+        plugin = self._make_plugin()
+        prompt = {
+            "attachments": [
+                {"mime_type": "audio/mpeg", "data": "BBBB"},
+            ]
+        }
+        parts = plugin._extract_multimodal_parts(prompt)
+        assert len(parts) == 0
+
+    def test_redacts_base64_data(self) -> None:
+        plugin = self._make_plugin()
+        prompt = {
+            "attachments": [
+                {"mime_type": "image/png", "data": "A" * 10000},
+            ]
+        }
+        redacted = plugin._copy_and_redact_data(prompt)
+        att = redacted["attachments"][0]
+        assert att["data"].startswith("<redacted:")
+        assert att["mime_type"] == "image/png"
+
+
+# ---------------------------------------------------------------------------
+# Chat completion tests
+# ---------------------------------------------------------------------------
+
+
+class TestChatCompletion:
+    def _make_plugin(self) -> Any:
+        from cortex.llm_provider.openrouter import OpenRouterPlugin
+
+        plugin = OpenRouterPlugin.__new__(OpenRouterPlugin)
+        plugin._current_model = "test/model"
+        plugin._notify_fn = lambda *a: None
+        return plugin
+
+    @pytest.mark.asyncio
+    async def test_successful_completion(self) -> None:
+        plugin = self._make_plugin()
+
+        response_body = {
+            "choices": [
+                {
+                    "message": {
+                        "content": '{"actions": [{"type": "message_synth_webui", "payload": {"text": "hello"}}]}'
+                    }
+                }
+            ],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 50},
+        }
+
+        with (
+            patch(
+                "cortex.llm_provider.openrouter.OPENROUTER_API_KEY",
+                MagicMock(__str__=lambda s: "test-key", __bool__=lambda s: True),
+            ),
+            patch(
+                "cortex.llm_provider.openrouter.OPENROUTER_BASE_URL",
+                MagicMock(__str__=lambda s: "https://openrouter.ai/api/v1"),
+            ),
+            patch(
+                "cortex.llm_provider.openrouter.OPENROUTER_SITE_URL",
+                MagicMock(__str__=lambda s: ""),
+            ),
+            patch(
+                "cortex.llm_provider.openrouter.OPENROUTER_APP_NAME",
+                MagicMock(__str__=lambda s: "Test"),
+            ),
+            patch("cortex.llm_provider.openrouter.requests.post") as mock_post,
+        ):
+            mock_post.return_value = _make_http_response(json_body=response_body)
+
+            result = await plugin._openai_chat_completion(
+                prompt_text='{"actions": []}',
+                system_instruction="You are a test.",
+                max_tokens=1024,
+                model="test/model",
+            )
+
+        assert "hello" in result
+        mock_post.assert_called_once()
+
+        # Verify request structure
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        assert payload["model"] == "test/model"
+        assert len(payload["messages"]) == 2
+        assert payload["messages"][0]["role"] == "system"
+        assert payload["messages"][1]["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_handles_api_error(self) -> None:
+        plugin = self._make_plugin()
+
+        error_body = {"error": {"message": "Rate limit exceeded"}}
+
+        with (
+            patch(
+                "cortex.llm_provider.openrouter.OPENROUTER_API_KEY",
+                MagicMock(__str__=lambda s: "test-key", __bool__=lambda s: True),
+            ),
+            patch(
+                "cortex.llm_provider.openrouter.OPENROUTER_BASE_URL",
+                MagicMock(__str__=lambda s: "https://openrouter.ai/api/v1"),
+            ),
+            patch(
+                "cortex.llm_provider.openrouter.OPENROUTER_SITE_URL",
+                MagicMock(__str__=lambda s: ""),
+            ),
+            patch(
+                "cortex.llm_provider.openrouter.OPENROUTER_APP_NAME",
+                MagicMock(__str__=lambda s: "Test"),
+            ),
+            patch("cortex.llm_provider.openrouter.requests.post") as mock_post,
+        ):
+            mock_post.return_value = _make_http_response(json_body=error_body)
+
+            result = await plugin._openai_chat_completion(
+                prompt_text="test",
+                system_instruction="test",
+                max_tokens=100,
+            )
+
+        parsed = json.loads(result)
+        assert parsed["actions"][0]["type"] == "system_message"
+        assert "Rate limit exceeded" in parsed["actions"][0]["payload"]["text"]
+
+    @pytest.mark.asyncio
+    async def test_handles_empty_choices(self) -> None:
+        plugin = self._make_plugin()
+
+        with (
+            patch(
+                "cortex.llm_provider.openrouter.OPENROUTER_API_KEY",
+                MagicMock(__str__=lambda s: "test-key", __bool__=lambda s: True),
+            ),
+            patch(
+                "cortex.llm_provider.openrouter.OPENROUTER_BASE_URL",
+                MagicMock(__str__=lambda s: "https://openrouter.ai/api/v1"),
+            ),
+            patch(
+                "cortex.llm_provider.openrouter.OPENROUTER_SITE_URL",
+                MagicMock(__str__=lambda s: ""),
+            ),
+            patch(
+                "cortex.llm_provider.openrouter.OPENROUTER_APP_NAME",
+                MagicMock(__str__=lambda s: "Test"),
+            ),
+            patch("cortex.llm_provider.openrouter.requests.post") as mock_post,
+        ):
+            mock_post.return_value = _make_http_response(json_body={"choices": []})
+
+            result = await plugin._openai_chat_completion(
+                prompt_text="test",
+                system_instruction="test",
+                max_tokens=100,
+            )
+
+        parsed = json.loads(result)
+        assert "missing choices" in parsed["actions"][0]["payload"]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Health & interface limits tests
+# ---------------------------------------------------------------------------
+
+
+class TestHealthAndLimits:
+    def _make_plugin(self) -> Any:
+        from cortex.llm_provider.openrouter import OpenRouterPlugin
+
+        plugin = OpenRouterPlugin.__new__(OpenRouterPlugin)
+        plugin._current_model = "anthropic/claude-sonnet-4"
+        return plugin
+
+    def test_health_no_key(self) -> None:
+        plugin = self._make_plugin()
+        with patch(
+            "cortex.llm_provider.openrouter.OPENROUTER_API_KEY",
+            MagicMock(__bool__=lambda s: False, __str__=lambda s: ""),
+        ):
+            ok, msg = plugin.get_health_status()
+        assert ok is False
+        assert "not configured" in msg
+
+    def test_health_with_key(self) -> None:
+        plugin = self._make_plugin()
+        with patch(
+            "cortex.llm_provider.openrouter.OPENROUTER_API_KEY",
+            MagicMock(__bool__=lambda s: True, __str__=lambda s: "sk-test"),
+        ):
+            ok, msg = plugin.get_health_status()
+        assert ok is True
+
+    def test_interface_limits_from_catalog(self) -> None:
+        from cortex.llm_provider.openrouter import OpenRouterModel, _catalog
+
+        plugin = self._make_plugin()
+        _catalog.models["anthropic/claude-sonnet-4"] = OpenRouterModel(
+            id="anthropic/claude-sonnet-4",
+            name="Claude Sonnet 4",
+            context_length=200000,
+            max_completion_tokens=8192,
+            supports_vision=True,
+        )
+        limits = plugin.get_interface_limits()
+        assert limits["max_prompt_chars"] == 200000 * 3
+        assert limits["max_response_chars"] == 8192
+        assert limits["supports_images"] is True
+
+        # Cleanup
+        _catalog.models.pop("anthropic/claude-sonnet-4", None)
+
+    def test_rate_limit(self) -> None:
+        plugin = self._make_plugin()
+        rl = plugin.get_rate_limit()
+        assert rl == (60, 60, 0.5)
+
+
+# ---------------------------------------------------------------------------
+# Parse routes helper
+# ---------------------------------------------------------------------------
+
+
+class TestParseRoutes:
+    def test_dict_passthrough(self) -> None:
+        from cortex.llm_provider.openrouter import _parse_routes
+
+        routes = {"scopes": {"grillo": "test/model"}}
+        assert _parse_routes(routes) == routes
+
+    def test_json_string(self) -> None:
+        from cortex.llm_provider.openrouter import _parse_routes
+
+        result = _parse_routes('{"scopes": {"grillo": "test/model"}}')
+        assert result == {"scopes": {"grillo": "test/model"}}
+
+    def test_invalid_string(self) -> None:
+        from cortex.llm_provider.openrouter import _parse_routes
+
+        assert _parse_routes("not json") == {}
+
+    def test_none(self) -> None:
+        from cortex.llm_provider.openrouter import _parse_routes
+
+        assert _parse_routes(None) == {}
+
+
+# ---------------------------------------------------------------------------
+# Capabilities query
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilities:
+    def _make_plugin(self) -> Any:
+        from cortex.llm_provider.openrouter import OpenRouterPlugin
+
+        plugin = OpenRouterPlugin.__new__(OpenRouterPlugin)
+        plugin._current_model = "test/model"
+        return plugin
+
+    def test_capabilities_from_catalog(self) -> None:
+        from cortex.llm_provider.openrouter import OpenRouterModel, _catalog
+
+        _catalog.models["test/model"] = OpenRouterModel(
+            id="test/model",
+            name="Test Model",
+            context_length=8192,
+            max_completion_tokens=2048,
+            modality="text+image->text",
+            supports_vision=True,
+            supports_tool_use=True,
+        )
+
+        plugin = self._make_plugin()
+        caps = plugin.get_model_capabilities("test/model")
+        assert caps["available"] is True
+        assert caps["supports_vision"] is True
+        assert caps["supports_tool_use"] is True
+
+        _catalog.models.pop("test/model", None)
+
+    def test_capabilities_missing_model(self) -> None:
+        plugin = self._make_plugin()
+        caps = plugin.get_model_capabilities("nonexistent/model")
+        assert caps["available"] is False
+
+    def test_catalog_summary(self) -> None:
+        from cortex.llm_provider.openrouter import OpenRouterModel, _catalog
+
+        _catalog.models = {
+            "a": OpenRouterModel(id="a", name="A", supports_vision=True),
+            "b": OpenRouterModel(id="b", name="B", supports_audio=True),
+        }
+        _catalog.last_fetched = 100.0
+
+        plugin = self._make_plugin()
+        summary = plugin.get_catalog_summary()
+        assert summary["total_models"] == 2
+        assert summary["vision_models"] == 1
+        assert summary["audio_models"] == 1
+
+        _catalog.models = {}
+        _catalog.last_fetched = 0.0


### PR DESCRIPTION
# feat: OpenRouter engine, Auris/Vox pipeline, scope routing & Grillo optimizations

**Base:** `develop` <- **Head:** `feat/openrouter`

---

## Summary

Major feature branch adding multi-engine LLM support, voice I/O pipeline, and cortex scope routing.

### OpenRouter LLM Engine
- Full OpenRouter engine with OpenAI-compatible API, auto-fetched model catalog, multi-model routing, prompt caching, and searchable model picker in WebUI
- Multimodal support: images (vision) and audio (`input_audio` format) with automatic Gemini transcription fallback when provider rejects native audio
- Dedicated human-readable API request/response logger (`logs/cortex_api.log`) wired into both OpenRouter and Gemini engines, with auto-redaction of API keys

### Cortex Scope Routing
- `TRAINER_CORTEX` / `GRILLO_CORTEX` / `LIVE_CORTEX` overrides now actually work end-to-end: trainer messages route to OpenRouter/Grok while Grillo and other scopes stay on Gemini
- Fixed `interface_id` resolution in message queue consumer (was always `"unknown"`, making `is_trainer` permanently false)
- Scope selectors added to WebUI with cortex commands (`/cortex_trainer`, `/cortex_grillo`, `/cortex_live`)

### Voice I/O Pipeline (Auris + Vox)
- Auris STT plugin with Vosk and Gemini engines, auto-download for missing models
- Vox TTS plugin with Kitten, Chatterbox, Harmony, HTTP, and Qwen3 engines
- Voice message fallback rewritten: when Auris is unavailable, voice notes are enqueued as multimodal attachments through the normal message pipeline (with full persona context and scope routing) instead of falling back to Gemini Live with a generic prompt
- Input source detection (voice vs text) in prompt engine

### Grillo Optimizations
- Skip recon LLM call for internal Grillo beats
- Fix system instruction: explicitly tell LLM not to output `message_*` actions on internal beats
- Net savings: Grillo beats now cost **1 API call instead of 3**

### WebUI Skin Editor
- New "Skin Editor" in the Skins tab: create skins with name, author, version, and physical appearance description
- Upload/download skins as `.zip` archives for easy sharing
- Per-skin VRM model and preview image upload buttons on each card
- Delete skins from the UI (Rei is protected as it provides fallback animations)
- 6 new backend API endpoints: `POST /api/skins` (create), `POST /api/skins/{name}/vrm`, `POST /api/skins/{name}/preview`, `GET /api/skins/{name}/download`, `POST /api/skins/upload`, `DELETE /api/skins/{name}`

### Other Improvements
- Discord: `/join` voice command, live chat history sync, enhanced trainer registry
- WebUI: experimental multi-session support, enhanced WebSocket error handling
- Message chain: filter previously successful actions on retry, handle Markdown parse errors gracefully
- Grillo deduplication for messages and auto-fix numeric string IDs

## Test plan
- [x] `uv run ruff format .` -- passes
- [x] `uv run ruff check --fix .` -- no new errors (all pre-existing)
- [x] `uv run ty check` on modified files -- passes
- [x] `uv run pytest tests/test_openrouter_engine.py` -- 31/31 pass
- [ ] Manual: Skins tab -- create a new skin, upload VRM + preview, download as zip, upload zip, delete skin (verify Rei is protected)
