### PR TITLE
feat(openapi): WebUI inline config, model auto-select, history fix

### DIFF
--- a/core/history_engine.py
+++ b/core/history_engine.py
@@ -129,6 +129,17 @@ register_exposed_var(
     advanced=True,
 )
 
+register_exposed_var(
+    "PROMPT_LITE_MODE",
+    label="Prompt Lite Mode",
+    default=0,
+    value_type=int,
+    ui_type="bool",
+    description="Aggressively minimize prompt size for small/local models. Reduces history, strips actions, removes redundant context.",
+    scope="core",
+    component="history_engine",
+)
+
 
 def _get_int(key: str, default: int) -> int:
     try:
@@ -146,13 +157,24 @@ def _get_bool(key: str, default: bool) -> bool:
 
 
 def _format_ts(ts: Any) -> str:
+    """Format a timestamp for display in chat history.
+
+    Converts to the server's local timezone so history entries align with the
+    ``time`` context field that the time plugin injects (which also uses local time).
+    """
     try:
+        from core.time_zone_utils import utc_to_local
+
         if isinstance(ts, str):
             ts = ts.replace("Z", "+00:00")
             dt = datetime.fromisoformat(ts)
+            if dt.tzinfo is not None:
+                dt = utc_to_local(dt)
             return dt.strftime("%d/%m/%y:%H%M")
         if hasattr(ts, "isoformat"):
-            # datetime
+            # datetime object
+            if getattr(ts, "tzinfo", None) is not None:
+                ts = utc_to_local(ts)
             return ts.strftime("%d/%m/%y:%H%M")
     except Exception:
         pass
@@ -255,8 +277,15 @@ class HistoryEngine:
         memories: Optional[Sequence[HistoryEntry]] = None,
         history_scope: str | None = None,
     ) -> Dict[str, Any]:
+        lite_mode = _get_bool("PROMPT_LITE_MODE", False)
+
         verbosity = max(0, _get_int("CONTEXT_VERBOSITY", 10))
         thoughts_limit = max(0, _get_int("THOUGHTS_LIMIT", 5))
+
+        # In lite mode, aggressively cap limits for small/local models
+        if lite_mode:
+            verbosity = min(verbosity, 3)
+            thoughts_limit = min(thoughts_limit, 2)
 
         enable_current = _get_bool("ENABLE_HISTORY_CURRENT_CHAT", True)
         enable_recent = _get_bool("ENABLE_HISTORY_RECENT", True)
@@ -695,7 +724,8 @@ class HistoryEngine:
         # Core-provided memories (already searched by prompt engine)
         out_memories: List[Any] = []
         if enable_memories and memories:
-            out_memories = list(memories)[:verbosity] if verbosity > 0 else []
+            mem_limit = min(verbosity, 2) if lite_mode else verbosity
+            out_memories = list(memories)[:mem_limit] if mem_limit > 0 else []
 
         # Final per-target limits
         if verbosity > 0:
@@ -704,21 +734,17 @@ class HistoryEngine:
         if thoughts_limit > 0:
             thoughts = thoughts[-thoughts_limit:]
 
-        # Expose explicit local/global separation in addition to legacy keys
-        local_history = history_current_chat
-        global_history = history_recent
-
-        # Do NOT strip out the alternate history by default; always return both
-        # `local_history` and `global_history` so the assistant sees surrounding
-        # context while still being able to distinguish them.
-
         context: Dict[str, Any] = {
             "history_current_chat": history_current_chat,
             "history_recent": history_recent,
-            "local_history": local_history,
-            "global_history": global_history,
             "thoughts": thoughts,
         }
+
+        # NOTE: local_history / global_history used to be unconditional aliases
+        # of history_current_chat / history_recent.  They are *always* identical
+        # to the canonical keys, so including them just doubles token usage.
+        # The ``history_scope`` field below already tells the LLM which stream
+        # is primary — no alias keys are needed.
 
         # Echo the requested history_scope (if any) so downstream systems can
         # treat one stream as 'primary' while still seeing the other.
@@ -731,7 +757,7 @@ class HistoryEngine:
         if enable_memories:
             context["memories"] = out_memories
 
-        if enable_tags_placeholder:
+        if enable_tags_placeholder and not lite_mode:
             context["tags_placeholder"] = []
 
         return context

--- a/core/message_chain.py
+++ b/core/message_chain.py
@@ -672,7 +672,12 @@ async def handle_incoming_message(
                                 # addition to the proper actions list, which creates a
                                 # duplicate that fails validation (no interface_path) and
                                 # triggers an unnecessary correction loop.
-                                if key in ("message", "text", "reply", "response") and isinstance(value, str):
+                                if key in (
+                                    "message",
+                                    "text",
+                                    "reply",
+                                    "response",
+                                ) and isinstance(value, str):
                                     already_present = any(
                                         isinstance(a, dict)
                                         and (a.get("type") or "").startswith("message_")
@@ -685,8 +690,28 @@ async def handle_incoming_message(
                                             f"[message_chain] Skipping synthetic '{key}' action — text already present in explicit message action"
                                         )
                                         continue
+                                # Resolve the correct action type and inject
+                                # interface_path for message-like synthetic actions
+                                # so they pass validation without a correction loop.
+                                synthetic_type = key
+                                ctx_ipath = ctx.get("interface_path") if ctx else None
+                                if key in (
+                                    "message",
+                                    "text",
+                                    "reply",
+                                    "response",
+                                ) and isinstance(value, str):
+                                    if ctx_ipath:
+                                        iface_prefix = str(ctx_ipath).split("/")[0]
+                                        resolved = _INTERFACE_TO_MESSAGE_ACTION.get(
+                                            iface_prefix
+                                        )
+                                        if resolved:
+                                            synthetic_type = resolved
+                                        if "interface_path" not in payload:
+                                            payload["interface_path"] = str(ctx_ipath)
                                 synthetic_actions.append(
-                                    {"type": key, "payload": payload}
+                                    {"type": synthetic_type, "payload": payload}
                                 )
 
                             actions.extend(synthetic_actions)
@@ -1035,6 +1060,7 @@ async def handle_incoming_message(
                         # engine is non-empty and not "disabled", we consider TTS on.
                         # For backwards compatibility we also honour the old boolean
                         # flags/endpoints, but they no longer drive the feature state.
+                        tts_raw = ""
                         try:
                             from core.config_manager import config_registry
 
@@ -1051,6 +1077,16 @@ async def handle_incoming_message(
 
                             # legacy fallback
                             if not vox_enabled:
+                                tts_raw = str(
+                                    config_registry.get_value(
+                                        "TTS_ENDPOINTS",
+                                        "",
+                                        value_type=str,
+                                        group="plugins",
+                                        component="tts_lipsync",
+                                    )
+                                    or ""
+                                )
                                 vox_enabled = bool(
                                     config_registry.get_value(
                                         "TTS_ENABLED",
@@ -1059,13 +1095,7 @@ async def handle_incoming_message(
                                         group="plugins",
                                         component="tts_lipsync",
                                     )
-                                    or config_registry.get_value(
-                                        "TTS_ENDPOINTS",
-                                        "",
-                                        value_type=str,
-                                        group="plugins",
-                                        component="tts_lipsync",
-                                    )
+                                    or tts_raw
                                 )
 
                             if not vox_enabled and not _explicit_tts_request:
@@ -1077,26 +1107,6 @@ async def handle_incoming_message(
                                 log_debug(
                                     "[message_chain] Vox engine disabled but request_tts=True — "
                                     "allowing TTS attempt (VoxPlugin will fall back to text if needed)"
-                                )
-
-                        except Exception:
-                            pass
-                            tts_enabled = config_registry.get_value(
-                                "TTS_ENABLED",
-                                False,
-                                value_type=bool,
-                                group="plugins",
-                                component="tts_lipsync",
-                            )
-
-                            if not tts_raw:
-                                log_debug(
-                                    "[message_chain] (legacy) TTS_ENDPOINTS not configured"
-                                )
-                                # note: we don't force skip here, because VOX_ENABLED \n                                # may already permit TTS without endpoints
-                            if not bool(tts_enabled):
-                                log_debug(
-                                    "[message_chain] (legacy) TTS_ENABLED is False"
                                 )
 
                         except Exception as e:

--- a/core/message_queue.py
+++ b/core/message_queue.py
@@ -34,6 +34,12 @@ _lock = asyncio.Lock()
 _consumer_task: asyncio.Task | None = None
 _counter = 0  # Monotonic counter to prevent dict comparison when priorities are equal
 
+# Track running LOW_PRIORITY background tasks by interface_path so they can be
+# cancelled when a higher-priority (user) message arrives for the same chat.
+# This prevents duplicate responses when a grillo outreach beat and a user
+# message target the same interface_path concurrently.
+_bg_tasks: dict[str, asyncio.Task] = {}
+
 
 class MessageQueue:
     """Minimal thread-safe queue for interfaces expecting blocking semantics."""
@@ -1004,11 +1010,28 @@ async def _consumer_loop() -> None:
                             _resolve_generation_animation_state("start")
                         )
 
+                        # Cancel any running LOW_PRIORITY background task for the
+                        # same interface_path.  This prevents duplicate responses
+                        # when a grillo outreach beat races against a user message
+                        # for the same chat — the outreach prompt includes chat
+                        # history and the LLM would otherwise respond to the user's
+                        # message, producing a duplicate alongside the trainer
+                        # engine's proper reply.
+                        _existing_bg = _bg_tasks.pop(interface_path, None)
+                        if _existing_bg is not None and not _existing_bg.done():
+                            _existing_bg.cancel()
+                            log_info(
+                                f"[QUEUE] Cancelled LOW_PRIORITY background task for {interface_path} "
+                                f"(superseded by incoming user message)"
+                            )
+
                         # Selenium-based LLMs manage browser state and cannot be safely
                         # cancelled mid-flight. All other engines (HTTP-based Gemini, OpenAI, …)
                         # support asyncio cancellation and should be stopped on timeout so they
                         # don't deliver a "ghost" reply after the fallback has already been sent.
-                        task_is_cancellable = getattr(plugin_instance, "task_cancellable", True)
+                        task_is_cancellable = getattr(
+                            plugin_instance, "task_cancellable", True
+                        )
 
                         # Run message processing in a Task so we can apply a per-element timeout.
                         processing_task = asyncio.create_task(
@@ -1031,6 +1054,10 @@ async def _consumer_loop() -> None:
                                 f"[QUEUE] Low-priority task scheduled as background for interface_path={interface_path}; not awaiting"
                             )
 
+                            # Track this background task so it can be cancelled if a
+                            # user message arrives for the same interface_path.
+                            _bg_tasks[interface_path] = processing_task
+
                             # Ensure generation_end hook is called when background task completes
                             processing_task.add_done_callback(
                                 lambda t: asyncio.create_task(
@@ -1038,16 +1065,25 @@ async def _consumer_loop() -> None:
                                 )
                             )
 
-                            # Log any exceptions when done
-                            def _bg_done_cb(t: asyncio.Task) -> None:
+                            # Clean up tracking and log exceptions when done
+                            _captured_ipath = interface_path  # capture for closure
+
+                            def _bg_done_cb(
+                                t: asyncio.Task,
+                                _ipath: str = _captured_ipath,
+                            ) -> None:
+                                # Remove from tracking dict
+                                _bg_tasks.pop(_ipath, None)
                                 try:
                                     exc = t.exception()
                                     if exc is not None:
                                         log_warning(
-                                            f"[QUEUE] Background task for {interface_path} raised: {exc}"
+                                            f"[QUEUE] Background task for {_ipath} raised: {exc}"
                                         )
                                 except asyncio.CancelledError:
-                                    pass
+                                    log_info(
+                                        f"[QUEUE] Background task for {_ipath} was cancelled (user message arrived)"
+                                    )
                                 except Exception:
                                     pass
 
@@ -1100,7 +1136,11 @@ async def _consumer_loop() -> None:
                                     await asyncio.wait_for(
                                         asyncio.shield(processing_task), timeout=2
                                     )
-                                except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                                except (
+                                    asyncio.TimeoutError,
+                                    asyncio.CancelledError,
+                                    Exception,
+                                ):
                                     pass
                                 try:
                                     await _call_bot_generation_end(processing_task)
@@ -1130,7 +1170,9 @@ async def _consumer_loop() -> None:
                                             pass
 
                                         try:
-                                            await _call_bot_generation_end(processing_task)
+                                            await _call_bot_generation_end(
+                                                processing_task
+                                            )
                                         except Exception:
                                             pass
 
@@ -1139,7 +1181,9 @@ async def _consumer_loop() -> None:
                                             item_chat = (
                                                 queued_item.get("chat_id")
                                                 if isinstance(queued_item, dict)
-                                                else getattr(queued_item, "chat_id", None)
+                                                else getattr(
+                                                    queued_item, "chat_id", None
+                                                )
                                             )
                                             if item_chat == chat_id:
                                                 still_pending = True
@@ -1161,7 +1205,9 @@ async def _consumer_loop() -> None:
                                                     f"[QUEUE] Failed to clear processing session meta (background): {set_e}"
                                                 )
                                             await _broadcast_global_animation_state(
-                                                _resolve_generation_animation_state("end")
+                                                _resolve_generation_animation_state(
+                                                    "end"
+                                                )
                                             )
                                     except Exception as e:
                                         log_debug(

--- a/core/notifier.py
+++ b/core/notifier.py
@@ -369,7 +369,7 @@ def notify_trainer(message: str) -> None:
         async def send(target: int | str):
             try:
                 # Build message data with thread_id for LogChat if applicable
-                message_data = {"text": message, "target": target}
+                message_data = {"text": message, "target": target, "skip_history": True}
                 log_chat_id = get_log_chat_id_sync()
                 if target == log_chat_id:
                     thread_id = get_log_chat_thread_id_sync()

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -52,46 +52,88 @@ DIARY_HISTORY_DAYS = config_registry.get_var(
 )
 
 
-def minify_actions_block(available_actions: dict) -> dict:
+def minify_actions_block(
+    available_actions: dict,
+    lite: bool = False,
+) -> dict:
     """Convert full action schemas to minimal versions for prompt.
 
     For LLM prompts, sends ONLY schema and brief description to minimize token usage.
     This dramatically reduces prompt size while preserving all critical information needed.
 
-    Uses new normalized action format:
-    - schema: JSON schema with structure, types, and required fields
-    - brief: One-line description of action purpose
-    - source: Which plugin/interface provides this action
+    When ``lite=True`` (Prompt Lite Mode for small/local models), applies aggressive
+    minification on top of the standard pass:
 
-    Full examples and detailed instructions are NOT included here - they're used by
-    the corrector when the LLM makes mistakes.
+    - Filters to essential actions only (message_*, diary, tts, animation)
+    - Strips schemas down to brief-only (no schema object)
 
     Parameters
     ----------
     available_actions : dict
-        Full actions block with schemas in new normalized format
+        Full actions block with schemas in new normalized format.
+    lite : bool
+        When True, apply aggressive filtering and strip to brief-only.
 
     Returns
     -------
     dict
-        Minified actions block suitable for LLM prompts (schema + brief only)
+        Minified actions block suitable for LLM prompts.
     """
     from core.action_schema_converter import (
         extract_for_llm_prompt,
         normalize_action_schema,
     )
 
+    _LITE_ESSENTIAL_ACTIONS = (
+        "create_personal_diary_entry",
+        "tts_speak",
+        "use_animation",
+    )
+
     minified = {}
     for action_name, action_def in available_actions.items():
+        # In lite mode, skip non-essential actions
+        if lite and not (
+            action_name.startswith("message_") or action_name in _LITE_ESSENTIAL_ACTIONS
+        ):
+            continue
+
         # Normalize to new format (handles both old and new formats)
         normalized = normalize_action_schema(action_name, action_def)
 
-        # Extract only what's needed for LLM (schema + brief)
-        minified_action = extract_for_llm_prompt(action_name, normalized)
-
-        minified[action_name] = minified_action
+        if lite:
+            # Lite: brief-only, no schema
+            minified[action_name] = {"brief": normalized.get("brief", "")}
+        else:
+            # Standard: schema + brief
+            minified[action_name] = extract_for_llm_prompt(action_name, normalized)
 
     return minified
+
+
+def _apply_lite_context_stripping(prompt: dict) -> dict:
+    """Strip redundant prompt sections for lite mode.
+
+    Called by the minification pipeline when PROMPT_LITE_MODE is enabled.
+    Removes verbose instructions, redundant context, and compacts emotions.
+    Action minification is handled by ``minify_actions_block(lite=True)``.
+    """
+    # Remove redundant top-level keys
+    prompt.pop("instructions_verbose", None)
+    prompt.pop("__pre_reduction_size", None)
+
+    # Compact context
+    ctx = prompt.get("context", {})
+    ctx.pop("recon", None)
+    ctx.pop("recon_instructions", None)
+    ctx.pop("tags_placeholder", None)
+    ctx.pop("participants", None)
+
+    # Compact emotions — keep current_emotions_nl, drop verbose instruction + list
+    ctx.pop("emotion_state", None)
+    ctx.pop("available_emotions", None)
+
+    return prompt
 
 
 async def build_json_prompt(
@@ -290,10 +332,11 @@ async def build_json_prompt(
     # (moved) prompt logging will occur later once input_payload exists
 
     # === 3. Recon contributions (prompt 0) ===
+    # Note: raw contributions are NOT included — their memories are already
+    # merged into the top-level `memories` list.  Only metadata is kept.
     try:
         if recon_contributions:
             context_section["recon"] = {
-                "contributions": recon_contributions,
                 "snippets": recon_snippets,
                 "language": resolved_language,
                 "message_tone": resolved_message_tone,
@@ -567,8 +610,18 @@ async def build_json_prompt(
     except Exception:
         prompt_with_instructions["__pre_reduction_size"] = None
 
+    # Resolve lite mode flag early so both actions and context use the same value
+    is_lite = False
+    try:
+        from core.config_manager import config_registry as _cfg
+
+        is_lite = bool(_cfg.get_value("PROMPT_LITE_MODE", 0, value_type=int))
+    except Exception:
+        pass
+
     # Include unified actions metadata from the initializer
     # Use minified version to keep prompt size manageable
+    # When lite mode is on, minify_actions_block handles the aggressive filtering too
     try:
         from core.core_initializer import core_initializer
 
@@ -589,14 +642,30 @@ async def build_json_prompt(
                 "(audio sent as multimodal content)"
             )
 
-        # Minify to reduce token usage
-        prompt_with_instructions["actions"] = minify_actions_block(full_actions)
+        # Minify to reduce token usage (lite=True also filters + strips to brief-only)
+        prompt_with_instructions["actions"] = minify_actions_block(
+            full_actions, lite=is_lite
+        )
         log_debug(
-            f"[json_prompt] Actions block minified: {len(json_dumps(full_actions))} -> {len(json_dumps(prompt_with_instructions['actions']))} chars"
+            f"[json_prompt] Actions block minified: {len(json_dumps(full_actions))} -> {len(json_dumps(prompt_with_instructions['actions']))} chars (lite={is_lite})"
         )
     except Exception as e:
         log_warning(f"[prompt_engine] Failed to inject actions block: {e}")
         prompt_with_instructions["actions"] = {}
+
+    # === Apply lite mode context stripping if enabled ===
+    if is_lite:
+        try:
+            pre_lite = len(json_dumps(prompt_with_instructions))
+            prompt_with_instructions = _apply_lite_context_stripping(
+                prompt_with_instructions
+            )
+            post_lite = len(json_dumps(prompt_with_instructions))
+            log_info(
+                f"[json_prompt] Lite mode applied: {pre_lite} -> {post_lite} chars"
+            )
+        except Exception as e:
+            log_warning(f"[json_prompt] Failed to apply lite mode: {e}")
 
     # === Final check: Reduce prompt if it exceeds LLM character limits ===
     try:

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -573,6 +573,22 @@ async def build_json_prompt(
         from core.core_initializer import core_initializer
 
         full_actions = core_initializer.actions_block.get("available_actions", {})
+
+        # When audio attachments are present as multimodal content, remove
+        # stt_transcribe from the available actions so the LLM processes the
+        # audio directly instead of requesting a redundant transcription step.
+        has_audio_attachment = attachments and any(
+            (a.get("mime_type") or "").startswith("audio/") for a in attachments
+        )
+        if has_audio_attachment and "stt_transcribe" in full_actions:
+            full_actions = {
+                k: v for k, v in full_actions.items() if k != "stt_transcribe"
+            }
+            log_debug(
+                "[json_prompt] Removed stt_transcribe from actions "
+                "(audio sent as multimodal content)"
+            )
+
         # Minify to reduce token usage
         prompt_with_instructions["actions"] = minify_actions_block(full_actions)
         log_debug(

--- a/core/webui.py
+++ b/core/webui.py
@@ -2990,6 +2990,7 @@ class SynthWebUIInterface:
         text: Optional[str] = None,
         **kwargs,
     ) -> None:
+        skip_history = kwargs.pop("skip_history", False)
         if isinstance(payload_or_chat_id, dict):
             payload = payload_or_chat_id
             # Accept both "text" (standard) and "value" (legacy synthetic-action mapping)
@@ -2999,6 +3000,7 @@ class SynthWebUIInterface:
                 or payload.get("target")
                 or payload.get("chat_id")
             )
+            skip_history = payload.get("skip_history", skip_history)
         else:
             chat_id = payload_or_chat_id or kwargs.get("chat_id")
             if text is None:
@@ -3111,13 +3113,16 @@ class SynthWebUIInterface:
         await self._append_history(session_id, "synth", text)
 
         # Save SyntH's response via core chat_context_manager
-        try:
-            from core.chat_context_manager import save_response_message
+        if not skip_history:
+            try:
+                from core.chat_context_manager import save_response_message
 
-            msg_interface_path = f"{INTERFACE_NAME}/{chat_id}"
-            await save_response_message(msg_interface_path, text)
-        except Exception as e:
-            log_debug(f"{LOG_PREFIX} Failed to save response via context_manager: {e}")
+                msg_interface_path = f"{INTERFACE_NAME}/{chat_id}"
+                await save_response_message(msg_interface_path, text)
+            except Exception as e:
+                log_debug(
+                    f"{LOG_PREFIX} Failed to save response via context_manager: {e}"
+                )
 
         if websocket:
             log_info(
@@ -3863,10 +3868,11 @@ class SynthWebUIInterface:
             if entry.get("hidden"):
                 continue
 
-            # Hide Cortex-engine-specific variables unless their engine is loaded
+            # Hide Cortex-engine-specific variables unless their engine is registered
             if (
                 "cortex_engine" in entry.get("tags", [])
                 and entry.get("component") not in loaded_cortex_engines
+                and entry.get("component") not in available_cortex_engines
             ):
                 continue
             component_label = self._get_display_name(entry["component"], None)

--- a/cortex/llm_provider/gemini_api.py
+++ b/cortex/llm_provider/gemini_api.py
@@ -1355,6 +1355,10 @@ class GeminiAPIPlugin(AIPluginBase):
         # Collect all attachments from all locations
         attachments: list[dict] = []
 
+        # Keys whose subtrees are schema definitions (not multimodal data)
+        # and should be skipped during recursive attachment collection.
+        SCHEMA_ONLY_KEYS = {"actions", "available_actions", "schema", "payload"}
+
         def collect_attachments_recursive(container: dict | list | str) -> None:
             """Recursively collect multimodal attachments from any level."""
             if isinstance(container, dict):
@@ -1381,8 +1385,12 @@ class GeminiAPIPlugin(AIPluginBase):
                             # Single item rather than list
                             attachments.append(items)
 
-                # Recurse into all dict values
-                for value in container.values():
+                # Recurse into dict values, skipping action schema subtrees
+                # which contain field definitions that look like attachments
+                # but are not (e.g. {"type": "string", "description": "..."}).
+                for key, value in container.items():
+                    if key in SCHEMA_ONLY_KEYS:
+                        continue
                     collect_attachments_recursive(value)
 
             elif isinstance(container, list):

--- a/cortex/llm_provider/openapi.py
+++ b/cortex/llm_provider/openapi.py
@@ -48,10 +48,10 @@ try:
     register_exposed_var(
         "OPENAPI_BASE_URL",
         label="OpenAPI Base URL",
-        default="http://localhost:11434/v1",
+        default="http://localhost:8081/v1",
         value_type=str,
         ui_type="string",
-        description="Base URL for the OpenAI-compatible endpoint (e.g., http://localhost:11434/v1 for Ollama).",
+        description="Base URL for the OpenAI-compatible endpoint (e.g., http://localhost:8081/v1 for Ollama).",
         scope="llm",
         component="openapi",
         tags=["cortex_engine"],
@@ -229,7 +229,7 @@ except Exception:
 # ---------------------------------------------------------------------------
 OPENAPI_BASE_URL = config_registry.get_var(
     "OPENAPI_BASE_URL",
-    "http://localhost:11434/v1",
+    "http://localhost:8081/v1",
     label="OpenAPI Base URL",
     description="Base URL for the OpenAI-compatible endpoint.",
     group="llm",
@@ -621,6 +621,7 @@ class OpenAPIPlugin(AIPluginBase):
                 base = str(OPENAPI_BASE_URL).strip()
                 api_key = str(OPENAPI_API_KEY).strip()
                 loop.run_until_complete(_refresh_catalog(base, api_key))
+                self._auto_select_model()
         except Exception as exc:
             log_warning(f"[openapi] Catalog fetch on init failed: {exc}")
 
@@ -639,6 +640,9 @@ class OpenAPIPlugin(AIPluginBase):
             if manual_models:
                 _catalog.update(manual_models)
 
+        # Auto-select model if current model isn't in the catalog
+        self._auto_select_model()
+
         # Schedule periodic refresh
         if bool(OPENAPI_AUTO_DISCOVER):
             interval = int(OPENAPI_CATALOG_REFRESH) if OPENAPI_CATALOG_REFRESH else 60
@@ -648,6 +652,31 @@ class OpenAPIPlugin(AIPluginBase):
                 _catalog._refresh_task = asyncio.create_task(
                     _catalog_refresh_loop(base_url, api_key, interval)
                 )
+
+    def _auto_select_model(self) -> None:
+        """Auto-select model from catalog if current model is missing."""
+        ids = _catalog.list_ids()
+        if not ids:
+            return
+        # Current model already in catalog — nothing to do
+        if self._current_model in ids:
+            return
+        # Single model served (typical for llama.cpp) — auto-select it
+        if len(ids) == 1:
+            old = self._current_model
+            self.set_current_model(ids[0])
+            log_info(
+                f"[openapi] Auto-selected model '{ids[0]}' "
+                f"(previous '{old}' not found in catalog)"
+            )
+            return
+        # Multiple models but current not found — pick first and warn
+        old = self._current_model
+        self.set_current_model(ids[0])
+        log_warning(
+            f"[openapi] Model '{old}' not in catalog. "
+            f"Auto-selected '{ids[0]}'. Available: {ids}"
+        )
 
     # ------------------------------------------------------------------
     # AIPluginBase interface
@@ -659,7 +688,7 @@ class OpenAPIPlugin(AIPluginBase):
         if not base_url:
             return (
                 False,
-                "OPENAPI_BASE_URL not configured. Please set it to your endpoint URL (e.g., http://localhost:11434/v1 for Ollama).",
+                "OPENAPI_BASE_URL not configured. Please set it to your endpoint URL (e.g., http://localhost:8081/v1 for Ollama).",
             )
 
         # Quick connectivity check

--- a/interface/telegram_bot.py
+++ b/interface/telegram_bot.py
@@ -855,7 +855,6 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return
 
     # utility used in several places below; import once to avoid scoping issues
-    from core.mention_utils import is_message_for_bot
 
     # LIVE MEDIA HANDLING (Voice, Video, Video Note)
     # Earlier we disabled this and treated media as generic attachments,

--- a/plugins/ai_diary.py
+++ b/plugins/ai_diary.py
@@ -1156,7 +1156,7 @@ class DiaryPlugin:
                     "properties": {
                         "interaction_summary": {
                             "type": "string",
-                            "description": "Summary of what happened in this interaction",
+                            "description": "Summary of what happened in this interaction. Do NOT include weather, temperature, or location data — that context is provided separately.",
                         },
                         "content": {
                             "type": "string",
@@ -1164,7 +1164,7 @@ class DiaryPlugin:
                         },
                         "personal_thought": {
                             "type": "string",
-                            "description": "Personal reflection on the interaction (optional)",
+                            "description": "Personal reflection on the interaction (optional). Focus on emotions and relationship dynamics, not environmental conditions.",
                         },
                         "emotions": {
                             "type": "array",
@@ -1193,7 +1193,7 @@ class DiaryPlugin:
                     },
                     "required": ["interaction_summary"],
                 },
-                "brief": "Add a new diary entry to synth's memory - REQUIRED in every response",
+                "brief": "Add a new diary entry to synth's memory - REQUIRED in every response. Never include weather/location data in summaries.",
                 "examples": {
                     "description": "Create a diary entry recording what happened in this interaction. This action MUST be included in EVERY response to maintain synth's persistent memory.",
                     "when_to_use": "Use this action in every single response to record the interaction in synth's personal memory",

--- a/plugins/grillo/grillo_outreach.py
+++ b/plugins/grillo/grillo_outreach.py
@@ -279,7 +279,7 @@ class GrilloOutreachPlugin:
 
         prompt = f"""[G.R.I.L.L.O. OUTREACH]
 
-You feel like reaching out. Based on your recent experiences and thoughts, 
+You feel like reaching out. Based on your recent experiences and thoughts,
 initiate a natural conversation with someone you care about.
 
 Recent context:

--- a/res/synth_webui/js/main.js
+++ b/res/synth_webui/js/main.js
@@ -2149,7 +2149,25 @@ function pickAccentDarkFromHex(hex) { return darkenHex(hex, 0.28); }
                     const componentsAurisListEl = document.getElementById('components-auris-list');
                     const componentsLiveListEl = document.getElementById('components-live-list');
                     if (!componentsCortexListEl || !componentsInterfacesListEl || !componentsPluginsListEl) return;
-                    const res = await fetch('/api/components');
+                    const [res, cfgRes] = await Promise.all([
+                        fetch('/api/components'),
+                        fetch('/api/config').catch(() => null),
+                    ]);
+                    // Build a map of component name → config items for inline editing
+                    let _componentConfigMap = {};
+                    try {
+                        if (cfgRes && cfgRes.ok) {
+                            const cfgPayload = await cfgRes.json();
+                            const cfgItems = Array.isArray(cfgPayload.items) ? cfgPayload.items : [];
+                            cfgItems.forEach((ci) => {
+                                if (ci && ci.component) {
+                                    if (!_componentConfigMap[ci.component]) _componentConfigMap[ci.component] = [];
+                                    _componentConfigMap[ci.component].push(ci);
+                                }
+                            });
+                        }
+                    } catch (e) { console.debug('[synth_webui] Failed to load config for components', e); }
+
                     // Handle non-2xx responses gracefully and display server-provided
                     // error details in the UI without throwing. This avoids breaking
                     // the Components tab when the server returns 500 and does not
@@ -2631,6 +2649,239 @@ function pickAccentDarkFromHex(hex) { return darkenHex(hex, 0.28); }
                                 actionsWrap.appendChild(list);
                                 details.appendChild(actionsWrap);
                             }
+                            // ── Inline config editing for cortex engines ──────────
+                            const compName = item.name || '';
+                            const cfgItems = _componentConfigMap[compName] || [];
+                            if (cfgItems.length) {
+                                const cfgSection = document.createElement('div');
+                                cfgSection.className = 'component-config-section';
+                                cfgSection.style.cssText = 'margin-top:12px; padding-top:10px; border-top:1px solid var(--border, #444);';
+
+                                const cfgHeader = document.createElement('div');
+                                cfgHeader.style.cssText = 'display:flex; align-items:center; gap:8px; margin-bottom:8px; cursor:pointer; user-select:none;';
+                                const cfgToggleIcon = document.createElement('span');
+                                cfgToggleIcon.textContent = '▶';
+                                cfgToggleIcon.style.cssText = 'font-size:0.7rem; transition:transform 0.2s;';
+                                const cfgTitle = document.createElement('span');
+                                cfgTitle.style.cssText = 'font-size:0.85rem; font-weight:600; color:var(--muted); text-transform:uppercase; letter-spacing:0.05em;';
+                                cfgTitle.textContent = 'Configuration';
+                                cfgHeader.appendChild(cfgToggleIcon);
+                                cfgHeader.appendChild(cfgTitle);
+
+                                const cfgBody = document.createElement('div');
+                                cfgBody.style.display = 'none';
+
+                                cfgHeader.addEventListener('click', () => {
+                                    const open = cfgBody.style.display !== 'none';
+                                    cfgBody.style.display = open ? 'none' : '';
+                                    cfgToggleIcon.style.transform = open ? '' : 'rotate(90deg)';
+                                });
+
+                                // Separate normal vs advanced items
+                                const normalCfg = cfgItems.filter(ci => !ci.advanced);
+                                const advancedCfg = cfgItems.filter(ci => ci.advanced);
+
+                                const buildCfgRow = (ci) => {
+                                    const row = document.createElement('div');
+                                    row.style.cssText = 'display:flex; flex-direction:column; gap:3px; margin-bottom:10px;';
+
+                                    const lbl = document.createElement('label');
+                                    lbl.style.cssText = 'font-size:0.88rem; font-weight:600; color:var(--text);';
+                                    lbl.textContent = ci.label || ci.key;
+                                    row.appendChild(lbl);
+
+                                    if (ci.description) {
+                                        const helpText = document.createElement('div');
+                                        helpText.style.cssText = 'font-size:0.78rem; color:var(--muted); margin-bottom:2px;';
+                                        helpText.textContent = ci.description;
+                                        row.appendChild(helpText);
+                                    }
+
+                                    const val = ci.value === null || ci.value === undefined ? '' : ci.value;
+                                    const editable = !!ci.editable && !ci.env_override;
+
+                                    const saveCfg = async (newVal, el) => {
+                                        try {
+                                            if (el) el.disabled = true;
+                                            const r = await fetch('/api/config', {
+                                                method: 'POST',
+                                                headers: { 'Content-Type': 'application/json' },
+                                                body: JSON.stringify({ key: ci.key, value: newVal })
+                                            });
+                                            if (!r.ok) {
+                                                const t = await r.text();
+                                                window.showToast && window.showToast('Save failed: ' + t, true);
+                                            } else {
+                                                const out = await r.json();
+                                                window.showToast && window.showToast('Saved', false);
+                                                if (out && out.requires_reload) {
+                                                    window.showToast && window.showToast(out.message || 'Reload recommended', false);
+                                                }
+                                            }
+                                        } catch (e) {
+                                            window.showToast && window.showToast('Save failed', true);
+                                        } finally {
+                                            if (el) el.disabled = !editable;
+                                        }
+                                    };
+
+                                    let inputEl = null;
+
+                                    if (ci.ui_type === 'bool' || ci.value_type === 'bool') {
+                                        const wrap = document.createElement('div');
+                                        wrap.style.cssText = 'display:flex; align-items:center; gap:8px;';
+                                        const cb = document.createElement('input');
+                                        cb.type = 'checkbox';
+                                        cb.checked = val === true || val === 1 || val === '1' || val === 'true';
+                                        cb.disabled = !editable;
+                                        cb.id = `comp-cfg-${ci.key}`;
+                                        const toggleLbl = document.createElement('label');
+                                        toggleLbl.className = 'toggle-switch';
+                                        toggleLbl.setAttribute('for', cb.id);
+                                        const slider = document.createElement('span');
+                                        slider.className = 'toggle-slider';
+                                        toggleLbl.appendChild(slider);
+                                        cb.addEventListener('change', () => saveCfg(cb.checked, cb));
+                                        wrap.appendChild(cb);
+                                        wrap.appendChild(toggleLbl);
+                                        inputEl = wrap;
+                                    } else if (ci.ui_type === 'select' && Array.isArray(ci.options) && ci.options.length) {
+                                        const sel = document.createElement('select');
+                                        sel.style.cssText = 'padding:6px 10px; background:var(--background); color:var(--text); border:1px solid var(--primary); border-radius:6px; font-size:0.88rem; max-width:400px;';
+                                        ci.options.forEach(opt => {
+                                            const o = document.createElement('option');
+                                            o.value = opt; o.textContent = opt;
+                                            if (String(val) === String(opt)) o.selected = true;
+                                            sel.appendChild(o);
+                                        });
+                                        sel.disabled = !editable;
+                                        sel.addEventListener('change', () => saveCfg(sel.value, sel));
+                                        inputEl = sel;
+                                    } else if (ci.ui_type === 'textarea' || (ci.value_type === 'json' && ci.ui_type !== 'tags')) {
+                                        const ta = document.createElement('textarea');
+                                        ta.rows = 3;
+                                        ta.style.cssText = 'width:100%; max-width:500px; padding:6px 10px; background:var(--background); color:var(--text); border:1px solid var(--border,#444); border-radius:6px; font-family:monospace; font-size:0.85rem; resize:vertical;';
+                                        ta.value = typeof val === 'string' ? val : JSON.stringify(val, null, 2);
+                                        ta.disabled = !editable;
+                                        ta.addEventListener('keydown', (ev) => {
+                                            if (ev.key === 'Enter' && (ev.ctrlKey || ev.metaKey)) { ev.preventDefault(); saveCfg(ta.value, ta); }
+                                        });
+                                        ta.addEventListener('blur', () => saveCfg(ta.value, ta));
+                                        inputEl = ta;
+                                    } else if (ci.ui_type === 'combobox') {
+                                        // Searchable dropdown with free-text fallback
+                                        const models = (item && Array.isArray(item.supported_models)) ? item.supported_models : [];
+                                        const wrap = document.createElement('div');
+                                        wrap.style.cssText = 'position:relative; max-width:400px; width:100%;';
+                                        const inp = document.createElement('input');
+                                        inp.type = 'text';
+                                        inp.autocomplete = 'off';
+                                        inp.style.cssText = 'padding:6px 10px; background:var(--background); color:var(--text); border:1px solid var(--primary); border-radius:6px; font-size:0.88rem; width:100%; box-sizing:border-box;';
+                                        inp.value = typeof val === 'string' ? val : JSON.stringify(val);
+                                        inp.disabled = !editable;
+                                        inp.placeholder = models.length ? `Search ${models.length} models…` : '';
+                                        wrap.appendChild(inp);
+
+                                        if (models.length) {
+                                            const dd = document.createElement('div');
+                                            dd.style.cssText = 'display:none; position:absolute; top:100%; left:0; right:0; max-height:220px; overflow-y:auto; border:1px solid var(--border,#444); border-radius:6px; background:var(--bg-card,#1a1a2e); z-index:999; margin-top:2px;';
+                                            const MAX_SHOW = 60;
+                                            const renderDd = (filter) => {
+                                                dd.innerHTML = '';
+                                                const q = (filter || '').toLowerCase();
+                                                let count = 0;
+                                                for (const m of models) {
+                                                    if (q && !m.toLowerCase().includes(q)) continue;
+                                                    if (++count > MAX_SHOW) {
+                                                        const more = document.createElement('div');
+                                                        more.style.cssText = 'padding:0.3rem 0.6rem; color:var(--muted); font-size:0.78rem;';
+                                                        more.textContent = `${models.length - MAX_SHOW}+ more — refine search`;
+                                                        dd.appendChild(more);
+                                                        break;
+                                                    }
+                                                    const row = document.createElement('div');
+                                                    row.textContent = m;
+                                                    row.style.cssText = 'padding:0.35rem 0.6rem; cursor:pointer; font-size:0.85rem; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;';
+                                                    if (m === val) row.style.fontWeight = '700';
+                                                    row.addEventListener('mouseenter', () => { row.style.background = 'var(--accent-dim, rgba(107,254,254,0.12))'; });
+                                                    row.addEventListener('mouseleave', () => { row.style.background = ''; });
+                                                    row.addEventListener('mousedown', (ev) => {
+                                                        ev.preventDefault();
+                                                        inp.value = m;
+                                                        dd.style.display = 'none';
+                                                        saveCfg(m, inp);
+                                                    });
+                                                    dd.appendChild(row);
+                                                }
+                                                if (count === 0) {
+                                                    const empty = document.createElement('div');
+                                                    empty.style.cssText = 'padding:0.4rem 0.6rem; color:var(--muted); font-size:0.82rem;';
+                                                    empty.textContent = 'No matching models';
+                                                    dd.appendChild(empty);
+                                                }
+                                            };
+                                            inp.addEventListener('focus', () => { renderDd(inp.value); dd.style.display = ''; });
+                                            inp.addEventListener('input', () => { renderDd(inp.value); });
+                                            inp.addEventListener('blur', () => { setTimeout(() => { dd.style.display = 'none'; }, 180); });
+                                            wrap.appendChild(dd);
+                                        }
+                                        inp.addEventListener('keydown', (ev) => {
+                                            if (ev.key === 'Enter') { ev.preventDefault(); saveCfg(inp.value, inp); }
+                                        });
+                                        inputEl = wrap;
+                                    } else {
+                                        // Default: text / password / number input
+                                        const inp = document.createElement('input');
+                                        inp.type = ci.ui_type === 'password' ? 'password'
+                                            : (ci.value_type === 'int' || ci.value_type === 'float' || ci.ui_type === 'number') ? 'number' : 'text';
+                                        inp.style.cssText = 'padding:6px 10px; background:var(--background); color:var(--text); border:1px solid var(--border,#444); border-radius:6px; font-size:0.88rem; max-width:400px; width:100%;';
+                                        inp.value = typeof val === 'string' ? val : JSON.stringify(val);
+                                        inp.disabled = !editable;
+                                        inp.addEventListener('keydown', (ev) => {
+                                            if (ev.key === 'Enter') { ev.preventDefault(); saveCfg(inp.value, inp); }
+                                        });
+                                        inp.addEventListener('blur', () => saveCfg(inp.value, inp));
+                                        inputEl = inp;
+                                    }
+
+                                    if (inputEl) row.appendChild(inputEl);
+                                    return row;
+                                };
+
+                                normalCfg.forEach(ci => cfgBody.appendChild(buildCfgRow(ci)));
+
+                                if (advancedCfg.length) {
+                                    const advHeader = document.createElement('div');
+                                    advHeader.style.cssText = 'display:flex; align-items:center; gap:6px; margin-top:8px; margin-bottom:6px; cursor:pointer; user-select:none;';
+                                    const advIcon = document.createElement('span');
+                                    advIcon.textContent = '▶';
+                                    advIcon.style.cssText = 'font-size:0.65rem; transition:transform 0.2s;';
+                                    const advLabel = document.createElement('span');
+                                    advLabel.style.cssText = 'font-size:0.8rem; font-weight:600; color:var(--muted);';
+                                    advLabel.textContent = 'Advanced';
+                                    advHeader.appendChild(advIcon);
+                                    advHeader.appendChild(advLabel);
+
+                                    const advBody = document.createElement('div');
+                                    advBody.style.display = 'none';
+                                    advancedCfg.forEach(ci => advBody.appendChild(buildCfgRow(ci)));
+
+                                    advHeader.addEventListener('click', (ev) => {
+                                        ev.stopPropagation();
+                                        const open = advBody.style.display !== 'none';
+                                        advBody.style.display = open ? 'none' : '';
+                                        advIcon.style.transform = open ? '' : 'rotate(90deg)';
+                                    });
+
+                                    cfgBody.appendChild(advHeader);
+                                    cfgBody.appendChild(advBody);
+                                }
+
+                                cfgSection.appendChild(cfgHeader);
+                                cfgSection.appendChild(cfgBody);
+                                details.appendChild(cfgSection);
+                            }
+
                             container.appendChild(details);
                         });
                     };

--- a/tests/test_current_chat_history.py
+++ b/tests/test_current_chat_history.py
@@ -172,12 +172,13 @@ def test_local_global_separation(monkeypatch):
     )
 
     ctx = res["context"]
-    assert "local_history" in ctx and "global_history" in ctx
-    assert any("Local message" in e for e in ctx["local_history"])
-    # global_history must NOT contain the local message
-    assert all("Local message" not in e for e in ctx["global_history"])
-    # global_history should include the other chat's message
-    assert any("Other chat message" in e for e in ctx["global_history"])
+    # local/global aliases are only present when history_scope='local';
+    # check canonical keys instead.
+    assert any("Local message" in e for e in ctx["history_current_chat"])
+    # history_recent must NOT contain the local message
+    assert all("Local message" not in e for e in ctx["history_recent"])
+    # history_recent should include the other chat's message
+    assert any("Other chat message" in e for e in ctx["history_recent"])
 
 
 def test_history_scope_local_only(monkeypatch):
@@ -220,11 +221,17 @@ def test_history_scope_local_only(monkeypatch):
     )
 
     ctx = res["context"]
-    # local_history must contain the local entry
-    assert any("Local only" in e for e in ctx.get("local_history", []))
-    # global_history must still include external chat entries (and MUST NOT include local entries)
-    assert any("External" in e for e in ctx.get("global_history", []))
-    assert all("Local only" not in e for e in ctx.get("global_history", []))
+    # local_history / global_history aliases are no longer emitted (they were
+    # always identical to the canonical keys, wasting tokens).  Instead verify
+    # the canonical keys carry the expected data.
+    assert "local_history" not in ctx
+    assert "global_history" not in ctx
+    assert any("Local only" in e for e in ctx.get("history_current_chat", []))
+    assert any("External" in e for e in ctx.get("history_recent", []))
+    assert all("Local only" not in e for e in ctx.get("history_recent", []))
+
+    # history_scope is echoed so the LLM knows which stream is primary
+    assert ctx.get("history_scope") == "local"
 
     # The input payload should expose the requested scope so the LLM can prioritise
     assert res.get("input", {}).get("payload", {}).get("history_scope") == "local"

--- a/tests/test_prompt_recon_injection.py
+++ b/tests/test_prompt_recon_injection.py
@@ -74,16 +74,24 @@ async def test_build_json_prompt_includes_recon_contributions(monkeypatch):
         message=msg, context_memory={}, interface_name="test"
     )
 
-    # Recon contributions should be present in context
+    # Recon metadata should be present in context (raw contributions are
+    # no longer included — their memories are merged into top-level memories)
     ctx = prompt.get("context", {})
     assert "recon" in ctx, "recon key missing from context"
     recon = ctx.get("recon")
     assert recon is not None
-    contribs = recon.get("contributions", [])
-    assert any(c.get("type") == "memory" for c in contribs)
+    assert "contributions" not in recon, (
+        "raw contributions should no longer be in recon"
+    )
     assert recon.get("language") == "it"
     assert recon.get("message_tone") == "empathetic"
     assert recon.get("conversation_tone") == "warm"
+
+    # Recon memories should be merged into top-level memories
+    memories = ctx.get("memories", [])
+    assert any(
+        isinstance(m, dict) and m.get("snippet") == "important memory" for m in memories
+    ), "recon memory should appear in top-level memories"
 
     # Instructions should include language and tone prefixes
     instr = prompt.get("instructions", "")

--- a/tests/test_telegram_voice.py
+++ b/tests/test_telegram_voice.py
@@ -568,7 +568,9 @@ async def test_handle_message_media_not_directed(monkeypatch):
         chat=SimpleNamespace(type="group", id=1),
     )
     update = SimpleNamespace(message=msg)
-    bot = SimpleNamespace(get_file=AsyncMock(return_value=DummyFile()), send_chat_action=AsyncMock())
+    bot = SimpleNamespace(
+        get_file=AsyncMock(return_value=DummyFile()), send_chat_action=AsyncMock()
+    )
     ctx = SimpleNamespace(bot=bot)
 
     monkeypatch.setattr(

--- a/uv.lock
+++ b/uv.lock
@@ -482,14 +482,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
 ]
 
 [[package]]
@@ -562,31 +562,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cuda-bindings"
-version = "12.9.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cuda-pathfinder" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/d8/b546104b8da3f562c1ff8ab36d130c8fe1dd6a045ced80b4f6ad74f7d4e1/cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d3c842c2a4303b2a580fe955018e31aea30278be19795ae05226235268032e5", size = 12148218, upload-time = "2025-10-21T14:51:28.855Z" },
-    { url = "https://files.pythonhosted.org/packages/45/e7/b47792cc2d01c7e1d37c32402182524774dadd2d26339bd224e0e913832e/cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c912a3d9e6b6651853eed8eed96d6800d69c08e94052c292fec3f282c5a817c9", size = 12210593, upload-time = "2025-10-21T14:51:36.574Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
-    { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628, upload-time = "2025-10-21T14:51:49.905Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/84/1e6be415e37478070aeeee5884c2022713c1ecc735e6d82d744de0252eee/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56e0043c457a99ac473ddc926fe0dc4046694d99caef633e92601ab52cbe17eb", size = 11925991, upload-time = "2025-10-21T14:51:56.535Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/af/6dfd8f2ed90b1d4719bc053ff8940e494640fe4212dc3dd72f383e4992da/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b72ee72a9cc1b531db31eebaaee5c69a8ec3500e32c6933f2d3b15297b53686", size = 11922703, upload-time = "2025-10-21T14:52:03.585Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/19/90ac264acc00f6df8a49378eedec9fd2db3061bf9263bf9f39fd3d8377c3/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d80bffc357df9988dca279734bc9674c3934a654cab10cadeed27ce17d8635ee", size = 11924658, upload-time = "2025-10-21T14:52:10.411Z" },
-]
-
-[[package]]
-name = "cuda-pathfinder"
-version = "1.3.5"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/b5/e4056e4058fb56519fcddf1face6fe3ff2398953b41615fafe9fb1540bf2/cuda_pathfinder-1.3.5-py3-none-any.whl", hash = "sha256:6c88220f8637cb35d2a75c620d72efebf683b248b923713d8fbe235844c1a4b9", size = 33711, upload-time = "2026-02-23T18:34:27.253Z" },
-]
-
-[[package]]
 name = "discord-ext-voice-recv"
 version = "0.5.2a179"
 source = { registry = "https://pypi.org/simple" }
@@ -650,6 +625,21 @@ resolution-markers = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "edge-tts"
+version = "7.2.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "tabulate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/d2/1ce38f6e4fe7275207f4033b0971db489a0b594340ae6bac2320127e71ee/edge_tts-7.2.7.tar.gz", hash = "sha256:0127fba57a742bc48ff0a2a3b24b8324f7859260185274c335b4e54735aff325", size = 27508, upload-time = "2025-12-12T20:54:28.403Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/89/92ac6b154ab87d236c15e5e0c73cb99be58efb1ea3eb9318c266bf9a36bf/edge_tts-7.2.7-py3-none-any.whl", hash = "sha256:ac11d9e834347e5ee62cbe72e8a56ffd65d3c4e795be14b1e593b72cf6480dd9", size = 30556, upload-time = "2025-12-12T20:54:26.956Z" },
 ]
 
 [[package]]
@@ -868,6 +858,19 @@ wheels = [
 ]
 
 [[package]]
+name = "gtts"
+version = "2.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/79/5ddb1dfcd663581d0d3fca34ccb1d8d841b47c22a24dc8dce416e3d87dfa/gtts-2.5.4.tar.gz", hash = "sha256:f5737b585f6442f677dbe8773424fd50697c75bdf3e36443585e30a8d48c1884", size = 24018, upload-time = "2024-11-10T21:58:00.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/6c/8b8b1fdcaee7e268536f1bb00183a5894627726b54a9ddc6fc9909888447/gTTS-2.5.4-py3-none-any.whl", hash = "sha256:5dd579377f9f5546893bc26315ab1f846933dc27a054764b168f141065ca8436", size = 29184, upload-time = "2024-11-10T21:57:58.448Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -887,6 +890,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/cb/9bb543bd987ffa1ee48202cc96a756951b734b79a542335c566148ade36c/hf_xet-1.3.2.tar.gz", hash = "sha256:e130ee08984783d12717444e538587fa2119385e5bd8fc2bb9f930419b73a7af", size = 643646, upload-time = "2026-02-27T17:26:08.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/75/462285971954269432aad2e7938c5c7ff9ec7d60129cec542ab37121e3d6/hf_xet-1.3.2-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:335a8f36c55fd35a92d0062f4e9201b4015057e62747b7e7001ffb203c0ee1d2", size = 3761019, upload-time = "2026-02-27T17:25:49.441Z" },
+    { url = "https://files.pythonhosted.org/packages/35/56/987b0537ddaf88e17192ea09afa8eca853e55f39a4721578be436f8409df/hf_xet-1.3.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:c1ae4d3a716afc774e66922f3cac8206bfa707db13f6a7e62dfff74bfc95c9a8", size = 3521565, upload-time = "2026-02-27T17:25:47.469Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5c/7e4a33a3d689f77761156cc34558047569e54af92e4d15a8f493229f6767/hf_xet-1.3.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d6dbdf231efac0b9b39adcf12a07f0c030498f9212a18e8c50224d0e84ab803d", size = 4176494, upload-time = "2026-02-27T17:25:40.247Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b3/71e856bf9d9a69b3931837e8bf22e095775f268c8edcd4a9e8c355f92484/hf_xet-1.3.2-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c1980abfb68ecf6c1c7983379ed7b1e2b49a1aaf1a5aca9acc7d48e5e2e0a961", size = 3955601, upload-time = "2026-02-27T17:25:38.376Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d7/aecf97b3f0a981600a67ff4db15e2d433389d698a284bb0ea5d8fcdd6f7f/hf_xet-1.3.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:1c88fbd90ad0d27c46b77a445f0a436ebaa94e14965c581123b68b1c52f5fd30", size = 4154770, upload-time = "2026-02-27T17:25:56.756Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e1/3af961f71a40e09bf5ee909842127b6b00f5ab4ee3817599dc0771b79893/hf_xet-1.3.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:35b855024ca37f2dd113ac1c08993e997fbe167b9d61f9ef66d3d4f84015e508", size = 4394161, upload-time = "2026-02-27T17:25:58.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c3/859509bade9178e21b8b1db867b8e10e9f817ab9ac1de77cb9f461ced765/hf_xet-1.3.2-cp313-cp313t-win_amd64.whl", hash = "sha256:31612ba0629046e425ba50375685a2586e11fb9144270ebabd75878c3eaf6378", size = 3637377, upload-time = "2026-02-27T17:26:10.611Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7f/724cfbef4da92d577b71f68bf832961c8919f36c60d28d289a9fc9d024d4/hf_xet-1.3.2-cp313-cp313t-win_arm64.whl", hash = "sha256:433c77c9f4e132b562f37d66c9b22c05b5479f243a1f06a120c1c06ce8b1502a", size = 3497875, upload-time = "2026-02-27T17:26:09.034Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/75/9d54c1ae1d05fb704f977eca1671747babf1957f19f38ae75c5933bc2dc1/hf_xet-1.3.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:c34e2c7aefad15792d57067c1c89b2b02c1bbaeabd7f8456ae3d07b4bbaf4094", size = 3761076, upload-time = "2026-02-27T17:25:55.42Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/8a/08a24b6c6f52b5d26848c16e4b6d790bb810d1bf62c3505bed179f7032d3/hf_xet-1.3.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4bc995d6c41992831f762096020dc14a65fdf3963f86ffed580b596d04de32e3", size = 3521745, upload-time = "2026-02-27T17:25:54.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/db/a75cf400dd8a1a8acf226a12955ff6ee999f272dfc0505bafd8079a61267/hf_xet-1.3.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:959083c89dee30f7d6f890b36cdadda823386c4de63b1a30384a75bfd2ae995d", size = 4176301, upload-time = "2026-02-27T17:25:46.044Z" },
+    { url = "https://files.pythonhosted.org/packages/01/40/6c4c798ffdd83e740dd3925c4e47793b07442a9efa3bc3866ba141a82365/hf_xet-1.3.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:cfa760888633b08c01b398d212ce7e8c0d7adac6c86e4b20dfb2397d8acd78ee", size = 3955437, upload-time = "2026-02-27T17:25:44.703Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/09/9a3aa7c5f07d3e5cc57bb750d12a124ffa72c273a87164bd848f9ac5cc14/hf_xet-1.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3155a02e083aa21fd733a7485c7c36025e49d5975c8d6bda0453d224dd0b0ac4", size = 4154535, upload-time = "2026-02-27T17:26:05.207Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e0/831f7fa6d90cb47a230bc23284b502c700e1483bbe459437b3844cdc0776/hf_xet-1.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:91b1dc03c31cbf733d35dc03df7c5353686233d86af045e716f1e0ea4a2673cf", size = 4393891, upload-time = "2026-02-27T17:26:06.607Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/96/6ed472fdce7f8b70f5da6e3f05be76816a610063003bfd6d9cea0bbb58a3/hf_xet-1.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:211f30098512d95e85ad03ae63bd7dd2c4df476558a5095d09f9e38e78cbf674", size = 3637583, upload-time = "2026-02-27T17:26:17.349Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/e8/a069edc4570b3f8e123c0b80fadc94530f3d7b01394e1fc1bb223339366c/hf_xet-1.3.2-cp314-cp314t-win_arm64.whl", hash = "sha256:4a6817c41de7c48ed9270da0b02849347e089c5ece9a0e72ae4f4b3a57617f82", size = 3497977, upload-time = "2026-02-27T17:26:14.966Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/28/dbb024e2e3907f6f3052847ca7d1a2f7a3972fafcd53ff79018977fcb3e4/hf_xet-1.3.2-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f93b7595f1d8fefddfede775c18b5c9256757824f7f6832930b49858483cd56f", size = 3763961, upload-time = "2026-02-27T17:25:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/71/b99aed3823c9d1795e4865cf437d651097356a3f38c7d5877e4ac544b8e4/hf_xet-1.3.2-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:a85d3d43743174393afe27835bde0cd146e652b5fcfdbcd624602daef2ef3259", size = 3526171, upload-time = "2026-02-27T17:25:50.968Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ca/907890ce6ef5598b5920514f255ed0a65f558f820515b18db75a51b2f878/hf_xet-1.3.2-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7c2a054a97c44e136b1f7f5a78f12b3efffdf2eed3abc6746fc5ea4b39511633", size = 4180750, upload-time = "2026-02-27T17:25:43.125Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ad/bc7f41f87173d51d0bce497b171c4ee0cbde1eed2d7b4216db5d0ada9f50/hf_xet-1.3.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:06b724a361f670ae557836e57801b82c75b534812e351a87a2c739f77d1e0635", size = 3961035, upload-time = "2026-02-27T17:25:41.837Z" },
+    { url = "https://files.pythonhosted.org/packages/73/38/600f4dda40c4a33133404d9fe644f1d35ff2d9babb4d0435c646c63dd107/hf_xet-1.3.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:305f5489d7241a47e0458ef49334be02411d1d0f480846363c1c8084ed9916f7", size = 4161378, upload-time = "2026-02-27T17:26:00.365Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b3/7bc1ff91d1ac18420b7ad1e169b618b27c00001b96310a89f8a9294fe509/hf_xet-1.3.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:06cdbde243c85f39a63b28e9034321399c507bcd5e7befdd17ed2ccc06dfe14e", size = 4398020, upload-time = "2026-02-27T17:26:03.977Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/99bfd948a3ed3620ab709276df3ad3710dcea61976918cce8706502927af/hf_xet-1.3.2-cp37-abi3-win_amd64.whl", hash = "sha256:9298b47cce6037b7045ae41482e703c471ce36b52e73e49f71226d2e8e5685a1", size = 3641624, upload-time = "2026-02-27T17:26:13.542Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/02/9a6e4ca1f3f73a164c0cd48e41b3cc56585dcc37e809250de443d673266f/hf_xet-1.3.2-cp37-abi3-win_arm64.whl", hash = "sha256:83d8ec273136171431833a6957e8f3af496bee227a0fe47c7b8b39c106d1749a", size = 3503976, upload-time = "2026-02-27T17:26:12.123Z" },
 ]
 
 [[package]]
@@ -924,6 +959,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/7a/304cec37112382c4fe29a43bcb0d5891f922785d18745883d2aa4eb74e4b/huggingface_hub-1.6.0.tar.gz", hash = "sha256:d931ddad8ba8dfc1e816bf254810eb6f38e5c32f60d4184b5885662a3b167325", size = 717071, upload-time = "2026-03-06T14:19:18.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/e3/e3a44f54c8e2f28983fcf07f13d4260b37bd6a0d3a081041bc60b91d230e/huggingface_hub-1.6.0-py3-none-any.whl", hash = "sha256:ef40e2d5cb85e48b2c067020fa5142168342d5108a1b267478ed384ecbf18961", size = 612874, upload-time = "2026-03-06T14:19:16.844Z" },
 ]
 
 [[package]]
@@ -1306,6 +1361,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1412,12 +1479,12 @@ wheels = [
 ]
 
 [[package]]
-name = "mpmath"
-version = "1.3.0"
+name = "mdurl"
+version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -1565,167 +1632,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
-name = "networkx"
-version = "3.4.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263, upload-time = "2024-10-21T12:39:36.247Z" },
-]
-
-[[package]]
-name = "networkx"
-version = "3.6.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
-]
-
-[[package]]
-name = "nvidia-cublas-cu12"
-version = "12.8.4.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.8.93"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-runtime-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
-]
-
-[[package]]
-name = "nvidia-cudnn-cu12"
-version = "9.10.2.21"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cublas-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
-]
-
-[[package]]
-name = "nvidia-cufft-cu12"
-version = "11.3.3.83"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
-]
-
-[[package]]
-name = "nvidia-cufile-cu12"
-version = "1.13.1.3"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
-]
-
-[[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.9.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
-]
-
-[[package]]
-name = "nvidia-cusolver-cu12"
-version = "11.7.3.90"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
-]
-
-[[package]]
-name = "nvidia-cusparse-cu12"
-version = "12.5.8.93"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
-]
-
-[[package]]
-name = "nvidia-cusparselt-cu12"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
-]
-
-[[package]]
-name = "nvidia-nccl-cu12"
-version = "2.27.5"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
-]
-
-[[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.8.93"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
-]
-
-[[package]]
-name = "nvidia-nvshmem-cu12"
-version = "3.4.5"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
-]
-
-[[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
 ]
 
 [[package]]
@@ -2122,6 +2028,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pydub"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/9a/e6bca0eed82db26562c73b5076539a4a08d3cffd19c3cc5913a3e61145fd/pydub-0.25.1.tar.gz", hash = "sha256:980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f", size = 38326, upload-time = "2021-03-10T02:09:54.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl", hash = "sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6", size = 32327, upload-time = "2021-03-10T02:09:53.503Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2322,6 +2237,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
 ]
 
 [[package]]
@@ -2534,17 +2462,12 @@ wheels = [
 ]
 
 [[package]]
-name = "silero-vad"
-version = "6.2.1"
+name = "shellingham"
+version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "torch" },
-    { name = "torchaudio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/32/d3/e31f526482782764aa4f70e20fd4545cf2e4a81a60b6fb0f089f6d107991/silero_vad-6.2.1.tar.gz", hash = "sha256:b23062b0e39fad17b1266fc23c1e7b4290219dbe82ce08510889e32f681f4b3b", size = 28913811, upload-time = "2026-02-24T08:41:59.329Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/2b/48566f29a8b53d856ceb1994f209122749b3fda0a733a07e82047257de7a/silero_vad-6.2.1-py3-none-any.whl", hash = "sha256:09de93c4d874bb19c53e62a47dd38be5f163cedad2b5599583231f2a84ef79cb", size = 9146242, upload-time = "2026-02-24T08:41:56.955Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -2783,18 +2706,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sympy"
-version = "1.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mpmath" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
-]
-
-[[package]]
 name = "synthetic-heart"
 version = "0.1.0"
 source = { virtual = "." }
@@ -2807,8 +2718,11 @@ dependencies = [
     { name = "cryptography" },
     { name = "discord-ext-voice-recv" },
     { name = "discord-py" },
+    { name = "edge-tts" },
     { name = "fastapi" },
     { name = "google-genai" },
+    { name = "gtts" },
+    { name = "huggingface-hub" },
     { name = "jinja2" },
     { name = "lxml" },
     { name = "matrix-nio" },
@@ -2816,6 +2730,7 @@ dependencies = [
     { name = "praw" },
     { name = "pycryptodome" },
     { name = "pydantic" },
+    { name = "pydub" },
     { name = "pymysql" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -2831,20 +2746,13 @@ dependencies = [
     { name = "tzdata" },
     { name = "undetected-chromedriver" },
     { name = "uvicorn" },
+    { name = "vosk" },
     { name = "watchfiles" },
     { name = "webdriver-manager" },
     { name = "websockets" },
 ]
 
 [package.optional-dependencies]
-audio = [
-    { name = "silero-vad" },
-    { name = "torch" },
-]
-silero = [
-    { name = "silero-vad" },
-    { name = "torch" },
-]
 vosk = [
     { name = "vosk" },
 ]
@@ -2872,8 +2780,11 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.4" },
     { name = "discord-ext-voice-recv", specifier = ">=0.5.2a179" },
     { name = "discord-py", specifier = ">=2.6.4" },
+    { name = "edge-tts", specifier = ">=7.2.7" },
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "google-genai", specifier = ">=1.61.0" },
+    { name = "gtts", specifier = ">=2.5.4" },
+    { name = "huggingface-hub", specifier = ">=1.5.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "matrix-nio", specifier = "<0.25" },
@@ -2881,6 +2792,7 @@ requires-dist = [
     { name = "praw", specifier = ">=7.8.1" },
     { name = "pycryptodome", specifier = ">=3.23.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "pydub", specifier = ">=0.25.1" },
     { name = "pymysql", specifier = ">=1.1.2" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "python-multipart", specifier = ">=0.0.22" },
@@ -2890,22 +2802,19 @@ requires-dist = [
     { name = "selenium", specifier = ">=4.40.0" },
     { name = "selenium-stealth", specifier = ">=1.0.6" },
     { name = "setuptools", specifier = ">=70.0.0" },
-    { name = "silero-vad", marker = "extra == 'audio'", specifier = ">=5.1" },
-    { name = "silero-vad", marker = "extra == 'silero'", specifier = ">=5.1" },
     { name = "telethon", specifier = ">=1.42.0" },
     { name = "tenacity", specifier = ">=9.1.2" },
-    { name = "torch", marker = "extra == 'audio'", specifier = ">=2.0" },
-    { name = "torch", marker = "extra == 'silero'", specifier = ">=2.0" },
     { name = "tqdm", specifier = ">=4.67.2" },
     { name = "tzdata", specifier = ">=2025.3" },
     { name = "undetected-chromedriver", specifier = ">=3.5.5" },
     { name = "uvicorn", specifier = ">=0.40.0" },
+    { name = "vosk", specifier = ">=0.3.45" },
     { name = "vosk", marker = "extra == 'vosk'", specifier = ">=0.3.45" },
     { name = "watchfiles", specifier = ">=1.1.1" },
     { name = "webdriver-manager", specifier = ">=4.0.1" },
     { name = "websockets", specifier = ">=15.0.1" },
 ]
-provides-extras = ["silero", "audio", "vosk"]
+provides-extras = ["vosk"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2916,6 +2825,15 @@ dev = [
     { name = "sphinx-rtd-theme", specifier = ">=2.0.0" },
     { name = "ty", specifier = ">=0.0.14" },
     { name = "unittest-xml-reporting", specifier = ">=3.2.0" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]
@@ -2995,110 +2913,6 @@ wheels = [
 ]
 
 [[package]]
-name = "torch"
-version = "2.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'" },
-    { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/30/bfebdd8ec77db9a79775121789992d6b3b75ee5494971294d7b4b7c999bc/torch-2.10.0-2-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:2b980edd8d7c0a68c4e951ee1856334a43193f98730d97408fbd148c1a933313", size = 79411457, upload-time = "2026-02-10T21:44:59.189Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/1a/c61f36cfd446170ec27b3a4984f072fd06dab6b5d7ce27e11adb35d6c838/torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d", size = 145992962, upload-time = "2026-01-21T16:24:14.04Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/60/6662535354191e2d1555296045b63e4279e5a9dbad49acf55a5d38655a39/torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444", size = 915599237, upload-time = "2026-01-21T16:23:25.497Z" },
-    { url = "https://files.pythonhosted.org/packages/40/b8/66bbe96f0d79be2b5c697b2e0b187ed792a15c6c4b8904613454651db848/torch-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a4be6a2a190b32ff5c8002a0977a25ea60e64f7ba46b1be37093c141d9c49aeb", size = 113720931, upload-time = "2026-01-21T16:24:23.743Z" },
-    { url = "https://files.pythonhosted.org/packages/76/bb/d820f90e69cda6c8169b32a0c6a3ab7b17bf7990b8f2c680077c24a3c14c/torch-2.10.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:35e407430795c8d3edb07a1d711c41cc1f9eaddc8b2f1cc0a165a6767a8fb73d", size = 79411450, upload-time = "2026-01-21T16:25:30.692Z" },
-    { url = "https://files.pythonhosted.org/packages/78/89/f5554b13ebd71e05c0b002f95148033e730d3f7067f67423026cc9c69410/torch-2.10.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3282d9febd1e4e476630a099692b44fdc214ee9bf8ee5377732d9d9dfe5712e4", size = 145992610, upload-time = "2026-01-21T16:25:26.327Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/30/a3a2120621bf9c17779b169fc17e3dc29b230c29d0f8222f499f5e159aa8/torch-2.10.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a2f9edd8dbc99f62bc4dfb78af7bf89499bca3d753423ac1b4e06592e467b763", size = 915607863, upload-time = "2026-01-21T16:25:06.696Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/3d/c87b33c5f260a2a8ad68da7147e105f05868c281c63d65ed85aa4da98c66/torch-2.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:29b7009dba4b7a1c960260fc8ac85022c784250af43af9fb0ebafc9883782ebd", size = 113723116, upload-time = "2026-01-21T16:25:21.916Z" },
-    { url = "https://files.pythonhosted.org/packages/61/d8/15b9d9d3a6b0c01b883787bd056acbe5cc321090d4b216d3ea89a8fcfdf3/torch-2.10.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:b7bd80f3477b830dd166c707c5b0b82a898e7b16f59a7d9d42778dd058272e8b", size = 79423461, upload-time = "2026-01-21T16:24:50.266Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/af/758e242e9102e9988969b5e621d41f36b8f258bb4a099109b7a4b4b50ea4/torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf", size = 145996088, upload-time = "2026-01-21T16:24:44.171Z" },
-    { url = "https://files.pythonhosted.org/packages/23/8e/3c74db5e53bff7ed9e34c8123e6a8bfef718b2450c35eefab85bb4a7e270/torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb", size = 915711952, upload-time = "2026-01-21T16:23:53.503Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/5c/dee910b87c4d5c0fcb41b50839ae04df87c1cfc663cf1b5fca7ea565eeaa/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:6d3707a61863d1c4d6ebba7be4ca320f42b869ee657e9b2c21c736bf17000294", size = 79498198, upload-time = "2026-01-21T16:24:34.704Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/6f/f2e91e34e3fcba2e3fc8d8f74e7d6c22e74e480bbd1db7bc8900fdf3e95c/torch-2.10.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5c4d217b14741e40776dd7074d9006fd28b8a97ef5654db959d8635b2fe5f29b", size = 146004247, upload-time = "2026-01-21T16:24:29.335Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fb/5160261aeb5e1ee12ee95fe599d0541f7c976c3701d607d8fc29e623229f/torch-2.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6b71486353fce0f9714ca0c9ef1c850a2ae766b409808acd58e9678a3edb7738", size = 915716445, upload-time = "2026-01-21T16:22:45.353Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/16/502fb1b41e6d868e8deb5b0e3ae926bbb36dab8ceb0d1b769b266ad7b0c3/torch-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2ee399c644dc92ef7bc0d4f7e74b5360c37cdbe7c5ba11318dda49ffac2bc57", size = 113757050, upload-time = "2026-01-21T16:24:19.204Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/0b/39929b148f4824bc3ad6f9f72a29d4ad865bcf7ebfc2fa67584773e083d2/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:3202429f58309b9fa96a614885eace4b7995729f44beb54d3e4a47773649d382", size = 79851305, upload-time = "2026-01-21T16:24:09.209Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/14/21fbce63bc452381ba5f74a2c0a959fdf5ad5803ccc0c654e752e0dbe91a/torch-2.10.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:aae1b29cd68e50a9397f5ee897b9c24742e9e306f88a807a27d617f07adb3bd8", size = 146005472, upload-time = "2026-01-21T16:22:29.022Z" },
-    { url = "https://files.pythonhosted.org/packages/54/fd/b207d1c525cb570ef47f3e9f836b154685011fce11a2f444ba8a4084d042/torch-2.10.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6021db85958db2f07ec94e1bc77212721ba4920c12a18dc552d2ae36a3eb163f", size = 915612644, upload-time = "2026-01-21T16:21:47.019Z" },
-    { url = "https://files.pythonhosted.org/packages/36/53/0197f868c75f1050b199fe58f9bf3bf3aecac9b4e85cc9c964383d745403/torch-2.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff43db38af76fda183156153983c9a096fc4c78d0cd1e07b14a2314c7f01c2c8", size = 113997015, upload-time = "2026-01-21T16:23:00.767Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/13/e76b4d9c160e89fff48bf16b449ea324bda84745d2ab30294c37c2434c0d/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:cdf2a523d699b70d613243211ecaac14fe9c5df8a0b0a9c02add60fb2a413e0f", size = 79498248, upload-time = "2026-01-21T16:23:09.315Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/93/716b5ac0155f1be70ed81bacc21269c3ece8dba0c249b9994094110bfc51/torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:bf0d9ff448b0218e0433aeb198805192346c4fd659c852370d5cc245f602a06a", size = 79464992, upload-time = "2026-01-21T16:23:05.162Z" },
-    { url = "https://files.pythonhosted.org/packages/69/2b/51e663ff190c9d16d4a8271203b71bc73a16aa7619b9f271a69b9d4a936b/torch-2.10.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:233aed0659a2503b831d8a67e9da66a62c996204c0bba4f4c442ccc0c68a3f60", size = 146018567, upload-time = "2026-01-21T16:22:23.393Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/cd/4b95ef7f293b927c283db0b136c42be91c8ec6845c44de0238c8c23bdc80/torch-2.10.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:682497e16bdfa6efeec8cde66531bc8d1fbbbb4d8788ec6173c089ed3cc2bfe5", size = 915721646, upload-time = "2026-01-21T16:21:16.983Z" },
-    { url = "https://files.pythonhosted.org/packages/56/97/078a007208f8056d88ae43198833469e61a0a355abc0b070edd2c085eb9a/torch-2.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:6528f13d2a8593a1a412ea07a99812495bec07e9224c28b2a25c0a30c7da025c", size = 113752373, upload-time = "2026-01-21T16:22:13.471Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/94/71994e7d0d5238393df9732fdab607e37e2b56d26a746cb59fdb415f8966/torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f5ab4ba32383061be0fb74bda772d470140a12c1c3b58a0cfbf3dae94d164c28", size = 79850324, upload-time = "2026-01-21T16:22:09.494Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/65/1a05346b418ea8ccd10360eef4b3e0ce688fba544e76edec26913a8d0ee0/torch-2.10.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:716b01a176c2a5659c98f6b01bf868244abdd896526f1c692712ab36dbaf9b63", size = 146006482, upload-time = "2026-01-21T16:22:18.42Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/b9/5f6f9d9e859fc3235f60578fa64f52c9c6e9b4327f0fe0defb6de5c0de31/torch-2.10.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d8f5912ba938233f86361e891789595ff35ca4b4e2ac8fe3670895e5976731d6", size = 915613050, upload-time = "2026-01-21T16:20:49.035Z" },
-    { url = "https://files.pythonhosted.org/packages/66/4d/35352043ee0eaffdeff154fad67cd4a31dbed7ff8e3be1cc4549717d6d51/torch-2.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:71283a373f0ee2c89e0f0d5f446039bdabe8dbc3c9ccf35f0f784908b0acd185", size = 113995816, upload-time = "2026-01-21T16:22:05.312Z" },
-]
-
-[[package]]
-name = "torchaudio"
-version = "2.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "torch" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/59/88ab8ebff9d91f1f1365088b30f1b9ccce07c5eeac666038a5dee5e2f9b1/torchaudio-2.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cde383582a6240c1315443df5c5638863e96b03acf1cb44a298aff07a72d373", size = 734944, upload-time = "2026-01-21T16:28:49.535Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/d6/41f25f9ae9b37c191bed4cd474e403626685d2be8f7d20d011e6601fede1/torchaudio-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:cfb2ad4b7847d81931989127d803487263c8284f21156e9000daec1ac16c0831", size = 390449, upload-time = "2026-01-21T16:28:48.585Z" },
-    { url = "https://files.pythonhosted.org/packages/43/ac/a14425fddd1cf56bb052a3bfd38880258008f8c3cd17f37bba55b3a88ce7/torchaudio-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:316cdb15fb37290fca89894b095d97b4dc14a90c4c61148ae5c96bb334d962cd", size = 1891070, upload-time = "2026-01-21T16:28:47.323Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/03/d1898db1bf7ecd47ca9b4e1b70927597d236cf721e3736d953d555901832/torchaudio-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:013079d1ba2a652184703e671b8339cbc7991f17e4ed927071fe7635f908a4a1", size = 474045, upload-time = "2026-01-21T16:28:46.191Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/e7/401fe1d024bf9352371d854be6f339ad9928669e6bc8a5ba08e9dbce81cf/torchaudio-2.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bcab0e39eb18da84cba1a0c87f600abb6ce97c882200cb46e841caea106f037f", size = 736373, upload-time = "2026-01-21T16:28:41.589Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/b7/c66dc34a27441d78997e20d0ffe2f5ad73db9f7b1267511be255bb94ac9b/torchaudio-2.10.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:87c841a21e82703ebd4a29170c4e60c25a2b47312dc212930087ad58965ac0c8", size = 391843, upload-time = "2026-01-21T16:28:43.093Z" },
-    { url = "https://files.pythonhosted.org/packages/13/ae/a2a34a64947c4fa4a61b4c86d8f36fbcb4ebfec30fdde140267db260f96c/torchaudio-2.10.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b2c77fb9114dd463dc805560bf55a1ac2a52e219794cc32b7b32cf2aeffd2826", size = 1894140, upload-time = "2026-01-21T16:28:35.892Z" },
-    { url = "https://files.pythonhosted.org/packages/69/26/cd2aec609b4f8918e4e85e5c6a3f569bc7b5f72a7ecba3f784077102749c/torchaudio-2.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:4c6e9609046143b30a30183893d23ff1ce5de603dbe914b3cce5cc29f5aa5a9c", size = 474792, upload-time = "2026-01-21T16:28:45.254Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/36/28a6f3e857616cf7576bdbf8170e483b8c5d0a1f8d349ecb2b75921236aa/torchaudio-2.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9d0fbdbfd2f621c51d28571050d6d0c7287791034e5c7303b31480af1258f33f", size = 737144, upload-time = "2026-01-21T16:28:44.189Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/3f/df620439a76ece170472d41438d11a1545d5db5dc9f1eaeab8c6e055a328/torchaudio-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:42b148a0921a3721abd1f6ae098b1ec9f89703e555c4f7a0d44da87b8decbcb9", size = 391973, upload-time = "2026-01-21T16:28:39.732Z" },
-    { url = "https://files.pythonhosted.org/packages/98/25/e55a30d7138f8fe56ed006df25b0a3c27681f0ec7bc9989e1778e6d559c3/torchaudio-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0e77b2956448d63790a99beed0b74ac8b8cd3a94dcdd9ad01974411078f46278", size = 1895234, upload-time = "2026-01-21T16:28:37.034Z" },
-    { url = "https://files.pythonhosted.org/packages/be/a0/da53c7d20fac15f66f8838653b91162de1bf21fb40fee88cf839e4ef5174/torchaudio-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f76a01ecebf1869e1f2c50a261f1cf07e5fccb24402b4e9bbb82d6725b9c7dd", size = 475470, upload-time = "2026-01-21T16:28:40.615Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/02/341e7bd588355f82c5180103cb2f8070a72ab1be920ab27553a1135d4aa6/torchaudio-2.10.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8fd38d28ee150c584d3ee3b05f39e021f0ad8a8ec8fec1f26dfe150c9db9b2f5", size = 737164, upload-time = "2026-01-21T16:28:38.354Z" },
-    { url = "https://files.pythonhosted.org/packages/49/fd/831c2595c81b17141180ca11ab3c0836cc544ef13e15aa0e7b2cb619e582/torchaudio-2.10.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5bc39ff3ea341097ce1ab023dd88c9dd8ca5f96ebf48821e7d23766137bb55d7", size = 392757, upload-time = "2026-01-21T16:28:33.631Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/d8/405c80c57dc68ca5855bddfaae57c3d84ea7397bf1eb2aa5d59c9fa1d3a9/torchaudio-2.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3057c4286db5673d266124a2a10ca54e19f516772e9057f44573a7da5b85e328", size = 1897099, upload-time = "2026-01-21T16:28:24.793Z" },
-    { url = "https://files.pythonhosted.org/packages/73/cf/0e48d67788c935e3b3d00e6f55a930a54a67f432e04c33ef80a38cb764fd/torchaudio-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:99e74d1901742bc10961d807fe75c0dd9496f4a4a4ff4bb317c5de4a0b6f24e6", size = 475476, upload-time = "2026-01-21T16:28:28.249Z" },
-    { url = "https://files.pythonhosted.org/packages/48/29/30bcce0f17a8279b051b09250993691a828f89a03278306b23571c18df04/torchaudio-2.10.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6cfe98ef0ea9bee6d6297493ce67ce0c54a38d80caf6535a3ae48900fd5f3769", size = 742449, upload-time = "2026-01-21T16:28:29.556Z" },
-    { url = "https://files.pythonhosted.org/packages/43/8c/653e7f67855424bf3b7cbb48335f8316f7fb02bb01a6cab38f6bf9555676/torchaudio-2.10.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:b41b254d958632dc00dc7768431cadda516c91641d798775cbb19bcd4f0d2be4", size = 393430, upload-time = "2026-01-21T16:28:34.855Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/1f/f91fcb9dd47a19b720fb48042a2f6f023651948e73726e98fff60d5ed5c7/torchaudio-2.10.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:da1081d1018a1e95f5a13947402aeb037cf5ac8861219a6164df004898a96bb1", size = 1897271, upload-time = "2026-01-21T16:28:23.519Z" },
-    { url = "https://files.pythonhosted.org/packages/57/27/270c26890f43838e8faa5d3e52f079bd9d9d09f9a535a11cf6b94e20ed21/torchaudio-2.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f1afa53146a5655258d3a86e689c6879dfe78581d9bee9ef611ace98722f86bb", size = 478966, upload-time = "2026-01-21T16:28:32.491Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/5c/0e54b162bd0d1ec2f87b545553af839f906b940888d0122cdef04b965385/torchaudio-2.10.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1f2897fbf776d55afcb5f6d9b7bdfaea850ca7a129c8f5e4b3a4b025c431130d", size = 739544, upload-time = "2026-01-21T16:28:26.947Z" },
-    { url = "https://files.pythonhosted.org/packages/57/a1/ef5571406858f4ea89c18d6ad844d21cb9858708149e6bbd9a789ee30ea5/torchaudio-2.10.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:b2d5e11a2bec08f02a4f5fb7d1902ff82d48c533a27ceedc21e6ade650cf65b3", size = 393061, upload-time = "2026-01-21T16:28:25.802Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/0f/a0cf0ebc6f71b1868ea056dd4cd4f1a2244b8da8bc38372a1adc984a7c1f/torchaudio-2.10.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:77f6cf11a3b61af1b0967cd642368ecd30a86d70f622b22410ae6cb42d980b72", size = 1897137, upload-time = "2026-01-21T16:28:15.366Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/48/98e6710a4601e190bc923c3683629c29d41fb18a818a9328515541f023ed/torchaudio-2.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:4711c2a86a005685ca3b5da135b2f370d81ac354e3dcb142ef45fe2c78b9c9c4", size = 475154, upload-time = "2026-01-21T16:28:22.438Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/9b/cd02f8add38bd98761548b0821a5e54c564117a9bbeafaf95f665ab0fd72/torchaudio-2.10.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13bdc1bde0c88e999699d1503304a56fc9dea6401b76bc08a5f268368129d46c", size = 742453, upload-time = "2026-01-21T16:28:20.989Z" },
-    { url = "https://files.pythonhosted.org/packages/53/8a/946aa07393845b918d318b5e34b3bd0359fd27fc9fac10a85fae2bb86382/torchaudio-2.10.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:ed912de8ec1b400e17a5172badcfcddc601a9cd4e02d200f3a9504fc8e54961c", size = 393434, upload-time = "2026-01-21T16:28:18.668Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/68/e37e8fbbae986afa80f8851e08fc017eb8ae5f7b398ee28ed92303da163e/torchaudio-2.10.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:f7aa33a8198e87949896e16ea245ea731906445becdf10130e8823c68494a94a", size = 1897289, upload-time = "2026-01-21T16:28:17.059Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/61/0e1f464463b85bc677036faffdfd23493aa17e8c3fc3a649abca8c019701/torchaudio-2.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e49f6a18a8552620c4394f8529b7551eda9312d46dfdd3500bd2be459c86aea4", size = 478968, upload-time = "2026-01-21T16:28:19.542Z" },
-]
-
-[[package]]
 name = "tqdm"
 version = "4.67.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3161,20 +2975,6 @@ wheels = [
 ]
 
 [[package]]
-name = "triton"
-version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/f7/f1c9d3424ab199ac53c2da567b859bcddbb9c9e7154805119f8bd95ec36f/triton-3.6.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6550fae429e0667e397e5de64b332d1e5695b73650ee75a6146e2e902770bea", size = 188105201, upload-time = "2026-01-20T16:00:29.272Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/12/b05ba554d2c623bffa59922b94b0775673de251f468a9609bc9e45de95e9/triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e323d608e3a9bfcc2d9efcc90ceefb764a82b99dea12a86d643c72539ad5d3", size = 188214640, upload-time = "2026-01-20T16:00:35.869Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
-    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
-    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
-]
-
-[[package]]
 name = "ty"
 version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
@@ -3196,6 +2996,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/08/d5/655beb51224d1bfd4f9ddc0bb209659bfe71ff141bcf05c418ab670698f0/ty-0.0.14-py3-none-win32.whl", hash = "sha256:b20e22cf54c66b3e37e87377635da412d9a552c9bf4ad9fc449fed8b2e19dad2", size = 9507626, upload-time = "2026-01-27T00:57:41.43Z" },
     { url = "https://files.pythonhosted.org/packages/b6/d9/c569c9961760e20e0a4bc008eeb1415754564304fd53997a371b7cf3f864/ty-0.0.14-py3-none-win_amd64.whl", hash = "sha256:e312ff9475522d1a33186657fe74d1ec98e4a13e016d66f5758a452c90ff6409", size = 10437980, upload-time = "2026-01-27T00:57:36.422Z" },
     { url = "https://files.pythonhosted.org/packages/ad/0c/186829654f5bfd9a028f6648e9caeb11271960a61de97484627d24443f91/ty-0.0.14-py3-none-win_arm64.whl", hash = "sha256:b6facdbe9b740cb2c15293a1d178e22ffc600653646452632541d01c36d5e378", size = 9885831, upload-time = "2026-01-27T00:57:49.747Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/07/b822e1b307d40e263e8253d2384cf98c51aa2368cc7ba9a07e523a1d964b/typer-0.23.1.tar.gz", hash = "sha256:2070374e4d31c83e7b61362fd859aa683576432fd5b026b060ad6b4cd3b86134", size = 120047, upload-time = "2026-02-13T10:04:30.984Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/91/9b286ab899c008c2cb05e8be99814807e7fbbd33f0c0c960470826e5ac82/typer-0.23.1-py3-none-any.whl", hash = "sha256:3291ad0d3c701cbf522012faccfbb29352ff16ad262db2139e6b01f15781f14e", size = 56813, upload-time = "2026-02-13T10:04:32.008Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Inline configuration rendering in Components tab for all cortex engines
- Searchable model dropdown populated from /v1/models API endpoint
- Auto-select model from catalog when configured model is missing
- Default OpenAPI port changed from 11434 to 8081 to avoid Ollama conflict
- Config visible for all available engines, not just the active one
- Cortex change notifications no longer pollute WebUI chat history

## Test plan
- [x] OpenAPI engine connects to llama.cpp on port 8081
- [x] Model auto-selection working (no more "default" as model name)
- [x] Inline config renders for all engines in Components tab
- [x] Notifications excluded from chat history cache
- [x] Valid JSON responses confirmed via cortex_api.log
