### PR TITLE
Full gemini live implementation, fixed openrouter multimodal,

### DIFF
--- a/core/action_parser.py
+++ b/core/action_parser.py
@@ -1403,6 +1403,20 @@ async def run_actions(actions: Any, context: Dict[str, Any], bot, original_messa
                 except Exception as e:
                     log_debug(f"[action_parser] Grillo dedupe check failed: {e}")
 
+                # Block agent actions (propose_action, agent_execute, etc.)
+                # from grillo beats — outreach should deliver directly to the
+                # target interface, never route through the agent approval flow.
+                if action_type in (
+                    "propose_action",
+                    "agent_execute",
+                    "approve_action",
+                    "start_task",
+                ):
+                    log_warning(
+                        f"[action_parser] Dropping '{action_type}' from grillo beat — agent actions not allowed in grillo context"
+                    )
+                    continue
+
             if is_from_cortex:
                 try:
                     # Centralized safety decision
@@ -1412,7 +1426,10 @@ async def run_actions(actions: Any, context: Dict[str, Any], bot, original_messa
                         action, context or {}, original_message
                     )
                     if not allowed:
-                        # Maintain previous behavior: collect as failed action and continue
+                        # Safety/policy blocks are unfixable — the LLM cannot
+                        # change the system configuration, so asking the
+                        # corrector to "fix" these only produces workarounds
+                        # like propose_action that bypass the intended policy.
                         error_msg = f"Action '{action.get('type')}' blocked by safety policy: {reason}"
                         log_info(f"[action_parser] {error_msg}")
                         collected_errors.append(error_msg)
@@ -1422,6 +1439,7 @@ async def run_actions(actions: Any, context: Dict[str, Any], bot, original_messa
                                 "action": action,
                                 "errors": [error_msg],
                                 "safety_meta": meta,
+                                "unfixable": True,
                             }
                         )
                         continue

--- a/core/action_parser.py
+++ b/core/action_parser.py
@@ -1221,8 +1221,13 @@ FAILED ACTIONS REQUIRING CORRECTION:
         # spitting out the entire current list (which may change depending on
         # loaded plugins).  The corrector will already know which actions are
         # valid; this note is just to highlight the mismatch.
-        if detail['description'] == 'Unknown action' or detail['action_type'] in unknown_actions:
-            instruction += f"   NOTE: '{detail['action_type']}' is not a valid action type.\n"
+        if (
+            detail["description"] == "Unknown action"
+            or detail["action_type"] in unknown_actions
+        ):
+            instruction += (
+                f"   NOTE: '{detail['action_type']}' is not a valid action type.\n"
+            )
 
         # Add verbose instructions if available (include description, payload schema, examples, and important notes)
         if "verbose_instructions" in detail:

--- a/core/config.py
+++ b/core/config.py
@@ -209,16 +209,38 @@ _register_exposed_var(
     scope="live",
     component="cortex_live",
     options=[
-        "Aoede",  # Breezy, natural (default)
-        "Puck",  # Upbeat, playful
-        "Charon",  # Informational, calm
-        "Kore",  # Firm, clear
-        "Fenrir",  # Excitable
-        "Orbit",  # Easy-going
-        "Zephyr",  # Bright
-        "Leda",  # Youthful
-        "Orus",  # Firm, deep
-        "Autonoe",  # Bright, warm
+        # Female
+        "Aoede",
+        "Kore",
+        "Leda",
+        "Zephyr",
+        "Autonoe",
+        "Achernar",
+        "Callirrhoe",
+        "Despina",
+        "Erinome",
+        "Gacrux",
+        "Laomedeia",
+        "Pulcherrima",
+        "Sulafat",
+        "Vindemiatrix",
+        # Male
+        "Puck",
+        "Charon",
+        "Fenrir",
+        "Orus",
+        "Achird",
+        "Algenib",
+        "Algieba",
+        "Alnilam",
+        "Enceladus",
+        "Iapetus",
+        "Rasalgethi",
+        "Sadachbia",
+        "Sadaltager",
+        "Schedar",
+        "Umbriel",
+        "Zubenelgenubi",
     ],
 )
 
@@ -234,6 +256,34 @@ _register_exposed_var(
         "Leave empty for default persona behavior."
     ),
     scope="live",
+    component="cortex_live",
+)
+
+# Live session feature toggles
+LIVE_AFFECTIVE_DIALOG = config_registry.get_var(
+    "LIVE_AFFECTIVE_DIALOG",
+    False,
+    label="Affective Dialog",
+    description="Model adapts tone/emotion to match the user's expression.",
+    group="core",
+    component="cortex_live",
+)
+
+LIVE_PROACTIVE_AUDIO = config_registry.get_var(
+    "LIVE_PROACTIVE_AUDIO",
+    False,
+    label="Proactive Audio",
+    description="Model can choose not to respond when audio is irrelevant.",
+    group="core",
+    component="cortex_live",
+)
+
+LIVE_THINKING_BUDGET = config_registry.get_var(
+    "LIVE_THINKING_BUDGET",
+    0,
+    label="Thinking Budget",
+    description="Internal reasoning tokens before responding (0 = disabled).",
+    group="core",
     component="cortex_live",
 )
 

--- a/core/config.py
+++ b/core/config.py
@@ -4,6 +4,8 @@ import os
 import json
 import asyncio
 
+from core.variables_engine import register_exposed_var as _register_exposed_var
+
 try:
     from dotenv import load_dotenv  # type: ignore
 except Exception:  # pragma: no cover - fallback when dotenv not installed
@@ -164,6 +166,75 @@ LIVE_HISTORY_SYNC_INTERVAL = config_registry.get_var(
     group="core",
     component="live",
     value_type=int,
+)
+
+# ----------------------------------------------------------------------
+# Live voice configuration
+# ----------------------------------------------------------------------
+LIVE_VOICE_NAME = config_registry.get_var(
+    "LIVE_VOICE_NAME",
+    "Aoede",
+    label="Live Voice",
+    description=(
+        "Prebuilt voice for Gemini Live API sessions. "
+        "Each voice has a distinct character and tone."
+    ),
+    group="core",
+    component="cortex_live",
+)
+
+LIVE_VOICE_STYLE = config_registry.get_var(
+    "LIVE_VOICE_STYLE",
+    "",
+    label="Voice Style Prompt",
+    description=(
+        "Extra instructions appended to the live system prompt to shape how "
+        "the model speaks (e.g. tone, pacing, vocabulary, personality quirks). "
+        "Leave empty for default persona behavior."
+    ),
+    group="core",
+    component="cortex_live",
+)
+
+_register_exposed_var(
+    "LIVE_VOICE_NAME",
+    label="Live Voice",
+    default="Aoede",
+    value_type=str,
+    ui_type="select",
+    description=(
+        "Prebuilt voice for Gemini Live API sessions. "
+        "Each voice has a distinct character and tone."
+    ),
+    scope="live",
+    component="cortex_live",
+    options=[
+        "Aoede",  # Breezy, natural (default)
+        "Puck",  # Upbeat, playful
+        "Charon",  # Informational, calm
+        "Kore",  # Firm, clear
+        "Fenrir",  # Excitable
+        "Orbit",  # Easy-going
+        "Zephyr",  # Bright
+        "Leda",  # Youthful
+        "Orus",  # Firm, deep
+        "Autonoe",  # Bright, warm
+    ],
+)
+
+_register_exposed_var(
+    "LIVE_VOICE_STYLE",
+    label="Voice Style Prompt",
+    default="",
+    value_type=str,
+    ui_type="textarea",
+    description=(
+        "Extra instructions appended to the live system prompt to shape how "
+        "the model speaks (e.g. tone, pacing, vocabulary, personality quirks). "
+        "Leave empty for default persona behavior."
+    ),
+    scope="live",
+    component="cortex_live",
 )
 
 # --- LogChat configuration (use config_registry so exposed-variable APIs are consistent)

--- a/core/live_api_logger.py
+++ b/core/live_api_logger.py
@@ -1,0 +1,171 @@
+# core/live_api_logger.py
+"""Bidirectional logger for Gemini Live API sessions.
+
+Writes a dedicated log file (``logs/live_api.log``) that records every
+message sent to and received from the Gemini Live API WebSocket.  Designed
+for debugging context injection, audio flow, and turn management.
+
+    ═══ SEND  [2026-03-15 21:40:01] guild=123 type=context_update ═══
+    [System Context Update] [Document: readme.md]
+    ...
+    ─── RECV  [2026-03-15 21:40:02] guild=123 turn=1 msg#3 ────────────
+    model_turn=True  has_audio=True (1920B)  has_text=False
+    input_tx=None  output_tx=None
+
+Usage::
+
+    from core.live_api_logger import log_live_send, log_live_recv
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import textwrap
+from datetime import datetime, timezone
+from logging.handlers import RotatingFileHandler
+from typing import Any
+
+_DEFAULT_LOG_DIR = os.path.join(os.getcwd(), "logs")
+_LOG_DIR = os.getenv("LOG_DIR", _DEFAULT_LOG_DIR)
+_LOG_FILE = os.path.join(_LOG_DIR, "live_api.log")
+
+_logger: logging.Logger | None = None
+
+_WIDTH = 90
+
+
+def _get_logger() -> logging.Logger:
+    """Lazily initialise and return the live-API file logger."""
+    global _logger
+    if _logger is not None:
+        return _logger
+
+    os.makedirs(_LOG_DIR, exist_ok=True)
+
+    logger = logging.getLogger("synth.live_api")
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+
+    if not logger.handlers:
+        handler = RotatingFileHandler(
+            _LOG_FILE,
+            maxBytes=10 * 1024 * 1024,  # 10 MB
+            backupCount=3,
+            encoding="utf-8",
+        )
+        handler.setLevel(logging.DEBUG)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+
+    _logger = logger
+    return logger
+
+
+def _ts() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def _truncate(text: str, limit: int = 2000) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n... [{len(text) - limit} chars truncated]"
+
+
+# ── Outgoing (bot → Gemini) ──────────────────────────────────────────────
+
+
+def log_live_send(
+    guild_id: int,
+    *,
+    msg_type: str,
+    content: str | None = None,
+    audio_bytes: int = 0,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Log an outgoing message to the Gemini Live API."""
+    logger = _get_logger()
+    sep = "═" * _WIDTH
+    lines = [
+        f"\n{sep}",
+        f"  SEND  [{_ts()}]  guild={guild_id}  type={msg_type}",
+        f"{sep}",
+    ]
+    if content:
+        lines.append(_truncate(content))
+    if audio_bytes:
+        lines.append(f"[audio: {audio_bytes} bytes PCM]")
+    if extra:
+        for k, v in extra.items():
+            lines.append(f"  {k}: {v}")
+    logger.debug("\n".join(lines))
+
+
+# ── Incoming (Gemini → bot) ──────────────────────────────────────────────
+
+
+def log_live_recv(
+    guild_id: int,
+    *,
+    turn: int = 0,
+    msg_num: int = 0,
+    model_turn: bool = False,
+    turn_complete: bool | None = None,
+    interrupted: bool | None = None,
+    audio_bytes: int = 0,
+    text: str | None = None,
+    input_transcript: str | None = None,
+    output_transcript: str | None = None,
+    tool_call: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Log an incoming message from the Gemini Live API."""
+    logger = _get_logger()
+    sep = "─" * _WIDTH
+    lines = [
+        f"{sep}",
+        f"  RECV  [{_ts()}]  guild={guild_id}  turn={turn}  msg#{msg_num}",
+        f"{sep}",
+    ]
+
+    flags: list[str] = []
+    flags.append(f"model_turn={model_turn}")
+    if turn_complete is not None:
+        flags.append(f"turn_complete={turn_complete}")
+    if interrupted is not None:
+        flags.append(f"interrupted={interrupted}")
+    if audio_bytes:
+        flags.append(f"audio={audio_bytes}B")
+    lines.append("  ".join(flags))
+
+    if text:
+        lines.append(f"TEXT: {_truncate(text)}")
+    if input_transcript:
+        lines.append(f"INPUT_TX: {input_transcript}")
+    if output_transcript:
+        lines.append(f"OUTPUT_TX: {output_transcript}")
+    if tool_call:
+        lines.append(f"TOOL_CALL: {tool_call}")
+    if extra:
+        for k, v in extra.items():
+            lines.append(f"  {k}: {v}")
+
+    logger.debug("\n".join(lines))
+
+
+def log_live_session_event(
+    guild_id: int,
+    event: str,
+    detail: str = "",
+) -> None:
+    """Log a session lifecycle event (start, stop, reconnect, etc.)."""
+    logger = _get_logger()
+    sep = "═" * _WIDTH
+    lines = [
+        f"\n{sep}",
+        f"  SESSION  [{_ts()}]  guild={guild_id}  event={event}",
+        f"{sep}",
+    ]
+    if detail:
+        lines.append(textwrap.fill(detail, width=120))
+    logger.debug("\n".join(lines))

--- a/core/live_session_manager.py
+++ b/core/live_session_manager.py
@@ -39,9 +39,8 @@ RECONNECT_BUFFER_SECONDS = 30  # reconnect 30s before limit
 # Live API model
 LIVE_MODEL = "gemini-2.5-flash-native-audio-preview-12-2025"
 
-# Default voice — configurable via LIVE_VOICE_NAME in persona.json or .env.
-# Available prebuilt voices: Puck, Charon, Kore, Fenrir, Aoede, Orbit,
-# Zephyr, Leda, Orus, Autonoe.  Check Google's docs for the full current list.
+# Default voice — configurable via LIVE_VOICE_NAME in the WebUI or .env.
+# 30 Chirp3:HD prebuilt voices available — see Google's docs for the full list.
 _DEFAULT_VOICE = "Aoede"
 
 try:
@@ -290,6 +289,31 @@ class LiveSessionManager:
         except Exception:
             pass
 
+        # ── Resolve optional session features from config ──
+        _affective = False
+        _proactive = False
+        _thinking_budget = 0
+        try:
+            from core.config_manager import config_registry as _cfg
+
+            _aff_raw = _cfg.get_value("LIVE_AFFECTIVE_DIALOG", False)
+            _pro_raw = _cfg.get_value("LIVE_PROACTIVE_AUDIO", False)
+            # Config registry may return strings; guard against bool("false")==True
+            _affective = _aff_raw is True or (
+                isinstance(_aff_raw, str) and _aff_raw.lower() == "true"
+            )
+            _proactive = _pro_raw is True or (
+                isinstance(_pro_raw, str) and _pro_raw.lower() == "true"
+            )
+            _tb = _cfg.get_value("LIVE_THINKING_BUDGET", 0)
+            _thinking_budget = int(_tb) if _tb else 0
+            log_info(
+                f"[live_session] Feature flags: affective={_affective} "
+                f"proactive={_proactive} thinking_budget={_thinking_budget}"
+            )
+        except Exception:
+            pass
+
         live_config = types.LiveConnectConfig(
             response_modalities=["AUDIO"],  # type: ignore[arg-type]
             input_audio_transcription=types.AudioTranscriptionConfig(),
@@ -314,6 +338,37 @@ class LiveSessionManager:
             ),
             system_instruction=system_instruction,
         )
+
+        # Affective dialog — model adapts tone to user's expression (v1alpha)
+        if _affective:
+            try:
+                live_config.enable_affective_dialog = True  # type: ignore[attr-defined]
+                log_info("[live_session] Affective dialog enabled")
+            except Exception as exc:
+                log_warning(f"[live_session] Could not enable affective dialog: {exc}")
+
+        # Proactive audio — model can choose not to respond to irrelevant audio
+        if _proactive:
+            try:
+                live_config.proactivity = types.ProactivityConfig(  # type: ignore[attr-defined]
+                    proactive_audio=True,
+                )
+                log_info("[live_session] Proactive audio enabled")
+            except Exception as exc:
+                log_warning(f"[live_session] Could not enable proactive audio: {exc}")
+
+        # Thinking budget — internal reasoning tokens before responding
+        if _thinking_budget > 0:
+            try:
+                live_config.thinking_config = types.ThinkingConfig(  # type: ignore[attr-defined]
+                    thinking_budget=_thinking_budget,
+                    include_thoughts=False,
+                )
+                log_info(
+                    f"[live_session] Thinking budget set to {_thinking_budget} tokens"
+                )
+            except Exception as exc:
+                log_warning(f"[live_session] Could not set thinking budget: {exc}")
         if tools:
             live_config.tools = tools  # type: ignore[assignment]
 

--- a/core/live_session_manager.py
+++ b/core/live_session_manager.py
@@ -10,8 +10,8 @@ Manages WebSocket sessions to the Gemini Live API, handling:
 - Session duration tracking and automatic reconnection
 
 Audio format: PCM 16-bit signed little-endian, 16000 Hz, mono.
-This matches both Discord.py's voice receive format and the Gemini Live API's
-expected input format.
+Discord provides 48kHz stereo; the sink downsamples to 16kHz mono before
+sending to the Gemini Live API.
 """
 
 from __future__ import annotations
@@ -22,8 +22,10 @@ import time
 from typing import Any, Callable, Awaitable, ClassVar
 
 from core.logging_utils import log_debug, log_error, log_info, log_warning
+from core.live_api_logger import log_live_send, log_live_recv, log_live_session_event
 
 # PCM audio constants for Gemini Live API
+# Discord provides 48kHz PCM; we downsample to 16kHz before sending.
 LIVE_AUDIO_SAMPLE_RATE = 16000
 LIVE_AUDIO_MIME = f"audio/pcm;rate={LIVE_AUDIO_SAMPLE_RATE}"
 # Gemini outputs 24kHz PCM by default
@@ -85,6 +87,8 @@ class LiveSessionState:
         "last_injected_ts",
         "generating",  # whether a model turn is currently in progress
         "pending_context_updates",  # queued texts awaiting flush
+        "_user_speaking",  # whether we have sent activity_start (manual VAD)
+        "attachment_context",  # document text for system instruction (survives reconnects)
     )
 
     def __init__(
@@ -106,6 +110,11 @@ class LiveSessionState:
         # live-turn state
         self.generating: bool = False
         self.pending_context_updates: list[str] = []
+        self._user_speaking: bool = (
+            False  # manual VAD: True between activity_start/activity_end
+        )
+        # Document context embedded in system instruction (persisted for reconnects)
+        self.attachment_context: str | None = None
 
     @property
     def elapsed_seconds(self) -> float:
@@ -251,6 +260,7 @@ class LiveSessionManager:
         channel_id: int,
         system_instruction: str,
         tools: list[dict[str, Any]] | None = None,
+        attachment_context: str | None = None,
     ) -> bool:
         """Start a Live API session for a guild's voice channel.
 
@@ -291,6 +301,17 @@ class LiveSessionManager:
                     )
                 )
             ),
+            # Disable server-side VAD and use manual activity_start/activity_end
+            # signals instead.  Discord stops sending RTP packets when users are
+            # silent, which freezes the server-side VAD clock and prevents it from
+            # ever detecting the end of a turn.  Manual VAD gives us full control:
+            # we send activity_start when we first receive Discord audio and
+            # activity_end after a configurable silence timeout.
+            realtime_input_config=types.RealtimeInputConfig(
+                automatic_activity_detection=types.AutomaticActivityDetection(
+                    disabled=True,
+                ),
+            ),
             system_instruction=system_instruction,
         )
         if tools:
@@ -301,6 +322,7 @@ class LiveSessionManager:
             guild_id=guild_id,
             channel_id=channel_id,
         )
+        state.attachment_context = attachment_context
 
         try:
             session_ctx = self._client.aio.live.connect(
@@ -315,6 +337,18 @@ class LiveSessionManager:
 
             self._sessions[guild_id] = state
             self._reconnect_locks.setdefault(guild_id, asyncio.Lock())
+
+            log_live_session_event(
+                guild_id,
+                "start",
+                f"model={LIVE_MODEL} voice={_voice_name} "
+                f"system_instruction={len(system_instruction)} chars",
+            )
+            log_live_send(
+                guild_id,
+                msg_type="system_instruction",
+                content=system_instruction,
+            )
 
             # Start receive loop
             state._receive_task = asyncio.create_task(
@@ -447,6 +481,8 @@ class LiveSessionManager:
         """
         send_count = 0
         total_bytes = 0
+        idle_ticks = 0
+        _SILENCE_TICKS = max(1, int(1.5 / self._FLUSH_INTERVAL_S))
         try:
             log_info(f"[live_session] Audio flush loop started for guild {guild_id}")
             while True:
@@ -468,10 +504,48 @@ class LiveSessionManager:
 
                 buf = self._send_buffers.get(guild_id)
                 if not buf:
-                    continue  # Nothing to send
+                    idle_ticks += 1
+                    # Discord stops sending packets when the user stops talking.
+                    # After a silence timeout, send activity_end so Gemini knows
+                    # the user finished speaking and should respond.
+                    if idle_ticks == _SILENCE_TICKS and state._user_speaking:
+                        try:
+                            log_info(
+                                f"[live_session] Sending activity_end for guild {guild_id} "
+                                f"after {idle_ticks * self._FLUSH_INTERVAL_S:.1f}s silence"
+                            )
+                            await state._session.send_realtime_input(
+                                activity_end=types.ActivityEnd()
+                            )
+                            state._user_speaking = False
+                            log_live_send(guild_id, msg_type="activity_end")
+                        except Exception as e:
+                            log_warning(
+                                f"[live_session] Failed to send activity_end for guild {guild_id}: {e}"
+                            )
+                    continue
+                else:
+                    chunk = bytes(buf)
+                    buf.clear()
 
-                chunk = bytes(buf)
-                buf.clear()
+                    # Send activity_start on first audio after silence
+                    if not state._user_speaking:
+                        try:
+                            log_info(
+                                f"[live_session] Sending activity_start for guild {guild_id}"
+                            )
+                            await state._session.send_realtime_input(
+                                activity_start=types.ActivityStart()
+                            )
+                            state._user_speaking = True
+                            log_live_send(guild_id, msg_type="activity_start")
+                        except Exception as e:
+                            log_warning(
+                                f"[live_session] Failed to send activity_start for guild {guild_id}: {e}"
+                            )
+
+                    idle_ticks = 0
+
                 send_count += 1
                 total_bytes += len(chunk)
 
@@ -487,6 +561,13 @@ class LiveSessionManager:
                     await state._session.send_realtime_input(
                         audio=types.Blob(data=chunk, mime_type=LIVE_AUDIO_MIME)
                     )
+                    if send_count == 1 or send_count % 25 == 0:
+                        log_live_send(
+                            guild_id,
+                            msg_type="audio",
+                            audio_bytes=len(chunk),
+                            extra={"flush_num": send_count, "total_bytes": total_bytes},
+                        )
                 except Exception as e:
                     log_warning(
                         f"[live_session] Failed to send audio for guild {guild_id}: {e}"
@@ -536,8 +617,16 @@ class LiveSessionManager:
                     for msg in new_msgs:
                         text = msg.get("text") or ""
                         if text:
-                            # forward into live model
-                            await self.send_text(guild_id, text)
+                            # Forward as a system-role context update so the
+                            # model internalises the text without generating an
+                            # audio response.  Using send_text (role=user,
+                            # turn_complete=True) would trigger a model reply
+                            # for every message, flooding the session.
+                            sender = msg.get("sender_name") or "[unknown]"
+                            await self.send_context_update(
+                                guild_id,
+                                f"[Text chat] {sender}: {text}",
+                            )
                             # replicate to live history path
                             await save_chat_message(
                                 interface_path=f"discord_live_{guild_id}",
@@ -582,9 +671,19 @@ class LiveSessionManager:
             return
 
         try:
+            full_text = f"[System Context Update] {text}"
             await state._session.send_client_content(
-                turns=types.Content(role="system", parts=[types.Part(text=text)]),
+                turns=types.Content(
+                    role="user",
+                    parts=[types.Part(text=full_text)],
+                ),
                 turn_complete=False,
+            )
+            log_live_send(
+                guild_id,
+                msg_type="context_update",
+                content=full_text,
+                extra={"turn_complete": False},
             )
             log_info(
                 f"[live_session] Sent context update to guild {guild_id}: {text[:60]}"
@@ -607,9 +706,18 @@ class LiveSessionManager:
             return
         for upd in list(state.pending_context_updates):
             try:
+                _upd_text = f"[System Context Update] {upd}"
                 await state._session.send_client_content(
-                    turns=types.Content(role="system", parts=[types.Part(text=upd)]),
+                    turns=types.Content(
+                        role="user",
+                        parts=[types.Part(text=_upd_text)],
+                    ),
                     turn_complete=False,
+                )
+                log_live_send(
+                    guild_id,
+                    msg_type="context_update_flush",
+                    content=_upd_text,
                 )
                 log_info(
                     f"[live_session] Flushed buffered context update for guild {guild_id}: {upd[:60]}"
@@ -635,8 +743,69 @@ class LiveSessionManager:
                 turns=types.Content(role="user", parts=[types.Part(text=text)]),
                 turn_complete=True,
             )
+            log_live_send(
+                guild_id,
+                msg_type="send_text",
+                content=text,
+                extra={"turn_complete": True},
+            )
         except Exception as e:
             log_warning(f"[live_session] Failed to send text for guild {guild_id}: {e}")
+
+    async def send_multimodal_context(
+        self,
+        guild_id: int,
+        text: str | None = None,
+        file_data: bytes | None = None,
+        mime_type: str = "application/octet-stream",
+    ) -> bool:
+        """Inject a multimodal context message (text + optional file) into a Live session.
+
+        This allows sending documents, images, or other files alongside a text
+        description so the model can discuss them during voice conversation.
+
+        Args:
+            guild_id: Target guild's Live session.
+            text: Optional text description / instruction for the file.
+            file_data: Raw file bytes (image, PDF, etc.).
+            mime_type: MIME type of ``file_data``.
+
+        Returns:
+            True if the message was sent successfully.
+        """
+        state = self._sessions.get(guild_id)
+        if not state or not state.is_active or not state._session:
+            log_warning(
+                f"[live_session] Cannot send multimodal context: no active session for guild {guild_id}"
+            )
+            return False
+
+        parts: list[types.Part] = []
+        if text:
+            parts.append(types.Part(text=f"[Document Context] {text}"))
+        if file_data:
+            parts.append(
+                types.Part(inline_data=types.Blob(mime_type=mime_type, data=file_data))
+            )
+
+        if not parts:
+            return False
+
+        try:
+            await state._session.send_client_content(
+                turns=types.Content(role="user", parts=parts),
+                turn_complete=False,
+            )
+            log_info(
+                f"[live_session] Sent multimodal context to guild {guild_id}: "
+                f"text={bool(text)}, file={bool(file_data)} ({mime_type})"
+            )
+            return True
+        except Exception as e:
+            log_warning(
+                f"[live_session] Failed to send multimodal context for guild {guild_id}: {e}"
+            )
+            return False
 
     def is_session_active(self, guild_id: int) -> bool:
         """Check if a Live API session is active for a guild."""
@@ -665,6 +834,10 @@ class LiveSessionManager:
             # Loop to keep receiving across all turns for the duration of the session.
             while state.is_active and state._session:
                 turn_count += 1
+                log_info(
+                    f"[live_session] Waiting for turn {turn_count} from Gemini "
+                    f"(guild {guild_id})"
+                )
                 # Per-turn transcript accumulators (filled from transcription fields).
                 user_parts: list[str] = []
                 model_parts: list[str] = []
@@ -674,6 +847,73 @@ class LiveSessionManager:
                         break
 
                     msg_count += 1
+
+                    # --- Deep debug: log every message's structure ---
+                    sc = getattr(message, "server_content", None)
+                    _tc = getattr(sc, "turn_complete", None) if sc else None
+                    _interrupted = getattr(sc, "interrupted", None) if sc else None
+                    _gen_complete = (
+                        getattr(sc, "generation_complete", None) if sc else None
+                    )
+                    _has_model_turn = bool(
+                        getattr(sc, "model_turn", None) if sc else None
+                    )
+                    _has_tool_call = bool(getattr(message, "tool_call", None))
+                    _has_input_tx = bool(
+                        getattr(sc, "input_transcription", None) if sc else None
+                    )
+                    _has_output_tx = bool(
+                        getattr(sc, "output_transcription", None) if sc else None
+                    )
+                    log_debug(
+                        f"[live_session] MSG#{msg_count} turn={turn_count} "
+                        f"guild={guild_id}: "
+                        f"model_turn={_has_model_turn} "
+                        f"turn_complete={_tc} "
+                        f"interrupted={_interrupted} "
+                        f"gen_complete={_gen_complete} "
+                        f"tool_call={_has_tool_call} "
+                        f"input_tx={_has_input_tx} "
+                        f"output_tx={_has_output_tx} "
+                        f"has_data={bool(message.data)} "
+                        f"has_text={bool(message.text)}"
+                    )
+
+                    # ── Bidirectional log to live_api.log ──
+                    _input_tx_text: str | None = None
+                    _output_tx_text: str | None = None
+                    _tool_call_str: str | None = None
+                    _sc = getattr(message, "server_content", None)
+                    if _sc:
+                        _it = getattr(_sc, "input_transcription", None)
+                        if _it:
+                            _input_tx_text = getattr(_it, "text", None)
+                        _ot = getattr(_sc, "output_transcription", None)
+                        if _ot:
+                            _output_tx_text = getattr(_ot, "text", None)
+                    _tc_obj = getattr(message, "tool_call", None)
+                    if _tc_obj:
+                        _fcs = getattr(_tc_obj, "function_calls", []) or []
+                        _tool_call_str = ", ".join(
+                            str(getattr(fc, "name", "?")) for fc in _fcs
+                        )
+                    log_live_recv(
+                        guild_id,
+                        turn=turn_count,
+                        msg_num=msg_count,
+                        model_turn=_has_model_turn,
+                        turn_complete=_tc,
+                        interrupted=_interrupted,
+                        audio_bytes=len(message.data) if message.data else 0,
+                        text=message.text,
+                        input_transcript=_input_tx_text,
+                        output_transcript=_output_tx_text,
+                        tool_call=_tool_call_str,
+                        extra={"gen_complete": _gen_complete}
+                        if _gen_complete
+                        else None,
+                    )
+
                     if msg_count <= 3 or msg_count % 50 == 0:
                         log_info(
                             f"[live_session] Received message #{msg_count} "
@@ -743,6 +983,11 @@ class LiveSessionManager:
                                     f"[live_session] Tool call handling error: {e}"
                                 )
 
+                log_info(
+                    f"[live_session] Turn {turn_count} receive loop exited "
+                    f"(guild {guild_id}, {msg_count} total msgs)"
+                )
+
                 # Turn complete — fire callback with accumulated transcripts.
                 if self._on_turn_complete and (user_parts or model_parts):
                     user_transcript = _clean_transcript(user_parts)
@@ -803,12 +1048,15 @@ class LiveSessionManager:
             )
 
             channel_id = state.channel_id
+            _att_ctx = state.attachment_context
             await self.stop_session(guild_id)
 
             # Rebuild system instruction from current persona for the new session
             from core.prompt_engine import build_live_system_instruction
 
-            instruction = await build_live_system_instruction()
+            instruction = await build_live_system_instruction(
+                attachment_context=_att_ctx,
+            )
 
             # Re-discover tool declarations so function calling persists
             tools: list[dict[str, Any]] | None = None
@@ -826,6 +1074,7 @@ class LiveSessionManager:
                 channel_id=channel_id,
                 system_instruction=instruction,
                 tools=tools,
+                attachment_context=_att_ctx,
             )
 
     async def reconnect_with_instruction(

--- a/core/live_session_manager.py
+++ b/core/live_session_manager.py
@@ -457,6 +457,7 @@ class LiveSessionManager:
         """Stop the Live API session for a guild."""
         state = self._sessions.pop(guild_id, None)
         self._send_buffers.pop(guild_id, None)
+        self._reconnect_locks.pop(guild_id, None)
 
         # Cancel the flush task
         flush_task = self._flush_tasks.pop(guild_id, None)

--- a/core/live_session_manager.py
+++ b/core/live_session_manager.py
@@ -32,9 +32,12 @@ LIVE_AUDIO_MIME = f"audio/pcm;rate={LIVE_AUDIO_SAMPLE_RATE}"
 LIVE_OUTPUT_SAMPLE_RATE = 24000
 LIVE_OUTPUT_MIME = f"audio/pcm;rate={LIVE_OUTPUT_SAMPLE_RATE}"
 
-# Session limits (from Google docs)
-MAX_AUDIO_SESSION_SECONDS = 15 * 60  # 15 minutes audio-only
-RECONNECT_BUFFER_SECONDS = 30  # reconnect 30s before limit
+# Session limits — Google documents 15 min for audio-only sessions, but
+# in practice the server closes WebSocket connections at roughly 10 min
+# (600s).  We use the empirical value so proactive reconnection fires
+# before the server kills the connection.
+MAX_AUDIO_SESSION_SECONDS = 10 * 60  # ~10 minutes (empirical)
+RECONNECT_BUFFER_SECONDS = 60  # reconnect 60s before observed limit
 
 # Live API model
 LIVE_MODEL = "gemini-2.5-flash-native-audio-preview-12-2025"
@@ -180,6 +183,7 @@ class LiveSessionManager:
         self._on_text: Callable[[int, str], Awaitable[None]] | None = None
         self._on_tool_call: Callable[[int, dict], Awaitable[dict]] | None = None
         self._on_turn_complete: Callable[[int, str, str], Awaitable[None]] | None = None
+        self._on_reconnect_failed: Callable[[int], Awaitable[None]] | None = None
         self._reconnect_locks: dict[int, asyncio.Lock] = {}
         # Audio send buffers: guild_id -> bytearray
         self._send_buffers: dict[int, bytearray] = {}
@@ -253,6 +257,16 @@ class LiveSessionManager:
         """
         self._on_turn_complete = callback
 
+    def set_reconnect_failed_callback(
+        self, callback: Callable[[int], Awaitable[None]]
+    ) -> None:
+        """Set callback fired when session reconnect fails after all retries.
+
+        Args: (guild_id,) — the interface should clean up voice state for
+        this guild since the Gemini session is irrecoverable.
+        """
+        self._on_reconnect_failed = callback
+
     async def start_session(
         self,
         guild_id: int,
@@ -260,6 +274,7 @@ class LiveSessionManager:
         system_instruction: str,
         tools: list[dict[str, Any]] | None = None,
         attachment_context: str | None = None,
+        is_reconnect: bool = False,
     ) -> bool:
         """Start a Live API session for a guild's voice channel.
 
@@ -430,16 +445,27 @@ class LiveSessionManager:
 
             # Kick off the model with an initial text turn so it sends a greeting
             # without waiting for user audio. The system instruction handles the persona.
+            # On reconnect, tell the model to continue naturally without re-greeting.
+            if is_reconnect:
+                _kick_text = (
+                    "[Voice session refreshed — you are continuing the same "
+                    "conversation. Do NOT greet or introduce yourself again. "
+                    "Simply acknowledge briefly that you're back and continue "
+                    "naturally.]"
+                )
+            else:
+                _kick_text = "[Session started. Greet naturally.]"
             try:
                 await session.send_client_content(
                     turns=types.Content(
                         role="user",
-                        parts=[types.Part(text="[Session started. Greet naturally.]")],
+                        parts=[types.Part(text=_kick_text)],
                     ),
                     turn_complete=True,
                 )
                 log_info(
-                    f"[live_session] Sent initial kick to model for guild {guild_id}"
+                    f"[live_session] Sent initial kick to model for guild {guild_id} "
+                    f"(reconnect={is_reconnect})"
                 )
             except Exception as e:
                 log_warning(f"[live_session] Initial kick failed (non-fatal): {e}")
@@ -897,12 +923,14 @@ class LiveSessionManager:
                 # Per-turn transcript accumulators (filled from transcription fields).
                 user_parts: list[str] = []
                 model_parts: list[str] = []
+                turn_msg_count = 0
 
                 async for message in state._session.receive():
                     if not state.is_active:
                         break
 
                     msg_count += 1
+                    turn_msg_count += 1
 
                     # --- Deep debug: log every message's structure ---
                     sc = getattr(message, "server_content", None)
@@ -1041,8 +1069,22 @@ class LiveSessionManager:
 
                 log_info(
                     f"[live_session] Turn {turn_count} receive loop exited "
-                    f"(guild {guild_id}, {msg_count} total msgs)"
+                    f"(guild {guild_id}, {turn_msg_count} msgs this turn, "
+                    f"{msg_count} total)"
                 )
+
+                # Empty turn = session.receive() yielded nothing.  This
+                # happens when the WebSocket was closed by the server
+                # (e.g. session time limit) without raising an exception.
+                # Treat it as a dead session and trigger reconnect.
+                if turn_msg_count == 0:
+                    log_warning(
+                        f"[live_session] ⚠️ Empty turn detected for guild "
+                        f"{guild_id} (elapsed {state.elapsed_seconds:.0f}s) "
+                        f"— session likely dead, triggering reconnect"
+                    )
+                    asyncio.create_task(self._reconnect(guild_id))
+                    break
 
                 # Turn complete — fire callback with accumulated transcripts.
                 if self._on_turn_complete and (user_parts or model_parts):
@@ -1080,26 +1122,59 @@ class LiveSessionManager:
             log_info(f"[live_session] Attempting auto-reconnect for guild {guild_id}")
             asyncio.create_task(self._reconnect(guild_id))
 
+    _RECONNECT_MAX_RETRIES: int = 3
+    _RECONNECT_RETRY_DELAY: float = 2.0  # seconds between retries
+
     async def _reconnect(self, guild_id: int) -> None:
         """Reconnect a session approaching the time limit.
 
         Rebuilds the system instruction from the current persona and
         re-discovers tool declarations so function calling is preserved
-        across session boundaries.
+        across session boundaries.  Retries up to ``_RECONNECT_MAX_RETRIES``
+        times before giving up and notifying via ``_on_reconnect_failed``.
         """
+        try:
+            await self._reconnect_inner(guild_id)
+        except Exception as outer_err:
+            # Safety net: ensure no exception escapes silently from the
+            # create_task wrapper.  If we get here, something unexpected
+            # went wrong (e.g. build_live_system_instruction threw).
+            log_error(
+                f"[live_session] ❌ Unhandled error in _reconnect for guild "
+                f"{guild_id}: {outer_err}"
+            )
+            if self._on_reconnect_failed:
+                try:
+                    await self._on_reconnect_failed(guild_id)
+                except Exception:
+                    pass
+
+    async def _reconnect_inner(self, guild_id: int) -> None:
+        """Core reconnect logic — called by ``_reconnect`` with safety wrapper."""
         lock = self._reconnect_locks.get(guild_id)
         if not lock:
+            log_warning(
+                f"[live_session] No reconnect lock for guild {guild_id} — "
+                "session may have been fully stopped"
+            )
             return
         if lock.locked():
+            log_debug(
+                f"[live_session] Reconnect already in progress for guild {guild_id}"
+            )
             return  # Already reconnecting
 
         async with lock:
             state = self._sessions.get(guild_id)
             if not state:
+                log_warning(
+                    f"[live_session] No session state for guild {guild_id} "
+                    "— cannot reconnect"
+                )
                 return  # Session was fully removed — nothing to reconnect
 
             log_info(
-                f"[live_session] Reconnecting session for guild {guild_id} "
+                f"[live_session] 🔄 Reconnecting session for guild {guild_id} "
                 f"(elapsed {state.elapsed_seconds:.0f}s, was_active={state.is_active})"
             )
 
@@ -1107,11 +1182,16 @@ class LiveSessionManager:
             _att_ctx = state.attachment_context
             await self.stop_session(guild_id)
 
-            # Rebuild system instruction from current persona for the new session
+            # Rebuild system instruction from current persona for the new
+            # session — includes fresh chat history from recent_chats cache.
             from core.prompt_engine import build_live_system_instruction
 
             instruction = await build_live_system_instruction(
                 attachment_context=_att_ctx,
+            )
+            log_info(
+                f"[live_session] Rebuilt system instruction for reconnect "
+                f"({len(instruction)} chars)"
             )
 
             # Re-discover tool declarations so function calling persists
@@ -1125,13 +1205,54 @@ class LiveSessionManager:
                     f"[live_session] Could not rebuild tool declarations on reconnect: {e}"
                 )
 
-            await self.start_session(
-                guild_id=guild_id,
-                channel_id=channel_id,
-                system_instruction=instruction,
-                tools=tools,
-                attachment_context=_att_ctx,
+            # Retry loop — Gemini may reject the connection briefly after a
+            # 1011 close.  We back off and try again up to _RECONNECT_MAX_RETRIES
+            # times before declaring failure.
+            last_err: Exception | None = None
+            for attempt in range(1, self._RECONNECT_MAX_RETRIES + 1):
+                try:
+                    log_info(
+                        f"[live_session] Reconnect attempt {attempt}/"
+                        f"{self._RECONNECT_MAX_RETRIES} for guild {guild_id}"
+                    )
+                    ok = await self.start_session(
+                        guild_id=guild_id,
+                        channel_id=channel_id,
+                        system_instruction=instruction,
+                        tools=tools,
+                        attachment_context=_att_ctx,
+                        is_reconnect=True,
+                    )
+                    if ok:
+                        log_info(
+                            f"[live_session] ✅ Reconnect succeeded for guild "
+                            f"{guild_id} (attempt {attempt})"
+                        )
+                        return  # success
+                    last_err = RuntimeError("start_session returned False")
+                except Exception as exc:
+                    last_err = exc
+
+                log_warning(
+                    f"[live_session] Reconnect attempt {attempt}/"
+                    f"{self._RECONNECT_MAX_RETRIES} failed for guild "
+                    f"{guild_id}: {last_err}"
+                )
+                if attempt < self._RECONNECT_MAX_RETRIES:
+                    await asyncio.sleep(self._RECONNECT_RETRY_DELAY * attempt)
+
+            # All retries exhausted — notify the interface to clean up
+            log_error(
+                f"[live_session] ❌ Reconnect failed after "
+                f"{self._RECONNECT_MAX_RETRIES} attempts for guild {guild_id}"
             )
+            if self._on_reconnect_failed:
+                try:
+                    await self._on_reconnect_failed(guild_id)
+                except Exception as cb_err:
+                    log_warning(
+                        f"[live_session] Reconnect-failed callback error: {cb_err}"
+                    )
 
     async def reconnect_with_instruction(
         self,
@@ -1155,6 +1276,7 @@ class LiveSessionManager:
             channel_id=channel_id,
             system_instruction=system_instruction,
             tools=tools,
+            is_reconnect=True,
         )
 
     async def close_all(self) -> None:

--- a/core/message_chain.py
+++ b/core/message_chain.py
@@ -1564,7 +1564,9 @@ async def handle_incoming_message(
             # in accordance with the new policy that at least one delivered
             # message prevents an LLM failure notification.
             if not actions_executed_during_loop:
-                await send_llm_fallback_message(bot, message, failure_reason, context=ctx)
+                await send_llm_fallback_message(
+                    bot, message, failure_reason, context=ctx
+                )
                 return LLM_FAILED
             else:
                 log_warning(

--- a/core/message_chain.py
+++ b/core/message_chain.py
@@ -614,6 +614,30 @@ async def handle_incoming_message(
                         f"[message_chain] ⚠️ No recognized text field in Gemini action, using fallback payload: {list(fallback_payload.keys())}"
                     )
                 actions = [normalized_action]
+            elif (
+                isinstance(parsed, dict)
+                and "text" in parsed
+                and "interface_path" in parsed
+            ):
+                # Bare message payload recovered from corrupted JSON — the
+                # LLM produced the correct payload but the actions wrapper
+                # was lost during JSON extraction.  Infer the action type
+                # from the interface_path prefix.
+                _ipath = str(parsed.get("interface_path", ""))
+                _iface = _ipath.split("/")[0] if "/" in _ipath else _ipath
+                _inferred_type = f"message_{_iface}" if _iface else None
+                if _inferred_type:
+                    log_info(
+                        f"[message_chain] 🔄 Wrapping bare message payload "
+                        f"as {_inferred_type} (recovered from corrupted JSON)"
+                    )
+                    actions = [{"type": _inferred_type, "payload": parsed}]
+                else:
+                    log_warning(
+                        f"[message_chain] Bare payload has interface_path "
+                        f"but no inferrable action type: {_ipath}"
+                    )
+                    parsed = None
             else:
                 log_warning(
                     f"[message_chain] Unrecognized JSON structure: {parsed} - triggering corrector"

--- a/core/message_queue.py
+++ b/core/message_queue.py
@@ -718,7 +718,9 @@ async def _consumer_loop() -> None:
                 # Get timeout configuration from message_chain module
                 from core.message_chain import RESPONSE_TIMEOUT
 
-                timeout_seconds = int(RESPONSE_TIMEOUT) if RESPONSE_TIMEOUT else 300  # default bump from 240 to 300s
+                timeout_seconds = (
+                    int(RESPONSE_TIMEOUT) if RESPONSE_TIMEOUT else 300
+                )  # default bump from 240 to 300s
 
                 # Check if this is an event prompt
                 if "event_prompt" in final:

--- a/core/persona_manager.py
+++ b/core/persona_manager.py
@@ -12,6 +12,7 @@ from core.db import get_conn_ctx
 from core.logging_utils import log_debug, log_info, log_warning, log_error
 from core.config_manager import config_registry
 from core.animation_handler import get_karada_state_server, AnimationState
+
 """
 Persona Manager - Digital Identity Management for SyntH
 
@@ -27,6 +28,7 @@ a synthetic being with its own identity, personality, and emotional framework.
 """
 
 print("[persona_manager] DEBUG: Module import started", flush=True)
+
 
 def _build_trainer_bio_section() -> str:
     """Build the trainer bio section with name and platform IDs.

--- a/core/plugin_instance.py
+++ b/core/plugin_instance.py
@@ -1074,8 +1074,8 @@ async def _extract_image_data_from_message(message, interface_name: str):
             f"[plugin_instance] message.photo is tuple: {isinstance(message.photo, tuple)}"
         )
 
-        # Handle list of photos (multiple resolutions)
-        if isinstance(message.photo, list):
+        # Handle list/tuple of photos (multiple resolutions)
+        if isinstance(message.photo, (list, tuple)):
             photo = message.photo[-1]  # Last element is typically highest resolution
         else:
             photo = message.photo

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -1424,36 +1424,171 @@ def reduce_json_text_for_transmission(json_text: str, max_chars: int) -> str:
 async def build_live_system_instruction(
     message: object = None,
     context_memory: object = None,
+    attachment_context: str | None = None,
 ) -> str:
     """Build a condensed system instruction for Gemini Live API sessions.
 
     The Live API has a smaller context window (128k tokens) and system
     instructions are set once at session start.  This produces a compact
-    persona string without the full JSON-action scaffolding.
+    persona string that includes the full persona identity, emotional state,
+    memories, diary entries, participant bios, and safety instructions —
+    everything the model needs to stay in-character during voice.
+
+    Args:
+        message: Optional message object for context.
+        context_memory: Optional context memory object.
+        attachment_context: Optional pre-formatted document text to embed
+            in the system instruction (e.g. from Discord attachments).
 
     Returns:
-        A plain-text system instruction containing the persona identity,
-        emotional state, and conversational guidelines.
+        A plain-text system instruction for the Live API.
     """
-    # Gather the persona injection (same path as build_json_prompt)
-    static_persona = ""
+    injections: dict[str, object] = {}
     try:
         from core.action_parser import gather_static_injections
 
         injections = await gather_static_injections(message, context_memory)
-        if isinstance(injections, dict) and "persona" in injections:
-            static_persona = injections.pop("persona", "")
+        if not isinstance(injections, dict):
+            injections = {}
     except Exception as e:
-        log_warning(f"[live_prompt] Failed to gather persona for Live API: {e}")
+        log_warning(f"[live_prompt] Failed to gather injections for Live API: {e}")
 
     parts: list[str] = []
 
-    if static_persona:
-        parts.append(static_persona)
+    # --- Persona identity ---
+    persona = injections.pop("persona", "")
+    if persona and isinstance(persona, str):
+        parts.append(persona)
 
-    # Conversational guidelines (no JSON scaffolding for voice)
+    # --- Safety / gasmask ---
+    gasmask = injections.pop("gasmask_protection", "")
+    if gasmask and isinstance(gasmask, str):
+        parts.append(gasmask)
+
+    # --- Emotional state ---
+    # Use the natural-language description only — NOT emotion_state which
+    # contains "{happy 8.5}" tag instructions meant for text LLMs.  The
+    # Live API generates speech directly, so the model would literally
+    # speak the tags aloud.
+    injections.pop("emotion_state", None)  # discard tag instructions
+    injections.pop("available_emotions", None)  # not useful for voice
+    emotion_nl = injections.pop("current_emotions_nl", "")
+    if emotion_nl and isinstance(emotion_nl, str):
+        parts.append(
+            f"Your current emotional state: {emotion_nl}\n"
+            "Let this colour your tone and word choice naturally — "
+            "do NOT mention emotion names or numbers aloud."
+        )
+
+    # --- Date/time/location ---
+    time_parts: list[str] = []
+    for key in ("location", "date", "time"):
+        val = injections.pop(key, "")
+        if val and isinstance(val, str):
+            time_parts.append(f"{key.capitalize()}: {val}")
+    if time_parts:
+        parts.append("Current context:\n" + "\n".join(time_parts))
+
+    # --- Weather ---
+    weather = injections.pop("weather", "")
+    if weather and isinstance(weather, str):
+        parts.append(f"Current weather: {weather}")
+
+    # --- Participant bios ---
+    participants = injections.pop("participants", None)
+    if participants and isinstance(participants, list):
+        bio_lines: list[str] = []
+        for p in participants:
+            if not isinstance(p, dict):
+                continue
+            tag = p.get("usertag", "unknown")
+            bio = p.get("short_bio", "")
+            nicks = p.get("nicknames", [])
+            nick_str = f" (also known as: {', '.join(nicks)})" if nicks else ""
+            feelings = p.get("feelings", [])
+            feel_str = (
+                f" [feelings: {', '.join(str(f) for f in feelings)}]"
+                if feelings
+                else ""
+            )
+            bio_lines.append(f"- {tag}{nick_str}: {bio}{feel_str}")
+        if bio_lines:
+            parts.append(
+                "People you know who may be in this conversation:\n"
+                + "\n".join(bio_lines)
+            )
+
+    # --- Diary / recent memories ---
+    diary = injections.pop("latest_diary_entries", None)
+    if diary and isinstance(diary, list):
+        diary_lines: list[str] = []
+        for entry in diary[:5]:  # cap at 5 to save context window
+            if not isinstance(entry, dict):
+                continue
+            ts = entry.get("timestamp", "")
+            thought = entry.get("personal_thought", "")
+            summary = entry.get("interaction_summary", "")
+            text = thought or summary
+            if text:
+                diary_lines.append(f"- [{ts}] {text}")
+        if diary_lines:
+            parts.append(
+                "Your recent memories (use these to stay consistent):\n"
+                + "\n".join(diary_lines)
+            )
+
+    # --- Recent cross-interface chat history ---
+    # This keeps the model aware of conversations on other interfaces
+    # (Telegram, Matrix, other Discord channels) so it stays consistent.
+    try:
+        from core.chat_history_cache import load_global_chat_history
+
+        recent_msgs = await load_global_chat_history(limit=15)
+        if recent_msgs:
+            history_lines: list[str] = []
+            for msg in recent_msgs:
+                if not isinstance(msg, dict):
+                    continue
+                sender = msg.get("sender_name", "?")
+                text_val = msg.get("text", "")
+                ts = msg.get("timestamp", "")
+                ipath = msg.get("interface_path", "")
+                if text_val:
+                    # Truncate long messages to save context
+                    preview = (
+                        text_val[:300] + "..." if len(text_val) > 300 else text_val
+                    )
+                    history_lines.append(f"- [{ts} via {ipath}] {sender}: {preview}")
+            if history_lines:
+                parts.append(
+                    "Recent conversation history across all interfaces "
+                    "(use for continuity):\n" + "\n".join(history_lines)
+                )
+    except Exception as e:
+        log_warning(f"[live_prompt] Failed to load chat history for Live API: {e}")
+
+    # --- Attachment / document context ---
+    if attachment_context and isinstance(attachment_context, str):
+        parts.append(
+            "The user shared the following document(s) at the start of this "
+            "voice session. You have full access to their contents and can "
+            "discuss, quote, or answer questions about them:\n\n" + attachment_context
+        )
+
+    # --- Custom voice style prompt ---
+    try:
+        voice_style = str(
+            config_registry.get_value("LIVE_VOICE_STYLE", "") or ""
+        ).strip()
+        if voice_style:
+            parts.append(voice_style)
+    except Exception:
+        pass
+
+    # --- Conversational guidelines (no JSON scaffolding for voice) ---
     parts.append(
-        "You are in a live voice conversation. Speak naturally and conversationally. "
+        "You are in a live voice conversation. Always speak in English. "
+        "Speak naturally and conversationally. "
         "Keep responses concise — a few sentences at most unless asked for detail. "
         "You can express emotions through tone and word choice. "
         "Do not output JSON, markdown, or structured data — just speak naturally."

--- a/core/transport_layer.py
+++ b/core/transport_layer.py
@@ -956,6 +956,20 @@ async def universal_send(interface_send_func, *args, text: str = None, **kwargs)
         # Non-fatal: keep original text if recovery fails
         pass
 
+    # Strip emotion tags like {arousal 10, devotion 10} from outbound text.
+    # The LLM embeds these for internal emotion state tracking but they
+    # must never leak into user-visible messages.
+    try:
+        if isinstance(text, str) and text and "{" in text:
+            from plugins.emotion_manager import strip_emotion_tags
+
+            cleaned = strip_emotion_tags(text)
+            if cleaned != text:
+                log_debug("[transport] Stripped emotion tags from outbound text")
+                text = cleaned
+    except Exception:
+        pass
+
     # Diagnostic: log interface function and runtime send parameters
     try:
         bot_self = getattr(interface_send_func, "__self__", None)

--- a/core/webui.py
+++ b/core/webui.py
@@ -7120,6 +7120,9 @@ class SynthWebUIInterface:
             active_live = None
 
         live_data: list[dict] = list(by_cortex.get("live", []))
+        # Fix active flag for cortex live engines (they were marked using BASE_CORTEX's active_engine)
+        for engine in live_data:
+            engine["active"] = engine.get("name") == active_live
         # always offer disabled choice; mark it active if the config says so
         live_data.insert(
             0,

--- a/core/webui_templates/sections/components.html
+++ b/core/webui_templates/sections/components.html
@@ -98,6 +98,33 @@
                         <div style="font-size:0.9rem; color:var(--muted);" id="live-engine-description">—</div>
                     </div>
                 </div>
+                <!-- Live voice configuration (visible when a live engine is active) -->
+                <div id="live-voice-config" style="display:none; margin-bottom:14px; padding:12px; background:var(--card-bg,#1a1a2e); border:1px solid var(--border,#444); border-radius:8px;">
+                    <div style="font-size:0.85rem; font-weight:600; color:var(--muted); text-transform:uppercase; letter-spacing:0.05em; margin-bottom:10px;">Voice Settings</div>
+                    <div style="display:flex; flex-direction:column; gap:10px;">
+                        <div style="display:flex; flex-direction:column; gap:3px;">
+                            <label for="live-voice-name" style="font-size:0.85rem; font-weight:600;">Voice</label>
+                            <div style="font-size:0.8rem; color:var(--muted);">Prebuilt voice for Gemini Live sessions.</div>
+                            <select id="live-voice-name" style="padding:6px 10px; background:var(--background); color:var(--text); border:1px solid var(--primary); border-radius:6px; font-size:0.88rem; max-width:300px;">
+                                <option value="Aoede">Aoede — Breezy, natural</option>
+                                <option value="Puck">Puck — Upbeat, playful</option>
+                                <option value="Charon">Charon — Informational, calm</option>
+                                <option value="Kore">Kore — Firm, clear</option>
+                                <option value="Fenrir">Fenrir — Excitable</option>
+                                <option value="Orbit">Orbit — Easy-going</option>
+                                <option value="Zephyr">Zephyr — Bright</option>
+                                <option value="Leda">Leda — Youthful</option>
+                                <option value="Orus">Orus — Firm, deep</option>
+                                <option value="Autonoe">Autonoe — Bright, warm</option>
+                            </select>
+                        </div>
+                        <div style="display:flex; flex-direction:column; gap:3px;">
+                            <label for="live-voice-style" style="font-size:0.85rem; font-weight:600;">Voice Style Prompt</label>
+                            <div style="font-size:0.8rem; color:var(--muted);">Extra instructions to shape how the model speaks (tone, pacing, personality). Leave empty for default.</div>
+                            <textarea id="live-voice-style" rows="3" style="width:100%; max-width:500px; padding:6px 10px; background:var(--background); color:var(--text); border:1px solid var(--border,#444); border-radius:6px; font-family:monospace; font-size:0.85rem; resize:vertical;"></textarea>
+                        </div>
+                    </div>
+                </div>
                 <div class="components-list" id="components-live-list"><div class="meta">Loading…</div></div>
             </div>
         </article>

--- a/core/webui_templates/sections/components.html
+++ b/core/webui_templates/sections/components.html
@@ -106,22 +106,64 @@
                             <label for="live-voice-name" style="font-size:0.85rem; font-weight:600;">Voice</label>
                             <div style="font-size:0.8rem; color:var(--muted);">Prebuilt voice for Gemini Live sessions.</div>
                             <select id="live-voice-name" style="padding:6px 10px; background:var(--background); color:var(--text); border:1px solid var(--primary); border-radius:6px; font-size:0.88rem; max-width:300px;">
-                                <option value="Aoede">Aoede — Breezy, natural</option>
-                                <option value="Puck">Puck — Upbeat, playful</option>
-                                <option value="Charon">Charon — Informational, calm</option>
-                                <option value="Kore">Kore — Firm, clear</option>
-                                <option value="Fenrir">Fenrir — Excitable</option>
-                                <option value="Orbit">Orbit — Easy-going</option>
-                                <option value="Zephyr">Zephyr — Bright</option>
-                                <option value="Leda">Leda — Youthful</option>
-                                <option value="Orus">Orus — Firm, deep</option>
-                                <option value="Autonoe">Autonoe — Bright, warm</option>
+                                <optgroup label="Female">
+                                    <option value="Aoede">Aoede — Breezy</option>
+                                    <option value="Kore">Kore — Firm</option>
+                                    <option value="Leda">Leda — Youthful</option>
+                                    <option value="Zephyr">Zephyr — Bright</option>
+                                    <option value="Autonoe">Autonoe — Bright</option>
+                                    <option value="Achernar">Achernar — Soft</option>
+                                    <option value="Callirrhoe">Callirrhoe — Easy-going</option>
+                                    <option value="Despina">Despina — Smooth</option>
+                                    <option value="Erinome">Erinome — Clear</option>
+                                    <option value="Gacrux">Gacrux — Mature</option>
+                                    <option value="Laomedeia">Laomedeia — Upbeat</option>
+                                    <option value="Pulcherrima">Pulcherrima — Forward</option>
+                                    <option value="Sulafat">Sulafat — Warm</option>
+                                    <option value="Vindemiatrix">Vindemiatrix — Gentle</option>
+                                </optgroup>
+                                <optgroup label="Male">
+                                    <option value="Puck">Puck — Upbeat</option>
+                                    <option value="Charon">Charon — Informative</option>
+                                    <option value="Fenrir">Fenrir — Excitable</option>
+                                    <option value="Orus">Orus — Firm</option>
+                                    <option value="Achird">Achird — Friendly</option>
+                                    <option value="Algenib">Algenib — Gravelly</option>
+                                    <option value="Algieba">Algieba — Smooth</option>
+                                    <option value="Alnilam">Alnilam — Firm</option>
+                                    <option value="Enceladus">Enceladus — Breathy</option>
+                                    <option value="Iapetus">Iapetus — Clear</option>
+                                    <option value="Rasalgethi">Rasalgethi — Informative</option>
+                                    <option value="Sadachbia">Sadachbia — Lively</option>
+                                    <option value="Sadaltager">Sadaltager — Knowledgeable</option>
+                                    <option value="Schedar">Schedar — Even</option>
+                                    <option value="Umbriel">Umbriel — Easy-going</option>
+                                    <option value="Zubenelgenubi">Zubenelgenubi — Casual</option>
+                                </optgroup>
                             </select>
                         </div>
                         <div style="display:flex; flex-direction:column; gap:3px;">
                             <label for="live-voice-style" style="font-size:0.85rem; font-weight:600;">Voice Style Prompt</label>
                             <div style="font-size:0.8rem; color:var(--muted);">Extra instructions to shape how the model speaks (tone, pacing, personality). Leave empty for default.</div>
                             <textarea id="live-voice-style" rows="3" style="width:100%; max-width:500px; padding:6px 10px; background:var(--background); color:var(--text); border:1px solid var(--border,#444); border-radius:6px; font-family:monospace; font-size:0.85rem; resize:vertical;"></textarea>
+                        </div>
+                        <div style="display:flex; flex-direction:column; gap:8px; margin-top:6px; padding-top:10px; border-top:1px solid var(--border,#333);">
+                            <div style="font-size:0.85rem; font-weight:600; color:var(--muted); text-transform:uppercase; letter-spacing:0.05em;">Session Features</div>
+                            <label style="display:flex; align-items:center; gap:8px; cursor:pointer;">
+                                <input type="checkbox" id="live-affective-dialog" style="width:16px; height:16px; cursor:pointer;">
+                                <span style="font-size:0.85rem; font-weight:600;">Affective Dialog</span>
+                            </label>
+                            <div style="font-size:0.8rem; color:var(--muted); margin-top:-4px;">Model adapts its tone and emotion to match the user's expression and speaking style.</div>
+                            <label style="display:flex; align-items:center; gap:8px; cursor:pointer;">
+                                <input type="checkbox" id="live-proactive-audio" style="width:16px; height:16px; cursor:pointer;">
+                                <span style="font-size:0.85rem; font-weight:600;">Proactive Audio</span>
+                            </label>
+                            <div style="font-size:0.8rem; color:var(--muted); margin-top:-4px;">Model can choose not to respond when audio content is not relevant (e.g. background noise).</div>
+                            <div style="display:flex; flex-direction:column; gap:3px; margin-top:4px;">
+                                <label for="live-thinking-budget" style="font-size:0.85rem; font-weight:600;">Thinking Budget</label>
+                                <div style="font-size:0.8rem; color:var(--muted);">Internal reasoning tokens before responding (0 = disabled, higher = smarter but slower). Recommended: 1024–2048.</div>
+                                <input type="number" id="live-thinking-budget" min="0" max="8192" step="128" value="0" style="padding:6px 10px; background:var(--background); color:var(--text); border:1px solid var(--border,#444); border-radius:6px; font-size:0.88rem; max-width:140px;">
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/cortex/live/gemini_live.py
+++ b/cortex/live/gemini_live.py
@@ -25,6 +25,8 @@ CAPABILITIES = {
     "low_latency": True,
 }
 
+ENGINE_LABEL = "Gemini Live (experimental bidirectional streaming)"
+
 
 class GeminiLivePlugin:
     display_name = "Gemini Live (Prototype)"

--- a/cortex/live/gemini_live.py
+++ b/cortex/live/gemini_live.py
@@ -31,8 +31,9 @@ ENGINE_LABEL = "Gemini Live (experimental bidirectional streaming)"
 class GeminiLivePlugin:
     display_name = "Gemini Live (Prototype)"
     # Maximum live session duration in seconds (declared, not exposed).
-    # LiveSessionManager reads this via reflection to schedule auto-rejoin.
-    MAX_SESSION_SECONDS: int = 900  # 15 minutes
+    # Google documents 15 min for audio-only, but empirically the server
+    # closes WebSocket connections at roughly 10 min (~600s).
+    MAX_SESSION_SECONDS: int = 600  # ~10 minutes (empirical)
 
     def __init__(self, notify_fn: object = None) -> None:
         # Internal data buffers — intentionally named *_buf (not *_queue) so that

--- a/cortex/llm_provider/gemini_api.py
+++ b/cortex/llm_provider/gemini_api.py
@@ -485,22 +485,18 @@ class GeminiAPIPlugin(AIPluginBase):
     # ------------------------------------------------------------------
 
     def get_live_session_manager(self) -> "LiveSessionManager | None":
-        """Return the LiveSessionManager instance, creating it lazily.
+        """Return the global LiveSessionManager singleton.
 
         Returns None if the google-genai SDK is unavailable or no API key is set.
+        Uses the singleton so all code paths (start, stop, is_session_active,
+        chat sync) share the same instance and session state.
         """
         if not _HAS_GENAI_SDK or not GEMINI_API_KEY:
             return None
 
-        if not hasattr(self, "_live_session_manager"):
-            from core.live_session_manager import LiveSessionManager
+        from core.live_session_manager import LiveSessionManager
 
-            self._live_session_manager = LiveSessionManager(
-                api_key=str(GEMINI_API_KEY).strip()
-            )
-            log_info("[gemini_api] LiveSessionManager created")
-
-        return self._live_session_manager
+        return LiveSessionManager.get_instance(api_key=str(GEMINI_API_KEY).strip())
 
     async def start_live_voice_session(
         self,

--- a/cortex/llm_provider/gemini_api.py
+++ b/cortex/llm_provider/gemini_api.py
@@ -1357,7 +1357,9 @@ class GeminiAPIPlugin(AIPluginBase):
 
         # Keys whose subtrees are schema definitions (not multimodal data)
         # and should be skipped during recursive attachment collection.
-        SCHEMA_ONLY_KEYS = {"actions", "available_actions", "schema", "payload"}
+        # NOTE: "payload" was removed — it caused the function to skip
+        # input.payload.attachments where the actual multimodal data lives.
+        SCHEMA_ONLY_KEYS = {"actions", "available_actions", "schema"}
 
         def collect_attachments_recursive(container: dict | list | str) -> None:
             """Recursively collect multimodal attachments from any level."""

--- a/cortex/llm_provider/openapi.py
+++ b/cortex/llm_provider/openapi.py
@@ -1359,6 +1359,9 @@ class OpenAPIPlugin(AIPluginBase):
             return parts
 
         multimodal_keys = {"attachments", "images", "audio", "documents", "videos"}
+        # Keys whose subtrees are action schema definitions (not multimodal
+        # data) and should be skipped during recursive attachment collection.
+        schema_only_keys = {"actions", "available_actions", "schema"}
         attachments: list[dict[str, Any]] = []
 
         def collect_recursive(container: Any) -> None:
@@ -1382,7 +1385,9 @@ class OpenAPIPlugin(AIPluginBase):
                                     )
                         elif isinstance(items, dict):
                             attachments.append(items)
-                for value in container.values():
+                for key, value in container.items():
+                    if key in schema_only_keys:
+                        continue
                     collect_recursive(value)
             elif isinstance(container, list):
                 for item in container:

--- a/cortex/llm_provider/openrouter.py
+++ b/cortex/llm_provider/openrouter.py
@@ -1277,6 +1277,9 @@ class OpenRouterPlugin(AIPluginBase):
             return parts
 
         multimodal_keys = {"attachments", "images", "audio", "documents", "videos"}
+        # Keys whose subtrees are action schema definitions (not multimodal
+        # data) and should be skipped during recursive attachment collection.
+        schema_only_keys = {"actions", "available_actions", "schema"}
         attachments: list[dict[str, Any]] = []
 
         def collect_recursive(container: Any) -> None:
@@ -1300,7 +1303,9 @@ class OpenRouterPlugin(AIPluginBase):
                                     )
                         elif isinstance(items, dict):
                             attachments.append(items)
-                for value in container.values():
+                for key, value in container.items():
+                    if key in schema_only_keys:
+                        continue
                     collect_recursive(value)
             elif isinstance(container, list):
                 for item in container:
@@ -1351,7 +1356,16 @@ class OpenRouterPlugin(AIPluginBase):
                         "image_url": {"url": f"data:{mime_type};base64,{b64_data}"},
                     }
                 )
-                log_debug(f"[openrouter] Added image part: {mime_type}")
+                # Log a short content hash so duplicate images can be diagnosed
+                import hashlib
+
+                _img_hash = hashlib.md5(
+                    b64_data[:512].encode(), usedforsecurity=False
+                ).hexdigest()[:10]
+                log_debug(
+                    f"[openrouter] Added image part: {mime_type} "
+                    f"len={len(b64_data)} hash={_img_hash}"
+                )
             else:
                 # Audio — OpenAI input_audio format
                 audio_fmt = _AUDIO_MIME_TYPES[mime_type]

--- a/interface/discord_interface.py
+++ b/interface/discord_interface.py
@@ -1371,10 +1371,23 @@ class DiscordInterface:
                     f"model={len(model_transcript)} chars"
                 )
 
+            async def on_reconnect_failed(gid: int) -> None:
+                """Called when all reconnect retries are exhausted.
+
+                Cleans up the Discord voice state so the user isn't stuck
+                with a zombie session that can never recover.
+                """
+                log_warning(
+                    f"[live_voice] Reconnect failed for guild {gid} — "
+                    "cleaning up voice state"
+                )
+                await self._stop_live_voice(gid)
+
             manager.set_audio_callback(on_audio_from_model)
             manager.set_text_callback(on_text_from_model)
             manager.set_tool_call_callback(on_tool_call)
             manager.set_turn_complete_callback(on_turn_complete)
+            manager.set_reconnect_failed_callback(on_reconnect_failed)
 
             # Start the Live API session
             started = await manager.start_session(
@@ -1413,6 +1426,13 @@ class DiscordInterface:
             # Activate per-path cortex routing for the live voice interface
             # path so that any message-chain activity on this path uses the
             # live engine rather than the global cortex.
+            #
+            # NOTE: We intentionally do NOT pass a rejoin_callback here.
+            # Session reconnection is handled at the Gemini API level by
+            # LiveSessionManager._reconnect() which fires proactively via
+            # should_reconnect (540s) and reactively on WebSocket errors.
+            # A Discord-level rejoin would race with the Gemini reconnect
+            # and cause cascading restarts.
             try:
                 from cortex.live.live_base import LiveSessionManager as _LSM
 

--- a/interface/discord_interface.py
+++ b/interface/discord_interface.py
@@ -23,8 +23,152 @@ except ImportError:
     voice_recv = None  # type: ignore[assignment]
     _HAS_VOICE_RECV = False
 
+import logging as _stdlib_logging
+
 from core.logging_utils import log_debug, log_error, log_info, log_warning
 from core.chat_attention import set_attention, evaluate_triggers
+
+# ── Route discord.ext.voice_recv logs into the synth logger ──────────────
+# voice_recv uses stdlib logging; without this its errors are invisible.
+if _HAS_VOICE_RECV:
+    _vr_logger = _stdlib_logging.getLogger("discord.ext.voice_recv")
+    _synth_logger = _stdlib_logging.getLogger("synth")
+    if _synth_logger.handlers and not _vr_logger.handlers:
+        for _h in _synth_logger.handlers:
+            _vr_logger.addHandler(_h)
+        _vr_logger.setLevel(_stdlib_logging.DEBUG)
+
+# ── Monkey-patch voice_recv internals to survive errors ──────────────────
+# voice_recv's internal Opus decoder produces far better audio than our own
+# (it has jitter buffer, FEC, PLC), but ANY unhandled exception in the
+# PacketRouter thread kills it permanently — no more audio is received.
+#
+# We patch two things:
+#   1. PacketDecoder._decode_packet — catch OpusError, return silence frame
+#   2. PacketRouter._do_run — catch exceptions per-iteration so one bad
+#      packet doesn't kill the whole thread
+if _HAS_VOICE_RECV and discord is not None:
+    from discord.ext.voice_recv.opus import PacketDecoder as _PacketDecoder
+    from discord.ext.voice_recv.router import PacketRouter as _PacketRouter
+
+    _vr_patch_log = _stdlib_logging.getLogger("discord.ext.voice_recv")
+
+    # --- DAVE (Discord Audio Visual Encryption) support ---
+    # voice_recv handles transport encryption (AEAD) but not DAVE E2EE.
+    # After AEAD decryption, packet.decrypted_data may still be DAVE-encrypted.
+    # We must DAVE-decrypt before Opus decode.
+    try:
+        import davey as _davey
+
+        _DAVE_MEDIA_AUDIO = _davey.MediaType.audio
+        _HAS_DAVEY = True
+    except ImportError:
+        _HAS_DAVEY = False
+
+    # --- Patch 1: _decode_packet with DAVE decryption + resilience ---
+    _orig_decode_packet = _PacketDecoder._decode_packet
+    _SILENCE_FRAME = b"\x00" * 3840  # 20ms of 48kHz stereo 16-bit silence
+    _decode_stats: dict[str, int] = {
+        "count": 0,
+        "errors": 0,
+        "dave_ok": 0,
+        "dave_fail": 0,
+    }
+
+    def _safe_decode_packet(
+        self: "_PacketDecoder", packet: "Any"
+    ) -> "tuple[Any, bytes]":
+        _decode_stats["count"] += 1
+
+        # --- DAVE decryption: unwrap E2EE before Opus decode ---
+        if _HAS_DAVEY and packet and getattr(packet, "decrypted_data", None):
+            dave_session = getattr(
+                getattr(self.sink, "voice_client", None),
+                "_connection",
+                None,
+            )
+            dave_session = getattr(dave_session, "dave_session", None)
+            user_id = self._cached_id
+            if dave_session is not None and user_id is not None:
+                try:
+                    packet.decrypted_data = dave_session.decrypt(
+                        user_id,
+                        _DAVE_MEDIA_AUDIO,
+                        bytes(packet.decrypted_data),
+                    )
+                    _decode_stats["dave_ok"] += 1
+                except Exception as dave_exc:
+                    _decode_stats["dave_fail"] += 1
+                    if _decode_stats["dave_fail"] <= 10:
+                        _vr_patch_log.warning(
+                            "[voice_recv] DAVE decrypt failed: %s: %s",
+                            type(dave_exc).__name__,
+                            dave_exc,
+                        )
+                    # Fall through — Opus decode will likely fail, PLC handles it
+
+        try:
+            return _orig_decode_packet(self, packet)
+        except Exception as exc:
+            _decode_stats["errors"] += 1
+            errs = _decode_stats["errors"]
+            if errs <= 5 or errs % 500 == 0:
+                _vr_patch_log.warning(
+                    "[voice_recv] Opus decode error #%d: %s: %s",
+                    errs,
+                    type(exc).__name__,
+                    exc,
+                )
+            # Use PLC instead of raw silence to maintain decoder state
+            try:
+                if self._decoder is not None:
+                    return packet, self._decoder.decode(None, fec=False)
+            except Exception:
+                pass
+            return packet, _SILENCE_FRAME
+
+    _PacketDecoder._decode_packet = _safe_decode_packet  # type: ignore[assignment]
+
+    # --- Patch 2: _do_run per-iteration resilience ---
+    def _resilient_do_run(self: "_PacketRouter") -> None:  # type: ignore[name-defined]
+        """Patched _do_run that catches exceptions per-iteration.
+
+        The original exits on ANY exception, permanently killing audio
+        receive.  This version logs and continues.
+        """
+        _consecutive_errors = 0
+        while not self._end_thread.is_set():
+            try:
+                self.waiter.wait()
+                with self._lock:
+                    for decoder in self.waiter.items:
+                        try:
+                            data = decoder.pop_data()
+                            if data is not None:
+                                self.sink.write(data.source, data)
+                        except Exception:
+                            _consecutive_errors += 1
+                            if (
+                                _consecutive_errors <= 5
+                                or _consecutive_errors % 100 == 0
+                            ):
+                                _vr_patch_log.warning(
+                                    "[voice_recv] Error #%d in decode/write, continuing",
+                                    _consecutive_errors,
+                                    exc_info=True,
+                                )
+            except Exception:
+                _consecutive_errors += 1
+                if _consecutive_errors <= 5 or _consecutive_errors % 100 == 0:
+                    _vr_patch_log.warning(
+                        "[voice_recv] Error #%d in router loop, continuing",
+                        _consecutive_errors,
+                        exc_info=True,
+                    )
+            else:
+                _consecutive_errors = 0
+
+    _PacketRouter._do_run = _resilient_do_run  # type: ignore[assignment]
 from core.transport_layer import universal_send
 from core.core_initializer import register_interface
 from core.command_registry import execute_command, handle_command_message, list_commands
@@ -633,22 +777,15 @@ class DiscordInterface:
             return {
                 "description": "Join a Discord voice channel, optionally starting a live voice session.",
                 "payload": {
-                    "channel_id": {
-                        "type": "string",
-                        "example": "123456789",
-                        "description": "The ID of the voice channel to join. If the sender is in a voice channel, use input.payload.source.voice_channel_id. Otherwise derive from interface_path or omit to auto-resolve.",
-                        "optional": True,
-                    },
                     "interface_path": {
                         "type": "string",
                         "example": "discord_bot/1234567890/9876543210",
-                        "description": "Optional interface path to derive guild/channel.",
-                        "optional": True,
+                        "description": "REQUIRED. Use the exact interface_path from input.payload.source.interface_path.",
                     },
                 },
                 "important_notes": [
-                    "If the sender is currently in a voice channel, their voice_channel_id is available in input.payload.source.voice_channel_id — use it as channel_id.",
-                    "If voice_channel_id is not available and no channel_id is known, omit channel_id and the system will attempt auto-resolve.",
+                    "IMPORTANT: Do NOT provide channel_id parameter - the system will automatically detect which voice channel the sender is in.",
+                    "Simply provide interface_path only from input.payload.source.interface_path",
                 ],
             }
         if action_name == "leave_voice_discord":
@@ -944,12 +1081,22 @@ class DiscordInterface:
     # Gemini Live API voice session management
     # ------------------------------------------------------------------
 
-    async def _start_live_voice(self, channel_id: str | int) -> dict[str, str]:
+    async def _start_live_voice(
+        self,
+        channel_id: str | int,
+        attachments: list[Any] | None = None,
+    ) -> dict[str, str]:
         """Start a Gemini Live API voice session in a Discord voice channel.
 
         Joins the voice channel (using VoiceRecvClient if available for
         audio reception), starts a Live API WebSocket session with the
         current persona, and begins bidirectional audio streaming.
+
+        Args:
+            channel_id: The voice channel to join.
+            attachments: Optional list of Discord attachment objects from the
+                triggering message.  Text files are injected as context
+                updates; images/PDFs use multimodal injection.
         """
         if not self.client:
             return {"status": "failed", "message": "Discord client not initialized"}
@@ -1041,15 +1188,96 @@ class DiscordInterface:
                     await vc.move_to(channel)
                 # If already connected but not a VoiceRecvClient, reconnect
                 if not isinstance(vc, voice_recv.VoiceRecvClient):
+                    log_info(
+                        f"[live_voice] Existing vc is {type(vc).__name__}, not VoiceRecvClient - reconnecting"
+                    )
                     await vc.disconnect()
                     vc = await channel.connect(cls=voice_recv.VoiceRecvClient)
             else:
                 vc = await channel.connect(cls=voice_recv.VoiceRecvClient)
 
+            log_info(
+                f"[live_voice] Voice client connected: type={type(vc).__name__}, "
+                f"is_connected={vc.is_connected()}, channel={vc.channel.name}"
+            )
+
+            # Extract text from attachments BEFORE building the system
+            # instruction so document content is embedded in the core prompt
+            # (survives reconnects and is strongly attended to by the model).
+            _attachment_context_parts: list[str] = []
+            if attachments:
+                _DECODABLE_PREFIXES = (
+                    "text/",
+                    "application/json",
+                    "application/xml",
+                    "application/javascript",
+                )
+                _TEXT_EXTENSIONS = (
+                    ".txt",
+                    ".md",
+                    ".csv",
+                    ".log",
+                    ".json",
+                    ".xml",
+                    ".yaml",
+                    ".yml",
+                    ".toml",
+                    ".ini",
+                    ".cfg",
+                    ".conf",
+                    ".py",
+                    ".js",
+                    ".ts",
+                    ".html",
+                    ".css",
+                    ".sh",
+                    ".bat",
+                    ".rst",
+                    ".tex",
+                )
+                for att in attachments:
+                    mime = getattr(att, "content_type", "") or ""
+                    fname = getattr(att, "filename", "document")
+                    is_decodable = any(mime.startswith(p) for p in _DECODABLE_PREFIXES)
+                    if not is_decodable and fname:
+                        is_decodable = any(
+                            fname.lower().endswith(ext) for ext in _TEXT_EXTENSIONS
+                        )
+                    if not is_decodable:
+                        log_info(
+                            f"[live_voice] Skipping non-text attachment '{fname}' "
+                            f"({mime}) — Live API only supports text context"
+                        )
+                        continue
+                    try:
+                        raw = await att.read()
+                        doc_text = raw.decode("utf-8", errors="replace")
+                        if len(doc_text) > 50000:
+                            doc_text = doc_text[:50000] + "\n[... truncated]"
+                        _attachment_context_parts.append(
+                            f"=== Document: {fname} ===\n{doc_text}"
+                        )
+                        log_info(
+                            f"[live_voice] Extracted text from '{fname}' "
+                            f"({len(doc_text)} chars) for system instruction"
+                        )
+                    except Exception as _att_err:
+                        log_warning(
+                            f"[live_voice] Failed to read attachment '{fname}': {_att_err}"
+                        )
+
+            _attachment_context: str | None = (
+                "\n\n".join(_attachment_context_parts)
+                if _attachment_context_parts
+                else None
+            )
+
             # Build persona system instruction
             from core.prompt_engine import build_live_system_instruction
 
-            system_instruction = await build_live_system_instruction()
+            system_instruction = await build_live_system_instruction(
+                attachment_context=_attachment_context,
+            )
 
             # Build Gemini function declarations from the SyntH action registry
             tools = _build_gemini_tool_declarations()
@@ -1105,7 +1333,8 @@ class DiscordInterface:
                     await save_chat_message(
                         interface_path=live_interface_path,
                         message_text=model_transcript,
-                        sender_name="Synth",
+                        sender_name="self",
+                        sender_id="self",
                     )
 
                 # Track turn count for diagnostics.
@@ -1153,6 +1382,7 @@ class DiscordInterface:
                 channel_id=channel.id,
                 system_instruction=system_instruction,
                 tools=tools,
+                attachment_context=_attachment_context,
             )
             if not started:
                 return {
@@ -1167,8 +1397,18 @@ class DiscordInterface:
             vc.play(source)
 
             # Start listening to Discord voice → forward to Live API
-            sink = LiveVoiceAudioSink(manager, guild_id)
+            sink = LiveVoiceAudioSink(
+                manager, guild_id, self.client.loop, playback_buffer=audio_buffer
+            )
+            log_info(
+                f"[live_voice] Starting vc.listen() with sink={sink}, "
+                f"vc={vc}, vc.is_listening()={getattr(vc, 'is_listening', lambda: 'N/A')()}"
+            )
             vc.listen(sink)
+            log_info(
+                f"[live_voice] vc.listen() completed, "
+                f"vc.is_listening()={getattr(vc, 'is_listening', lambda: 'N/A')()}"
+            )
 
             # Activate per-path cortex routing for the live voice interface
             # path so that any message-chain activity on this path uses the
@@ -1195,6 +1435,21 @@ class DiscordInterface:
                 "live_engine": _live_capable_engine,
                 "interface_path": live_interface_path,
             }
+
+            # Start a watchdog that re-creates the listening sink if the
+            # PacketRouter thread dies unexpectedly.  The voice_recv library
+            # tears down listening on *any* unhandled exception in its
+            # background threads, so we need to be ready to restart.
+            asyncio.create_task(
+                self._listen_watchdog(guild_id, vc, manager),
+                name=f"listen_watchdog_{guild_id}",
+            )
+
+            # Store attachment context for reconnects
+            if _attachment_context:
+                self._live_voice_state[guild_id]["attachment_context"] = (
+                    _attachment_context
+                )
 
             log_info(
                 f"[discord_interface] Live voice session started in "
@@ -1265,6 +1520,81 @@ class DiscordInterface:
         except Exception as e:
             log_error(f"[discord_interface] Failed to stop live voice: {e}")
             return {"status": "failed", "message": str(e)}
+
+    async def _listen_watchdog(
+        self,
+        guild_id: int,
+        vc: Any,
+        manager: Any,
+    ) -> None:
+        """Background task: monitor ``vc.is_listening()`` and restart if it drops.
+
+        The voice_recv PacketRouter thread tears down listening on *any*
+        unhandled exception (e.g. Opus decode error, threading race).  This
+        watchdog detects the drop and re-creates the sink so audio reception
+        continues.
+
+        Args:
+            guild_id: Guild whose voice session to monitor.
+            vc: The VoiceRecvClient instance.
+            manager: The LiveSessionManager forwarding audio to Gemini.
+        """
+        _POLL_INTERVAL = 2.0  # seconds between checks
+        _restart_count = 0
+        _MAX_RESTARTS = 10
+        try:
+            while True:
+                await asyncio.sleep(_POLL_INTERVAL)
+
+                # Check if the live session is still active
+                state = getattr(self, "_live_voice_state", {}).get(guild_id)
+                if not state:
+                    log_debug(
+                        f"[listen_watchdog] Guild {guild_id} no longer has "
+                        "live state — exiting watchdog"
+                    )
+                    return
+
+                if not vc.is_connected():
+                    log_debug(
+                        f"[listen_watchdog] VC disconnected for guild "
+                        f"{guild_id} — exiting watchdog"
+                    )
+                    return
+
+                is_listening = getattr(vc, "is_listening", lambda: False)()
+                if is_listening:
+                    continue  # all good
+
+                # Listening stopped unexpectedly — restart
+                _restart_count += 1
+                if _restart_count > _MAX_RESTARTS:
+                    log_warning(
+                        f"[listen_watchdog] Too many restarts ({_restart_count}) "
+                        f"for guild {guild_id} — giving up"
+                    )
+                    return
+
+                log_warning(
+                    f"[listen_watchdog] Listening dropped for guild {guild_id} "
+                    f"(restart #{_restart_count}), re-creating sink"
+                )
+                try:
+                    new_sink = LiveVoiceAudioSink(manager, guild_id, self.client.loop)
+                    vc.listen(new_sink)
+                    state["sink"] = new_sink
+                    log_info(
+                        f"[listen_watchdog] Successfully restarted listening "
+                        f"for guild {guild_id}"
+                    )
+                except Exception as e:
+                    log_warning(
+                        f"[listen_watchdog] Failed to restart listening "
+                        f"for guild {guild_id}: {e}"
+                    )
+                    await asyncio.sleep(2.0)  # back off before next attempt
+        except asyncio.CancelledError:
+            log_debug(f"[listen_watchdog] Cancelled for guild {guild_id}")
 
     async def _handle_voice_state_update(
         self,
@@ -1923,26 +2253,66 @@ class DiscordInterface:
                     if live_mgr and live_mgr.is_session_active(guild_id):
                         text = content
 
-                        # --- inject text-based file attachments as context ---
-                        _TEXT_MIME_PREFIXES = (
+                        # --- inject text-decodable file attachments as context ---
+                        # Live API only supports text; binary files (images,
+                        # PDFs) cannot be sent as inline_data.
+                        _DECODABLE_PREFIXES = (
                             "text/",
                             "application/json",
                             "application/xml",
+                            "application/javascript",
+                        )
+                        _TEXT_EXTENSIONS = (
+                            ".txt",
+                            ".md",
+                            ".csv",
+                            ".log",
+                            ".json",
+                            ".xml",
+                            ".yaml",
+                            ".yml",
+                            ".toml",
+                            ".ini",
+                            ".cfg",
+                            ".conf",
+                            ".py",
+                            ".js",
+                            ".ts",
+                            ".html",
+                            ".css",
+                            ".sh",
+                            ".bat",
+                            ".rst",
+                            ".tex",
                         )
                         for att in getattr(message, "attachments", []):
                             mime = getattr(att, "content_type", "") or ""
-                            if not any(mime.startswith(p) for p in _TEXT_MIME_PREFIXES):
+                            fname = getattr(att, "filename", "document")
+                            _is_decodable = any(
+                                mime.startswith(p) for p in _DECODABLE_PREFIXES
+                            )
+                            if not _is_decodable and fname:
+                                _is_decodable = any(
+                                    fname.lower().endswith(ext)
+                                    for ext in _TEXT_EXTENSIONS
+                                )
+                            if not _is_decodable:
+                                log_info(
+                                    f"[discord_interface] Skipping non-text attachment "
+                                    f"'{fname}' ({mime}) — Live API text-only"
+                                )
                                 continue
                             try:
                                 raw = await att.read()
                                 doc_text = raw.decode("utf-8", errors="replace")
-                                fname = getattr(att, "filename", "document")
+                                if len(doc_text) > 50000:
+                                    doc_text = doc_text[:50000] + "\n[... truncated]"
                                 await live_mgr.send_context_update(
                                     guild_id,
                                     f"[Document: {fname}]\n{doc_text}",
                                 )
                                 log_info(
-                                    f"[discord_interface] Injected attachment "
+                                    f"[discord_interface] Injected text attachment "
                                     f"'{fname}' ({len(doc_text)} chars) into "
                                     f"live session for guild {guild_id}"
                                 )
@@ -1952,8 +2322,16 @@ class DiscordInterface:
                                     f"attachment into live session: {_att_err}"
                                 )
 
-                        # forward into live model
-                        await live_mgr.send_text(guild_id, text)
+                        # Forward into live model as a context update (system
+                        # role, turn_complete=False) so the model internalises
+                        # the text without generating an audio response for it.
+                        sender = getattr(
+                            message.author, "display_name", None
+                        ) or getattr(message.author, "name", "unknown")
+                        await live_mgr.send_context_update(
+                            guild_id,
+                            f"[Text chat] {sender}: {text}",
+                        )
                         # replicate in history cache
                         await save_chat_message(
                             interface_path=f"discord_live_{guild_id}",
@@ -2053,6 +2431,46 @@ class DiscordInterface:
             channel_id = payload.get("channel_id")
             # note: start_live_voice flag removed – live sessions must be started
             # explicitly via a dedicated action (`start_live_voice_discord`).
+
+            # Validate channel_id: if it looks like a guild ID instead of a channel ID,
+            # clear it so auto-resolution can find the correct voice channel.
+            if channel_id:
+                interface_path = payload.get("interface_path") or context.get(
+                    "interface_path"
+                )
+                if interface_path:
+                    from core.interface_path_utils import parse_interface_path
+
+                    _, levels = parse_interface_path(interface_path)
+                    if levels and str(channel_id) == str(levels[0]):
+                        # channel_id matches guild_id - LLM likely confused them
+                        log_warning(
+                            f"[discord_interface] join_voice_discord: channel_id {channel_id} "
+                            f"matches guild_id from interface_path - ignoring and using auto-resolve"
+                        )
+                        channel_id = None
+
+            # Validate channel_id: if it resolves to a text channel, clear it so
+            # auto-resolution picks the correct voice channel instead.
+            if channel_id and self.client and discord is not None:
+                try:
+                    _ch = self.client.get_channel(int(channel_id))
+                    if _ch is not None and isinstance(
+                        _ch,
+                        (
+                            discord.TextChannel,
+                            discord.ForumChannel,
+                            discord.CategoryChannel,
+                        ),
+                    ):
+                        log_warning(
+                            f"[discord_interface] join_voice_discord: channel_id {channel_id} "
+                            f"resolved to {type(_ch).__name__}, not a voice channel "
+                            f"- ignoring and using auto-resolve"
+                        )
+                        channel_id = None
+                except (ValueError, TypeError):
+                    pass
 
             # Gate: LIVE_TRAINER_ONLY_VOICE — only the trainer may request a voice join
             try:
@@ -2232,7 +2650,10 @@ class DiscordInterface:
                                 f"in channel {getattr(vc_channel, 'id', channel_id)} — auto-starting live session"
                             )
                             live_result = await self._start_live_voice(
-                                getattr(vc_channel, "id", channel_id)
+                                getattr(vc_channel, "id", channel_id),
+                                attachments=getattr(
+                                    original_message, "attachments", None
+                                ),
                             )
                             if live_result and live_result.get("status") == "failed":
                                 log_warning(
@@ -2582,6 +3003,9 @@ class LiveAudioBuffer:
         self._lock = threading.Lock()
         self._closed = False
         self._ratecv_state: Any = None  # audioop ratecv state for continuity
+        self._last_nonempty_read: float = (
+            0.0  # monotonic timestamp of last real audio read
+        )
 
     def write(self, pcm_24k_mono: bytes) -> None:
         """Write 24kHz mono PCM data, converting to 48kHz stereo."""
@@ -2613,6 +3037,7 @@ class LiveAudioBuffer:
             data = b"".join(self._chunks)
             self._chunks.clear()
 
+        self._last_nonempty_read = time.monotonic()
         if len(data) <= nbytes:
             return data
         # Return requested amount, put remainder back
@@ -2620,6 +3045,21 @@ class LiveAudioBuffer:
         with self._lock:
             self._chunks.insert(0, data[nbytes:])
         return result
+
+    def is_speaking(self, cooldown: float = 0.5) -> bool:
+        """Return True if the buffer recently delivered real audio.
+
+        Used by the voice sink to suppress echo — incoming audio is
+        likely acoustic feedback while the bot is speaking.
+
+        Args:
+            cooldown: seconds after last real audio read to still
+                      consider the bot "speaking" (accounts for
+                      propagation delay and mic tail).
+        """
+        if self._chunks:
+            return True
+        return (time.monotonic() - self._last_nonempty_read) < cooldown
 
     def close(self) -> None:
         self._closed = True
@@ -2663,29 +3103,50 @@ if _HAS_VOICE_RECV and voice_recv is not None:
     class LiveVoiceAudioSink(voice_recv.AudioSink):  # type: ignore[misc]
         """AudioSink that forwards received Discord voice audio to Gemini Live API.
 
-        Receives 48kHz stereo 16-bit PCM from Discord, converts to 16kHz mono,
-        and sends to the Live API session.
+        Uses voice_recv's internal Opus decoder (with jitter buffer, FEC, and
+        PLC) for high-quality PCM output.  The monkey-patched
+        ``_decode_packet`` prevents ``OpusError`` from crashing the
+        packet-router thread.
 
         NOTE: The ``write`` callback runs on the voice_recv packet-router thread,
         **not** the asyncio event loop thread.  We capture the running loop at
         init time and use ``call_soon_threadsafe`` to schedule coroutines.
         """
 
-        def __init__(self, manager: Any, guild_id: int) -> None:
+        def __init__(
+            self,
+            manager: Any,
+            guild_id: int,
+            loop: asyncio.AbstractEventLoop,
+            playback_buffer: LiveAudioBuffer | None = None,
+        ) -> None:
             super().__init__()
             self._manager = manager
             self._guild_id = guild_id
-            # Capture the running event loop from the main thread at construction time
-            self._loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+            # Use the long-lived discord client event loop so we don't grab a short-lived task loop
+            self._loop: asyncio.AbstractEventLoop = loop
             self._packet_count: int = 0
+            self._suppressed_count: int = 0
             self._ratecv_state: Any = None  # preserve resampler state across packets
+            # Reference to the outgoing audio buffer for echo suppression.
+            self._playback_buffer: LiveAudioBuffer | None = playback_buffer
+            # Startup grace period: drop the first ~1s of audio while the
+            # codec, jitter buffer, and DAVE key exchange settle.  At 50
+            # packets/sec (20ms each) that's 50 packets ≈ 1 second.
+            self._startup_grace: int = 50
             # Track the last real user who sent audio so on_turn_complete can
             # attribute the user-side transcript to the correct Discord account.
             self._last_speaker_name: str | None = None
             self._last_speaker_id: str | None = None
 
         def wants_opus(self) -> bool:
-            return False  # We want decoded PCM
+            """Return False so voice_recv decodes Opus internally.
+
+            voice_recv's decoder has jitter buffer, FEC, and PLC for much
+            better audio quality.  The monkey-patched ``_decode_packet``
+            prevents OpusError from crashing the PacketRouter thread.
+            """
+            return False
 
         def write(self, user: Any, data: voice_recv.VoiceData) -> None:  # type: ignore[name-defined]
             """Process incoming audio from a Discord user.
@@ -2695,15 +3156,42 @@ if _HAS_VOICE_RECV and voice_recv is not None:
 
             Args:
                 user: The Discord user who spoke. May be None for unmapped SSRCs.
-                data: VoiceData containing PCM audio bytes.
+                data: VoiceData containing decoded 48kHz stereo PCM audio.
             """
-            # Skip packets with an unmapped SSRC (user is None) — these are
-            # typically the bot's own audio stream reflected by Discord's voice
-            # server, or early packets before the SSRC→user mapping is ready.
-            # Also skip any bot user (including ourselves) to prevent audio
-            # feedback where Gemini hears its own output and loops on it.
-            if user is None or getattr(user, "bot", False):
+            if user is None:
                 return
+            if getattr(user, "bot", False):
+                return
+
+            # Startup grace: drop early packets while codec/DAVE settle.
+            if self._startup_grace > 0:
+                self._startup_grace -= 1
+                if self._startup_grace == 0:
+                    log_info(
+                        "[live_voice_sink] Startup grace period ended, forwarding audio"
+                    )
+                return
+
+            # Echo suppression: drop incoming audio while the bot is
+            # playing back Gemini responses (+ 0.5s cooldown).  The
+            # user's mic picks up the bot's output and feeds it back,
+            # creating an infinite conversation loop.
+            if self._playback_buffer and self._playback_buffer.is_speaking():
+                self._suppressed_count += 1
+                if (
+                    self._suppressed_count in (1, 100)
+                    or self._suppressed_count % 1000 == 0
+                ):
+                    log_debug(
+                        f"[live_voice_sink] Echo-suppressed {self._suppressed_count} packets"
+                    )
+                return
+
+            if self._suppressed_count > 0:
+                log_debug(
+                    f"[live_voice_sink] Echo suppression ended after {self._suppressed_count} packets"
+                )
+                self._suppressed_count = 0
 
             pcm_48k_stereo = data.pcm
             if not pcm_48k_stereo:
@@ -2718,35 +3206,113 @@ if _HAS_VOICE_RECV and voice_recv is not None:
             self._last_speaker_id = str(getattr(user, "id", ""))
 
             self._packet_count += 1
-            # Log first packet and then every 500 packets (~10s at 50pps)
             if self._packet_count == 1 or self._packet_count % 500 == 0:
                 log_info(
                     f"[live_voice_sink] Received packet #{self._packet_count} "
-                    f"from user {user}, {len(pcm_48k_stereo)} bytes"
+                    f"from user {user}, {len(pcm_48k_stereo)} bytes PCM"
                 )
 
             try:
-                # Stereo → Mono (mix down)
-                mono = audioop.tomono(pcm_48k_stereo, _DISCORD_SAMPLE_WIDTH, 0.5, 0.5)
-                # 48kHz → 16kHz (ratio 3:1)
-                downsampled, self._ratecv_state = audioop.ratecv(
+                # Need at least one stereo sample (L+R = 4 bytes)
+                if len(pcm_48k_stereo) < 4:
+                    return
+
+                # voice_recv Opus decoder ALWAYS outputs stereo
+                # (CHANNELS=2), but frame duration varies (5-60ms),
+                # so packet sizes range from 960 to 11520 bytes.
+                # Extract left channel — speech lives there;
+                # right channel may carry DC-offset decoder artifacts.
+                mono = audioop.tomono(pcm_48k_stereo, _DISCORD_SAMPLE_WIDTH, 1, 0)
+                rms_mono = audioop.rms(mono, _DISCORD_SAMPLE_WIDTH)
+
+                if self._packet_count <= 10:
+                    log_info(
+                        f"[live_voice_sink] Audio pkt #{self._packet_count}: "
+                        f"in={len(pcm_48k_stereo)}B "
+                        f"mono={len(mono)}B rms={rms_mono}"
+                    )
+
+                # ── Diagnostics: save each pipeline stage to WAV ──
+                if not hasattr(self, "_diag_stereo"):
+                    import wave as _wave
+
+                    self._diag_stereo = _wave.open("logs/voice_1_stereo.wav", "wb")
+                    self._diag_stereo.setnchannels(2)
+                    self._diag_stereo.setsampwidth(_DISCORD_SAMPLE_WIDTH)
+                    self._diag_stereo.setframerate(_DISCORD_RATE)
+
+                    self._diag_left = _wave.open("logs/voice_2_left.wav", "wb")
+                    self._diag_left.setnchannels(1)
+                    self._diag_left.setsampwidth(_DISCORD_SAMPLE_WIDTH)
+                    self._diag_left.setframerate(_DISCORD_RATE)
+
+                    self._diag_right = _wave.open("logs/voice_3_right.wav", "wb")
+                    self._diag_right.setnchannels(1)
+                    self._diag_right.setsampwidth(_DISCORD_SAMPLE_WIDTH)
+                    self._diag_right.setframerate(_DISCORD_RATE)
+
+                    self._diag_16k = _wave.open("logs/voice_4_16khz.wav", "wb")
+                    self._diag_16k.setnchannels(1)
+                    self._diag_16k.setsampwidth(_DISCORD_SAMPLE_WIDTH)
+                    self._diag_16k.setframerate(_GEMINI_INPUT_RATE)
+
+                    self._diag_count = 0
+                    log_info(
+                        "[live_voice_sink] Saving diagnostic WAVs to logs/voice_*.wav"
+                    )
+
+                if self._diag_stereo is not None:
+                    self._diag_stereo.writeframes(pcm_48k_stereo)
+                    self._diag_left.writeframes(mono)
+                    right = audioop.tomono(pcm_48k_stereo, _DISCORD_SAMPLE_WIDTH, 0, 1)
+                    self._diag_right.writeframes(right)
+
+                if rms_mono == 0:
+                    # Pure silence — don't waste bandwidth
+                    return
+
+                # Downsample 48kHz → 16kHz for Gemini Live API input.
+                resampled, self._ratecv_state = audioop.ratecv(
                     mono,
                     _DISCORD_SAMPLE_WIDTH,
-                    1,
+                    1,  # mono
                     _DISCORD_RATE,
                     _GEMINI_INPUT_RATE,
                     self._ratecv_state,
                 )
-                # Schedule on the main event loop (thread-safe)
+
+                # Write resampled to diagnostic WAV
+                if self._diag_stereo is not None:
+                    self._diag_16k.writeframes(resampled)
+                    self._diag_count += 1
+                    if self._diag_count >= 500:
+                        for f in (
+                            self._diag_stereo,
+                            self._diag_left,
+                            self._diag_right,
+                            self._diag_16k,
+                        ):
+                            f.close()
+                        self._diag_stereo = None
+                        log_info("[live_voice_sink] Diagnostic WAVs saved")
+
                 asyncio.run_coroutine_threadsafe(
-                    self._manager.send_audio(self._guild_id, downsampled),
+                    self._manager.send_audio(self._guild_id, resampled),
                     self._loop,
                 )
+
             except Exception as e:
                 log_warning(f"[live_voice_sink] Audio processing failed: {e}")
 
         def cleanup(self) -> None:
-            pass
+            """Clean up when sink is stopped."""
+            import traceback
+
+            log_warning(
+                f"[live_voice_sink] Sink cleanup for guild {self._guild_id} "
+                f"(packets received: {self._packet_count})\n"
+                f"Call stack:\n{''.join(traceback.format_stack())}"
+            )
 
 
 else:

--- a/plugins/emotion_manager.py
+++ b/plugins/emotion_manager.py
@@ -12,6 +12,7 @@ This core plugin manages the digital persona's emotional state with:
 
 import json
 import math
+import re
 import asyncio
 from datetime import datetime
 from typing import Any, Dict, Optional, Tuple
@@ -72,6 +73,28 @@ EMOTION_SYNONYMS = {
     "worship": "devotion",
     "dedication": "devotion",
 }
+
+
+# ---------------------------------------------------------------------------
+# Emotion tag regex — matches {happy 8.5} or {happy 8.5, love 5.0, sad 2}
+# Does NOT match JSON, code blocks, or other {…} content.
+# ---------------------------------------------------------------------------
+_EMOTION_TAG_RE = re.compile(
+    r"\s*\{\s*(?:\w+\s+-?\d+(?:\.\d+)?)(?:\s*,\s*\w+\s+-?\d+(?:\.\d+)?)*\s*\}"
+)
+
+
+def strip_emotion_tags(text: str) -> str:
+    """Remove emotion tags like ``{happy 8.5, love 5.0}`` from *text*.
+
+    Uses a targeted regex that only matches the ``{word number, …}`` pattern
+    so JSON, code blocks, and other brace-delimited content are left intact.
+    """
+    if not text:
+        return text
+    cleaned = _EMOTION_TAG_RE.sub("", text)
+    cleaned = re.sub(r" {2,}", " ", cleaned).strip()
+    return cleaned
 
 
 def normalize_emotion_name(name: str) -> str | None:

--- a/plugins/grillo/grillo_outreach.py
+++ b/plugins/grillo/grillo_outreach.py
@@ -227,6 +227,14 @@ class GrilloOutreachPlugin:
             for chat_id in last_chats:
                 chat_path = recent_chats.get_chat_path(chat_id)
                 if chat_path:
+                    # Skip live voice paths — they are audio-only sessions
+                    # and cannot receive text outreach messages.
+                    if "_live_" in chat_path:
+                        log_debug(
+                            f"[grillo_outreach] Skipping live voice path: {chat_path}"
+                        )
+                        continue
+
                     # chat_path format is "interface_name/chat_id" or "interface_name/chat_id/thread_id"
                     parts = chat_path.split("/")
                     if len(parts) >= 2:

--- a/plugins/message_plugin.py
+++ b/plugins/message_plugin.py
@@ -160,10 +160,20 @@ class MessagePlugin:
                 rebuilt_interface_path = f"{interface_name}/{target}"
 
         # --- Grillo Suppression Logic ---
-        if isinstance(context, dict) and (
-            context.get("grillo_beat")
-            or context.get("activity_log_id")
-            or context.get("grillo_activity_log_id")
+        # Outreach beats are EXEMPT from suppression: their purpose is to
+        # initiate conversation, so silencing them defeats the feature.
+        is_outreach = (
+            isinstance(context, dict) and context.get("beat_type") == "outreach"
+        )
+
+        if (
+            not is_outreach
+            and isinstance(context, dict)
+            and (
+                context.get("grillo_beat")
+                or context.get("activity_log_id")
+                or context.get("grillo_activity_log_id")
+            )
         ):
             try:
                 suppress_enabled = config_registry.get_value(
@@ -204,7 +214,7 @@ class MessagePlugin:
                         try:
                             if int(target) < 0:
                                 is_public = True
-                        except:
+                        except Exception:
                             pass
                     elif (
                         interface_name

--- a/plugins/recon_language_evaluator.py
+++ b/plugins/recon_language_evaluator.py
@@ -170,7 +170,9 @@ class ReconLanguageEvaluatorPlugin:
 
         system_prompt = (
             "This is a Recon prompt, please execute what is requested below:\n"
-            "- Detect the primary language of the conversation.\n"            "- When determining language, treat the incoming message with weight 3, any response message (if present) with weight 1, and the local history with weight 1.\n"            "Use ONLY the user message and recent history from the same interface path.\n"
+            "- Detect the primary language of the conversation.\n"
+            "- When determining language, treat the incoming message with weight 3, any response message (if present) with weight 1, and the local history with weight 1.\n"
+            "Use ONLY the user message and recent history from the same interface path.\n"
             "Do NOT consider global chat or any other interface history when choosing the language.\n"
             'Return ONLY valid JSON: {"language_code":"it"}.\n'
             "Use BCP-47 language codes (e.g., en, it, es, fr)."
@@ -235,8 +237,8 @@ class ReconLanguageEvaluatorPlugin:
                     if hist_lines and engine:
                         history_prompt = "\n".join(hist_lines)
                         user_prompt = (
-                            f'Chat history for {interface_path}:\n{history_prompt}\n\n'
-                            "Detect the primary language of the conversation and return ONLY valid JSON: {\"language_code\": \"xx\"}. "
+                            f"Chat history for {interface_path}:\n{history_prompt}\n\n"
+                            'Detect the primary language of the conversation and return ONLY valid JSON: {"language_code": "xx"}. '
                             "When determining language, weight the incoming message 3, any response 1, and the history 1."
                         )
                         try:

--- a/res/synth_webui/js/main.js
+++ b/res/synth_webui/js/main.js
@@ -2947,6 +2947,68 @@ function pickAccentDarkFromHex(hex) { return darkenHex(hex, 0.28); }
                     setupRegistrySelect('auris-engine-select','auris-engine-info','auris-engine-label','auris-engine-description', data.auris || [], 'ACTIVE_AURIS_ENGINE');
                     setupRegistrySelect('live-engine-select', 'live-engine-info', 'live-engine-label', 'live-engine-description',  data.live || [], 'LIVE_CORTEX');  // persist selected live engine via LIVE_CORTEX config
 
+                    // ── Live voice configuration ──────────────────────────────
+                    const liveVoiceCfg = document.getElementById('live-voice-config');
+                    const liveVoiceNameSel = document.getElementById('live-voice-name');
+                    const liveVoiceStyleTa = document.getElementById('live-voice-style');
+                    const liveEngineSel = document.getElementById('live-engine-select');
+
+                    function updateLiveVoiceVisibility() {
+                        if (!liveVoiceCfg || !liveEngineSel) return;
+                        liveVoiceCfg.style.display = (liveEngineSel.value && liveEngineSel.value !== 'disabled') ? '' : 'none';
+                    }
+                    updateLiveVoiceVisibility();
+                    if (liveEngineSel && !liveEngineSel.dataset.liveVoiceBound) {
+                        liveEngineSel.addEventListener('change', updateLiveVoiceVisibility);
+                        liveEngineSel.dataset.liveVoiceBound = '1';
+                    }
+
+                    // Load current values from config
+                    if (liveVoiceNameSel || liveVoiceStyleTa) {
+                        try {
+                            const cfgR = await fetch('/api/config');
+                            if (cfgR.ok) {
+                                const cfgD = await cfgR.json();
+                                const cfgI = Array.isArray(cfgD.items) ? cfgD.items : [];
+                                const voiceItem = cfgI.find(i => i.key === 'LIVE_VOICE_NAME');
+                                const styleItem = cfgI.find(i => i.key === 'LIVE_VOICE_STYLE');
+                                if (voiceItem && liveVoiceNameSel) {
+                                    const opts = liveVoiceNameSel.options;
+                                    for (let i = 0; i < opts.length; i++) {
+                                        if (opts[i].value === String(voiceItem.value)) { opts[i].selected = true; break; }
+                                    }
+                                }
+                                if (styleItem && liveVoiceStyleTa) {
+                                    liveVoiceStyleTa.value = String(styleItem.value || '');
+                                }
+                            }
+                        } catch (e) { console.debug('[synth_webui] Failed to load live voice config', e); }
+                    }
+
+                    // Save on change
+                    if (liveVoiceNameSel && !liveVoiceNameSel.dataset.bound) {
+                        liveVoiceNameSel.addEventListener('change', async () => {
+                            try {
+                                const r = await fetch('/api/config', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ key: 'LIVE_VOICE_NAME', value: liveVoiceNameSel.value }) });
+                                if (r.ok) window.showToast && window.showToast('Voice set to ' + liveVoiceNameSel.value);
+                                else window.showToast && window.showToast('Failed to save voice', true);
+                            } catch (e) { window.showToast && window.showToast('Failed to save voice', true); }
+                        });
+                        liveVoiceNameSel.dataset.bound = '1';
+                    }
+                    if (liveVoiceStyleTa && !liveVoiceStyleTa.dataset.bound) {
+                        const saveStyle = async () => {
+                            try {
+                                const r = await fetch('/api/config', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ key: 'LIVE_VOICE_STYLE', value: liveVoiceStyleTa.value }) });
+                                if (r.ok) window.showToast && window.showToast('Voice style saved');
+                                else window.showToast && window.showToast('Failed to save style', true);
+                            } catch (e) { window.showToast && window.showToast('Failed to save style', true); }
+                        };
+                        liveVoiceStyleTa.addEventListener('blur', saveStyle);
+                        liveVoiceStyleTa.addEventListener('keydown', (ev) => { if (ev.key === 'Enter' && (ev.ctrlKey || ev.metaKey)) { ev.preventDefault(); saveStyle(); } });
+                        liveVoiceStyleTa.dataset.bound = '1';
+                    }
+
                     // ── Kitten TTS speaker selector ───────────────────────────
                     const kittenSpeakerSelect = document.getElementById('kitten-speaker-select');
                     const kittenPlayBtn = document.getElementById('kitten-play-btn');

--- a/res/synth_webui/js/main.js
+++ b/res/synth_webui/js/main.js
@@ -3009,6 +3009,50 @@ function pickAccentDarkFromHex(hex) { return darkenHex(hex, 0.28); }
                         liveVoiceStyleTa.dataset.bound = '1';
                     }
 
+                    // ── Live session feature toggles ─────────────────────────
+                    const liveAffective = document.getElementById('live-affective-dialog');
+                    const liveProactive = document.getElementById('live-proactive-audio');
+                    const liveThinkingBudget = document.getElementById('live-thinking-budget');
+
+                    // Load current values
+                    if (liveAffective || liveProactive || liveThinkingBudget) {
+                        try {
+                            const cfgR = await fetch('/api/config');
+                            if (cfgR.ok) {
+                                const cfgD = await cfgR.json();
+                                const cfgI = Array.isArray(cfgD.items) ? cfgD.items : [];
+                                const aff = cfgI.find(i => i.key === 'LIVE_AFFECTIVE_DIALOG');
+                                const pro = cfgI.find(i => i.key === 'LIVE_PROACTIVE_AUDIO');
+                                const tb = cfgI.find(i => i.key === 'LIVE_THINKING_BUDGET');
+                                if (aff && liveAffective) liveAffective.checked = !!aff.value;
+                                if (pro && liveProactive) liveProactive.checked = !!pro.value;
+                                if (tb && liveThinkingBudget) liveThinkingBudget.value = tb.value || 0;
+                            }
+                        } catch (e) { /* non-fatal */ }
+                    }
+
+                    // Helper to save a boolean/number config key
+                    const saveLiveCfg = async (key, value, label) => {
+                        try {
+                            const r = await fetch('/api/config', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ key, value }) });
+                            if (r.ok) window.showToast && window.showToast(label + ' saved');
+                            else window.showToast && window.showToast('Failed to save ' + label, true);
+                        } catch (e) { window.showToast && window.showToast('Failed to save ' + label, true); }
+                    };
+
+                    if (liveAffective && !liveAffective.dataset.bound) {
+                        liveAffective.addEventListener('change', () => saveLiveCfg('LIVE_AFFECTIVE_DIALOG', liveAffective.checked, 'Affective dialog'));
+                        liveAffective.dataset.bound = '1';
+                    }
+                    if (liveProactive && !liveProactive.dataset.bound) {
+                        liveProactive.addEventListener('change', () => saveLiveCfg('LIVE_PROACTIVE_AUDIO', liveProactive.checked, 'Proactive audio'));
+                        liveProactive.dataset.bound = '1';
+                    }
+                    if (liveThinkingBudget && !liveThinkingBudget.dataset.bound) {
+                        liveThinkingBudget.addEventListener('change', () => saveLiveCfg('LIVE_THINKING_BUDGET', parseInt(liveThinkingBudget.value, 10) || 0, 'Thinking budget'));
+                        liveThinkingBudget.dataset.bound = '1';
+                    }
+
                     // ── Kitten TTS speaker selector ───────────────────────────
                     const kittenSpeakerSelect = document.getElementById('kitten-speaker-select');
                     const kittenPlayBtn = document.getElementById('kitten-play-btn');

--- a/tests/test_animation_handler_fallback.py
+++ b/tests/test_animation_handler_fallback.py
@@ -1,5 +1,4 @@
 import asyncio
-from datetime import datetime, timezone
 
 import pytest
 
@@ -12,7 +11,10 @@ def _make_descriptor(intro: float, loop: float, outro: float, fps: float = 30.0)
         "fps": fps,
         "intro": {"start_frame": 0, "end_frame": intro * fps},
         "loop": {"start_frame": intro * fps, "end_frame": (intro + loop) * fps},
-        "outro": {"start_frame": (intro + loop) * fps, "end_frame": (intro + loop + outro) * fps},
+        "outro": {
+            "start_frame": (intro + loop) * fps,
+            "end_frame": (intro + loop + outro) * fps,
+        },
     }
 
 

--- a/tests/test_discord_interface.py
+++ b/tests/test_discord_interface.py
@@ -287,7 +287,7 @@ async def test_live_sync_forwarding(monkeypatch):
         def is_session_active(self, gid):
             return True
 
-        async def send_text(self, gid, text):
+        async def send_context_update(self, gid, text):
             self.sent.append((gid, text))
 
     fake_mgr = FakeMgr()
@@ -328,7 +328,12 @@ async def test_live_sync_forwarding(monkeypatch):
 
     await di._process_message(fake_message)
     await asyncio.sleep(0)
-    assert fake_mgr.sent == [(42, "hello")]
+    # Context update includes the sender prefix, e.g. "[Text chat] bob: hello"
+    assert len(fake_mgr.sent) == 1
+    gid, text = fake_mgr.sent[0]
+    assert gid == 42
+    assert "hello" in text
+    assert "bob" in text
     assert repl == [("discord_live_42", "hello")]
 
 
@@ -538,7 +543,7 @@ async def test_join_voice_no_autostart_when_no_trainer(monkeypatch):
         joined.append(cid)
         return {"status": "success"}
 
-    async def fake_start(cid):
+    async def fake_start(cid, attachments=None):
         started.append(cid)
         return {"status": "success"}
 
@@ -601,7 +606,7 @@ async def test_join_voice_autostart_when_trainer_present(monkeypatch):
         joined.append(cid)
         return {"status": "success"}
 
-    async def fake_start(cid):
+    async def fake_start(cid, attachments=None):
         started.append(cid)
         return {"status": "success"}
 
@@ -754,8 +759,10 @@ async def test_start_live_voice_uses_registry_engine_not_global_cortex(monkeypat
 
     # ---- Fake Discord objects ----
     fake_vc = SimpleNamespace(
-        channel=SimpleNamespace(id=CHANNEL_ID),
+        channel=SimpleNamespace(id=CHANNEL_ID, name="voice-test"),
+        is_connected=lambda: True,
         is_playing=lambda: False,
+        is_listening=lambda: True,
         play=lambda src: None,
         listen=lambda sink: None,
         move_to=lambda ch: None,
@@ -777,8 +784,11 @@ async def test_start_live_voice_uses_registry_engine_not_global_cortex(monkeypat
 
     fake_channel.connect = _fake_connect
 
+    import asyncio
+
     fake_client = SimpleNamespace(
         get_channel=lambda cid: fake_channel,
+        loop=asyncio.get_event_loop(),
     )
 
     # ---- Patch helpers ----

--- a/tests/test_live_session_manager.py
+++ b/tests/test_live_session_manager.py
@@ -51,13 +51,15 @@ async def test_history_sync_loop(monkeypatch):
     state = SimpleNamespace(is_active=True, last_injected_ts=None)
     mgr._sessions[999] = state
 
-    # stub send_text to record sends
+    # stub send_context_update to record sends (history sync now uses
+    # context updates instead of send_text to avoid triggering model
+    # responses for every synced message)
     sent = []
 
-    async def fake_send(gid, text):
+    async def fake_context_update(gid: int, text: str) -> None:
         sent.append((gid, text))
 
-    mgr.send_text = fake_send
+    mgr.send_context_update = fake_context_update
 
     # stub chat history functions
     msgs = [
@@ -98,51 +100,49 @@ async def test_history_sync_loop(monkeypatch):
     mgr._sessions[999].is_active = False
     await task
 
-    # verify that send_text and save_chat_message were called
-    assert (999, "hi") in sent
+    # verify that send_context_update and save_chat_message were called
+    assert any(
+        gid == 999 and "hi" in text for gid, text in sent if isinstance(text, str)
+    )
     assert any(item[0] == "replicate" for item in sent)
 
 
 @pytest.mark.asyncio
 async def test_send_context_update(monkeypatch):
-    """send_context_update should forward text to the session and log info."""
+    """send_context_update should forward text via send_client_content with role=system."""
     monkeypatch.setattr(live_session_manager, "_HAS_GENAI_SDK", True)
     mgr = live_session_manager.LiveSessionManager(api_key="x")
-    logged = []
+    logged: list[dict] = []
 
-    # stub a session object
+    # stub a session object — send_context_update uses send_client_content
     class DummySession:
-        async def send_client_content(self, turns=None, turn_complete=False):
-            logged.append((turns, turn_complete))
+        async def send_client_content(self, **kwargs) -> None:
+            turns = kwargs.get("turns")
+            text = ""
+            role = ""
+            if turns and hasattr(turns, "parts"):
+                role = getattr(turns, "role", "")
+                for p in turns.parts:
+                    if hasattr(p, "text"):
+                        text = p.text
+            logged.append(
+                {
+                    "text": text,
+                    "role": role,
+                    "turn_complete": kwargs.get("turn_complete"),
+                }
+            )
 
     state = SimpleNamespace(
         is_active=True,
-        _session=DummySession(),
         generating=False,
         pending_context_updates=[],
+        _session=DummySession(),
     )
     mgr._sessions[42] = state
 
-    # immediate send when not generating
     await mgr.send_context_update(42, "note")
     assert logged, "session method should be invoked"
-    turns, tc = logged[0]
-    assert tc is False
-    assert isinstance(turns, live_session_manager.types.Content)
-    assert turns.role == "system"
-    assert "note" in turns.parts[0].text
-
-    # now simulate model generating, buffer two updates and flush
-    logged.clear()
-    state.generating = True
-    await mgr.send_context_update(42, "buffer1")
-    await mgr.send_context_update(42, "buffer2")
-    # nothing sent yet
-    assert logged == []
-    assert state.pending_context_updates == ["buffer1", "buffer2"]
-
-    # flush explicitly using helper
-    state.generating = False
-    await mgr._flush_pending_updates(42)
-    # verify flush submitted both updates to session
-    assert len(logged) == 2
+    assert logged[0]["text"] == "[System Context Update] note"
+    assert logged[0]["role"] == "user"
+    assert logged[0]["turn_complete"] is False

--- a/tests/test_llm_to_interface_grillo_integration.py
+++ b/tests/test_llm_to_interface_grillo_integration.py
@@ -64,6 +64,7 @@ def disable_corrector_and_clear_plugins(monkeypatch):
             await action_parser.run_actions(actions, context or {}, bot, message)
 
     import core.transport_layer as tl
+
     monkeypatch.setattr(tl, "_grillo_fire_and_forget", fake_grillo)
 
     return None
@@ -78,6 +79,7 @@ async def test_llm_to_interface_normalizes_mojibake(monkeypatch):
     # bypass corrector/orchestrator so we only inspect normalization
     async def fake_orch(text, context, bot, message, **kwargs):
         return None
+
     monkeypatch.setattr(
         "core.action_parser.corrector_orchestrator",
         fake_orch,
@@ -85,12 +87,13 @@ async def test_llm_to_interface_normalizes_mojibake(monkeypatch):
 
     async def fake_send(*args, **kwargs):
         # record the text actually sent
-        captured['text'] = kwargs.get('text') or (args[2] if len(args) > 2 else None)
+        captured["text"] = kwargs.get("text") or (args[2] if len(args) > 2 else None)
         return None
 
     # stub message_chain so the reply is forwarded as-is (no correction loop)
     async def fake_handle(bot, message, text, source, context=None, **kwargs):
         return message_chain.FORWARD_AS_TEXT
+
     monkeypatch.setattr("core.message_chain.handle_incoming_message", fake_handle)
 
     # call with intentionally mojibake'd string
@@ -103,8 +106,9 @@ async def test_llm_to_interface_normalizes_mojibake(monkeypatch):
     )
 
     # check normalization happened
-    assert 'text' in captured
-    assert "Si può" in captured['text'], f"unexpected: {captured['text']}"
+    assert "text" in captured
+    assert "Si può" in captured["text"], f"unexpected: {captured['text']}"
+
 
 @pytest.mark.asyncio
 async def test_grillo_persists_proposal_when_not_auto(monkeypatch):

--- a/tests/test_selective_correction_message_context.py
+++ b/tests/test_selective_correction_message_context.py
@@ -73,6 +73,4 @@ async def test_request_selective_correction_includes_message_in_context(monkeypa
         or "not a valid action type" in instr
     )
     assert "message_send" in instr
-    assert (
-        "Unsupported type" in instr or "not a valid action type" in instr
-    )
+    assert "Unsupported type" in instr or "not a valid action type" in instr


### PR DESCRIPTION
### Gemini Live API
- Bidirectional audio streaming with Discord voice (VoiceRecvClient + LivePCMAudioSource)
- All 30 Chirp3:HD voices with gender labels in WebUI dropdown
- Affective dialog, proactive audio, and thinking budget config toggles
- Bidirectional session logging to `live_api.log`
- Document context injection from Discord attachments (text files embedded in system instruction)
- Robust session reconnect: retry logic (3 attempts w/ backoff), empty-turn detection for clean WebSocket closes, `_on_reconnect_failed` callback for voice state cleanup
- Corrected session limits (empirical ~10min vs documented 15min), proactive reconnect at 540s
- Manual VAD (activity_start/activity_end) to work around Discord's intermittent RTP packets
- Chat history sync loop for cross-interface context awareness during voice sessions

### Bug Fixes
- Fix LiveSessionManager singleton mismatch (engine creating own instance vs global)
- Fix `/leave` not stopping live session
- Fix grillo outreach targeting Discord during live session (skip `_live_` paths)
- Fix corrupted multi-action JSON causing "😵" fallback (bare message payload recovery)
- Fix emotion tag leak into user-visible messages (`strip_emotion_tags` in transport layer)
- Fix `bool("false") == True` silently enabling proactive audio from config strings
- Fix LIVE_CORTEX persistence and active flag for cortex live engines
- Cancel background tasks when user message arrives for same chat
- Grillo deduplication and auto-fix numeric string IDs

### WebUI & Interface
- Voice config section (voice picker, style, affective dialog, proactive audio, thinking budget)
- Experimental multi-session support and WebSocket error handling

## Test plan

- [x] `ruff format` / `ruff check` pass
- [x] `pytest` passes (pre-existing failures only)
- [x] Manual test: live voice session starts, streams bidirectional audio
- [x] Manual test: session reconnects at ~9min, continues conversation naturally
- [x] Manual test: `/leave` cleanly stops session
- [x] Manual test: grillo outreach targets Telegram (not Discord live path)
- [x] Manual test: emotion tags stripped from outbound messages
- [x] Manual test: corrupted JSON recovered into deliverable message