### PR TITLE
Gemini Live Fixes

### DIFF
--- a/core/action_parser.py
+++ b/core/action_parser.py
@@ -6,6 +6,7 @@ import inspect
 import time
 from typing import Any, Dict, List, Tuple
 
+from core.json_utils import dumps as json_dumps, redact_multimodal_for_logging
 from core.logging_utils import log_debug, log_info, log_warning, log_error
 from core.validation_registry import get_validation_registry
 from core.config_manager import config_registry
@@ -1087,7 +1088,10 @@ async def _handle_plugin_action(
                 log_info(
                     f"[action_parser] 🚀 Delegating action to {plugin.__class__.__name__}: type={action_type} interface={plugin_iface}"
                 )
-                log_debug(f"[action_parser] 📦 Action payload: {payload}")
+                log_debug(
+                    "[action_parser] 📦 Action payload: "
+                    + json_dumps(redact_multimodal_for_logging(payload))
+                )
 
                 result = plugin.execute_action(
                     new_action, context, bot, original_message
@@ -1927,7 +1931,10 @@ def _generate_context_tags(
 
 async def parse_action(action: dict, bot, message):
     """Parse and execute a single action."""
-    log_debug(f"[action_parser] Received action: {action}")
+    log_debug(
+        "[action_parser] Received action: "
+        + json_dumps(redact_multimodal_for_logging(action))
+    )
 
     action_type = action.get("type")
     interface = action.get("interface")
@@ -1943,7 +1950,7 @@ async def parse_action(action: dict, bot, message):
         + ", Interface: "
         + str(interface)
         + ", Payload: "
-        + str(payload)
+        + json_dumps(redact_multimodal_for_logging(payload))
     )
 
     # First allow the active LLM plugin to handle custom actions

--- a/core/config.py
+++ b/core/config.py
@@ -104,6 +104,7 @@ BASE_CORTEX = config_registry.get_var(
     group="core",
     component="cortex",
     hidden=True,  # Managed via the Cortex Engines component selector
+    allow_env_override=False,
 )
 
 GRILLO_CORTEX = config_registry.get_var(
@@ -114,6 +115,7 @@ GRILLO_CORTEX = config_registry.get_var(
     group="core",
     component="cortex",
     hidden=True,  # Managed via the Cortex Engines scope selectors
+    allow_env_override=False,
 )
 
 TRAINER_CORTEX = config_registry.get_var(
@@ -126,6 +128,7 @@ TRAINER_CORTEX = config_registry.get_var(
     group="core",
     component="cortex",
     hidden=True,  # Managed via the Cortex Engines scope selectors
+    allow_env_override=False,
 )
 
 LIVE_CORTEX = config_registry.get_var(
@@ -136,6 +139,7 @@ LIVE_CORTEX = config_registry.get_var(
     group="core",
     component="cortex",
     hidden=True,  # Managed via the Cortex Engines scope selectors
+    allow_env_override=False,
 )
 
 # ----------------------------------------------------------------------

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -122,6 +122,8 @@ class ConfigDefinition:
     hidden: bool = False
     # If True, the config is read-only in the UI (no edits allowed)
     readonly: bool = False
+    # If False, ignore environment variables for this key and load from DB/default.
+    allow_env_override: bool = True
 
     value: Any = None
     raw_value: Optional[str] = None
@@ -175,6 +177,7 @@ class ConfigRegistry:
         needs_component_reload: bool = False,
         readonly: bool = False,
         hidden: bool = False,
+        allow_env_override: bool = True,
     ) -> Any:
         """Return the typed value for ``key`` or register it if unknown."""
 
@@ -192,6 +195,7 @@ class ConfigRegistry:
             needs_component_reload=needs_component_reload,
             readonly=readonly,
             hidden=hidden,
+            allow_env_override=allow_env_override,
             constraints=constraints,
             getter=getter,
             setter=setter,
@@ -219,6 +223,7 @@ class ConfigRegistry:
         needs_component_reload: bool = False,
         readonly: bool = False,
         hidden: bool = False,
+        allow_env_override: bool = True,
     ) -> ConfigVar:
         """
         Return a ConfigVar that auto-updates when the config changes.
@@ -249,6 +254,7 @@ class ConfigRegistry:
             needs_component_reload=needs_component_reload,
             hidden=hidden,
             readonly=readonly,
+            allow_env_override=allow_env_override,
             constraints=constraints,
             getter=getter,
             setter=setter,
@@ -474,6 +480,7 @@ class ConfigRegistry:
         needs_component_reload: bool = False,
         hidden: bool = False,
         readonly: bool = False,
+        allow_env_override: bool = True,
         constraints: Optional[Dict[str, Any]],
         getter: Optional[Callable[[], Any]] = None,
         setter: Optional[Callable[[Any], None]] = None,
@@ -499,6 +506,7 @@ class ConfigRegistry:
             needs_component_reload=needs_component_reload,
             hidden=hidden,
             readonly=readonly,
+            allow_env_override=allow_env_override,
         )
         self._definitions[key] = definition
         log_debug(f"[config] Registered setting '{key}' (component={component})")
@@ -536,7 +544,11 @@ class ConfigRegistry:
         env_value = os.getenv(definition.key)
         # Treat empty env values as "not set" so DB can take precedence.
         # This is important when env files contain placeholders like KEY=.
-        if env_value is not None and str(env_value).strip() != "":
+        if (
+            definition.allow_env_override
+            and env_value is not None
+            and str(env_value).strip() != ""
+        ):
             definition.env_override = True
             definition.env_value = env_value
             definition.raw_value = env_value

--- a/core/external_endpoints/bridges/cortex_bridge.py
+++ b/core/external_endpoints/bridges/cortex_bridge.py
@@ -9,11 +9,15 @@ to a built-in engine from the perspective of the SyntH core.
 from __future__ import annotations
 
 import asyncio
+import base64
+import copy
 import json
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from core.ai_plugin_base import AIPluginBase
 from core.logging_utils import log_warning
+from core.external_endpoints.models import EndpointProtocol
 
 if TYPE_CHECKING:
     from core.external_endpoints.adapters.base import BaseProtocolAdapter
@@ -88,11 +92,8 @@ class ExternalCortexEngine(AIPluginBase):
         # Normalise to a messages list, same way openrouter/gemini handle the prompt
         if isinstance(messages, list):
             msg_list = messages
-        elif isinstance(messages, dict):
-            prompt_text = json.dumps(messages, ensure_ascii=False)
-            msg_list = [{"role": "user", "content": prompt_text}]
         else:
-            msg_list = [{"role": "user", "content": str(messages)}]
+            msg_list = self._build_messages(messages)
 
         model = self._endpoint.default_model
         if not model and self._endpoint.available_models:
@@ -142,14 +143,151 @@ class ExternalCortexEngine(AIPluginBase):
             for k, v in prompt.items()
             if k not in ("instructions", "instructions_verbose")
         }
-        user_content = json.dumps(user_dict, ensure_ascii=False)
+        redacted_user_dict = self._copy_and_redact_data(user_dict)
+        user_content: str | list[dict[str, Any]] = json.dumps(
+            redacted_user_dict, ensure_ascii=False
+        )
+
+        if self._endpoint.protocol == EndpointProtocol.OPENAI:
+            multimodal_parts = self._extract_multimodal_parts(user_dict)
+            if multimodal_parts:
+                user_content = [
+                    {
+                        "type": "text",
+                        "text": json.dumps(redacted_user_dict, ensure_ascii=False),
+                    },
+                    *multimodal_parts,
+                ]
 
         if instructions:
             return [
                 {"role": "system", "content": str(instructions)},
                 {"role": "user", "content": user_content},
             ]
-        return [{"role": "user", "content": json.dumps(prompt, ensure_ascii=False)}]
+        return [{"role": "user", "content": user_content}]
+
+    def _extract_multimodal_parts(self, prompt: Any) -> list[dict[str, Any]]:
+        """Extract OpenAI-style multimodal content parts from a SyntH prompt."""
+        parts: list[dict[str, Any]] = []
+
+        if isinstance(prompt, str):
+            try:
+                prompt = json.loads(prompt)
+            except (json.JSONDecodeError, ValueError):
+                return parts
+
+        if not isinstance(prompt, dict):
+            return parts
+
+        multimodal_keys = {"attachments", "images", "videos"}
+        schema_only_keys = {"actions", "available_actions", "schema"}
+        attachments: list[dict[str, Any]] = []
+
+        def collect_recursive(container: Any) -> None:
+            if isinstance(container, dict):
+                for key in multimodal_keys:
+                    if key in container:
+                        items = container[key]
+                        if isinstance(items, list):
+                            for item in items:
+                                if isinstance(item, dict):
+                                    attachments.append(item)
+                                elif isinstance(item, str):
+                                    default_mime = {
+                                        "images": "image/jpeg",
+                                        "videos": "video/mp4",
+                                    }.get(key, "application/octet-stream")
+                                    attachments.append(
+                                        {"path": item, "mime_type": default_mime}
+                                    )
+                        elif isinstance(items, dict):
+                            attachments.append(items)
+                for key, value in container.items():
+                    if key in schema_only_keys:
+                        continue
+                    collect_recursive(value)
+            elif isinstance(container, list):
+                for item in container:
+                    collect_recursive(item)
+
+        collect_recursive(prompt)
+
+        for att in attachments:
+            if not isinstance(att, dict):
+                continue
+
+            mime_type = str(att.get("mime_type") or att.get("mimeType") or "")
+            file_path = str(att.get("path") or att.get("file_path") or "")
+
+            if file_path and not mime_type:
+                import mimetypes as mt
+
+                mime_type, _ = mt.guess_type(file_path)
+                mime_type = mime_type or "application/octet-stream"
+
+            if not mime_type.startswith("image/"):
+                continue
+
+            b64_data = att.get("data") or att.get("base64", "")
+            if not b64_data and file_path:
+                try:
+                    path = Path(file_path)
+                    if path.exists() and path.is_file():
+                        b64_data = base64.b64encode(path.read_bytes()).decode("utf-8")
+                except Exception:
+                    continue
+
+            if not b64_data:
+                continue
+
+            parts.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{mime_type};base64,{b64_data}"},
+                }
+            )
+
+        return parts
+
+    def _copy_and_redact_data(self, prompt: dict[str, Any]) -> dict[str, Any]:
+        """Deep copy a prompt and remove heavy base64 attachment payloads."""
+        redacted = copy.deepcopy(prompt)
+        multimodal_keys = {"attachments", "images", "audio", "documents", "videos"}
+        data_fields = {"data", "base64"}
+        attachment_fields = {
+            "mime_type",
+            "mimeType",
+            "path",
+            "file_path",
+            "data",
+            "base64",
+        }
+
+        def redact_item(item: dict[str, Any]) -> None:
+            if not isinstance(item, dict) or not (item.keys() & attachment_fields):
+                return
+            for field in data_fields:
+                if field in item:
+                    item[field] = f"<redacted: {len(str(item[field]))} chars>"
+
+        def redact_recursive(container: Any) -> None:
+            if isinstance(container, dict):
+                for key in multimodal_keys:
+                    if key in container:
+                        items = container[key]
+                        if isinstance(items, list):
+                            for item in items:
+                                redact_item(item)
+                        elif isinstance(items, dict):
+                            redact_item(items)
+                for value in container.values():
+                    redact_recursive(value)
+            elif isinstance(container, list):
+                for item in container:
+                    redact_recursive(item)
+
+        redact_recursive(redacted)
+        return redacted
 
     async def handle_incoming_message(
         self, bot: Any, message: Any, prompt: Any

--- a/core/json_utils.py
+++ b/core/json_utils.py
@@ -1,7 +1,20 @@
+import copy
 import json
+import re
 from collections.abc import Mapping, Sequence
-from typing import Optional, Dict
+from typing import Any, Optional, Dict
 from core.logging_utils import log_debug, log_info, log_warning
+
+
+_INLINE_MEDIA_KEYS = {
+    "image_path",
+    "audio_path",
+    "video_path",
+    "file_path",
+    "path",
+}
+_BASE64_KEYS = {"data", "base64"}
+_BASE64_LIST_PATTERN = re.compile(r"(?:^|_)b64(?:$|_)", re.IGNORECASE)
 
 
 def custom_json_encoder(obj):
@@ -30,6 +43,76 @@ def sanitize_for_json(obj):
         if hasattr(obj, "__dict__"):
             return sanitize_for_json(obj.__dict__)
         return str(obj)
+
+
+def _looks_like_inline_media_value(value: str) -> bool:
+    compact = "".join(value.split())
+    if not compact:
+        return False
+    if compact.startswith("data:") and ";base64," in compact:
+        return True
+    if len(compact) < 256:
+        return False
+    if not re.fullmatch(r"[A-Za-z0-9+/=_-]+", compact):
+        return False
+    return True
+
+
+def _redacted_text(label: str, value: Any) -> str:
+    return f"<{label}: {len(str(value))} chars>"
+
+
+def _redact_multimodal_value(key: str, value: Any) -> Any:
+    if key in _BASE64_KEYS and isinstance(value, str):
+        return _redacted_text("redacted", value)
+
+    if _BASE64_LIST_PATTERN.search(key):
+        if isinstance(value, str):
+            return _redacted_text("redacted", value)
+        if isinstance(value, list):
+            return [
+                _redacted_text("redacted", item) if isinstance(item, str) else item
+                for item in value
+            ]
+
+    if key in _INLINE_MEDIA_KEYS and isinstance(value, str):
+        if _looks_like_inline_media_value(value):
+            return _redacted_text("redacted-inline-media", value)
+
+    return value
+
+
+def _redact_multimodal_recursive(obj: Any) -> Any:
+    if isinstance(obj, Mapping):
+        redacted: dict[Any, Any] = {}
+        for key, value in obj.items():
+            key_str = str(key)
+            maybe_redacted = _redact_multimodal_value(key_str, value)
+            if maybe_redacted is not value:
+                redacted[key] = maybe_redacted
+            else:
+                redacted[key] = _redact_multimodal_recursive(value)
+        return redacted
+
+    if isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+        return [_redact_multimodal_recursive(value) for value in obj]
+
+    return obj
+
+
+def redact_multimodal_for_logging(obj: Any) -> Any:
+    """Return a deep-copied log-safe view with heavy multimodal data redacted."""
+    if isinstance(obj, str):
+        stripped = obj.lstrip()
+        if stripped.startswith(("{", "[")):
+            try:
+                parsed = json.loads(obj)
+            except Exception:
+                return obj
+            return _redact_multimodal_recursive(parsed)
+        return obj
+
+    return _redact_multimodal_recursive(copy.deepcopy(obj))
 
 
 def extract_json_from_text(text: str, return_metadata: bool = False) -> Optional[Dict]:

--- a/core/message_chain.py
+++ b/core/message_chain.py
@@ -446,7 +446,9 @@ async def handle_incoming_message(
                         }
 
                         # Try to send corrector message
-                        asyncio.create_task(run_action(corrector_action, message))
+                        asyncio.create_task(
+                            run_action(corrector_action, ctx, bot, message)
+                        )
                         log_info(
                             "[message_chain] ✓ Corrector action scheduled for invalid emotions"
                         )
@@ -787,6 +789,22 @@ async def handle_incoming_message(
 
                 # Only enforce this for LLM-originated responses
                 if is_from_cortex and isinstance(actions, list):
+                    try:
+                        scoped_actions = ctx.get("allowed_action_types") or ctx.get(
+                            "allowed_actions"
+                        )
+                        if isinstance(scoped_actions, (list, set, tuple)):
+                            supported_action_types.update(
+                                str(action_type)
+                                for action_type in scoped_actions
+                                if action_type
+                            )
+                    except Exception as e:
+                        log_debug(
+                            "[message_chain] Failed to merge scoped allowed action "
+                            f"types into runtime supported set: {e}"
+                        )
+
                     # quick mapping: some models may output a generic "message"
                     # action when they really intend to send text to the current
                     # interface.  Convert it to a concrete type based on the

--- a/core/plugin_instance.py
+++ b/core/plugin_instance.py
@@ -13,7 +13,11 @@ import os
 import tempfile
 from pathlib import Path
 from core.logging_utils import log_debug, log_info, log_warning, log_error
-from core.json_utils import dumps as json_dumps, sanitize_for_json
+from core.json_utils import (
+    dumps as json_dumps,
+    redact_multimodal_for_logging,
+    sanitize_for_json,
+)
 from core.image_processor import get_image_processor, process_image_message
 from core.abstract_context import AbstractContext, AbstractUser, AbstractMessage
 from core.mention_utils import is_message_for_bot
@@ -719,7 +723,10 @@ async def handle_incoming_message(
         )
         # debug log of the full prompt content for reconstruction
         try:
-            log_debug(f"[flow] prompt content: {json_dumps(prompt)}")
+            log_debug(
+                "[flow] prompt content: "
+                + json_dumps(redact_multimodal_for_logging(prompt))
+            )
         except Exception:
             pass
     except Exception:
@@ -776,7 +783,11 @@ async def handle_incoming_message(
             log_error(f"[plugin_instance] Failed to log LLM traffic: {e}")
         # debug log response for full transaction replay
         try:
-            log_debug(f"[flow] LLM raw response: {result}")
+            redacted_result = redact_multimodal_for_logging(result)
+            if isinstance(redacted_result, (dict, list)):
+                log_debug("[flow] LLM raw response: " + json_dumps(redacted_result))
+            else:
+                log_debug(f"[flow] LLM raw response: {redacted_result}")
         except Exception:
             pass
 
@@ -1021,12 +1032,17 @@ def _log_llm_traffic(prompt, response, interface_name):
             log_prompt.pop("actions", None)
         except Exception:
             pass
+    try:
+        log_prompt = redact_multimodal_for_logging(log_prompt)
+        log_response = redact_multimodal_for_logging(response)
+    except Exception:
+        log_response = response
 
     entry = {
         "timestamp": datetime.utcnow().isoformat(),
         "interface": interface_name,
         "input_context": log_prompt,
-        "response": response,
+        "response": log_response,
     }
 
     try:
@@ -1216,9 +1232,7 @@ async def _extract_image_data_from_message(message, interface_name: str):
 
 def _build_unviewable_media_placeholder(mime_type: str | None) -> str:
     if mime_type:
-        return (
-            f"User attached a {mime_type} but the vision engine could not see it."
-        )
+        return f"User attached a {mime_type} but the vision engine could not see it."
     return "User attached a media file but the vision engine could not see it."
 
 

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -5,7 +5,7 @@ import random
 from core.db import get_conn_ctx
 from core.synth_tagging import extract_tags, expand_tags
 from core.logging_utils import log_debug, log_info, log_warning, log_error
-from core.json_utils import dumps as json_dumps
+from core.json_utils import dumps as json_dumps, redact_multimodal_for_logging
 from core.config_manager import config_registry
 from core.user_utils import get_user_display_name, get_user_usertag
 from datetime import datetime, time
@@ -322,15 +322,6 @@ async def build_json_prompt(
         )
         context_section = {"memories": memories}
 
-    # Expose chosen history_scope to downstream plugins/engines explicitly
-    try:
-        if effective_history_scope:
-            input_payload.setdefault("history_scope", effective_history_scope)
-    except Exception:
-        pass
-
-    # (moved) prompt logging will occur later once input_payload exists
-
     # === 3. Recon contributions (prompt 0) ===
     # Note: raw contributions are NOT included — their memories are already
     # merged into the top-level `memories` list.  Only metadata is kept.
@@ -422,9 +413,14 @@ async def build_json_prompt(
             else "local"
         ),
     }
+
+    # Expose chosen history_scope to downstream plugins/engines explicitly.
+    if effective_history_scope:
+        input_payload.setdefault("history_scope", effective_history_scope)
+
     # debug: log full prompt payload for reconstruction
     try:
-        full_text = json_dumps(input_payload)
+        full_text = json_dumps(redact_multimodal_for_logging(input_payload))
         log_debug(
             f"[json_prompt] ⏹️ Final prompt built ({len(full_text)} chars): {full_text}"
         )
@@ -520,8 +516,14 @@ async def build_json_prompt(
     }
 
     # Debug output for both sections
-    log_debug("[json_prompt] context = " + json_dumps(context_section))
-    log_debug("[json_prompt] input = " + json_dumps(input_section))
+    log_debug(
+        "[json_prompt] context = "
+        + json_dumps(redact_multimodal_for_logging(context_section))
+    )
+    log_debug(
+        "[json_prompt] input = "
+        + json_dumps(redact_multimodal_for_logging(input_section))
+    )
 
     # Add JSON instructions to the prompt
     json_instructions = load_json_instructions()

--- a/plugins/iris_plugin.py
+++ b/plugins/iris_plugin.py
@@ -13,7 +13,9 @@ external-endpoint bridges — no local model is bundled.
 from __future__ import annotations
 
 import asyncio
+import base64
 import os
+import tempfile
 from typing import Any
 
 from core.ai_plugin_base import AIPluginBase
@@ -204,8 +206,14 @@ class IrisPlugin(AIPluginBase):
                     "Analyse an image or video file and return a textual description "
                     "using the Iris vision subsystem."
                 ),
-                "required_fields": ["image_path"],
-                "optional_fields": ["mime_type", "prompt", "engine", "model"],
+                "required_fields": [],
+                "optional_fields": [
+                    "image_path",
+                    "mime_type",
+                    "prompt",
+                    "engine",
+                    "model",
+                ],
             }
         }
 
@@ -219,7 +227,11 @@ class IrisPlugin(AIPluginBase):
                 "payload": {
                     "image_path": {
                         "type": "string",
-                        "description": "Absolute path to the image or video file to analyse.",
+                        "description": (
+                            "Optional absolute path or base64 data URL for the image/video. "
+                            "When omitted, the current message attachment is analysed automatically."
+                        ),
+                        "optional": True,
                     },
                     "mime_type": {
                         "type": "string",
@@ -245,34 +257,30 @@ class IrisPlugin(AIPluginBase):
             }
         return {}
 
+    async def execute_action(
+        self,
+        action: dict,
+        context: dict,
+        bot: Any,
+        original_message: Any,
+    ) -> dict[str, Any]:
+        action_type = action.get("type")
+        payload = action.get("payload", {}) or {}
+        if action_type != "vision_describe":
+            return await super().execute_action(action, context, bot, original_message)
+        if not isinstance(payload, dict):
+            payload = dict(payload)
+        return await self._run_vision_describe(
+            payload,
+            bot=bot,
+            original_message=original_message,
+        )
+
     async def handle_custom_action(
         self, action_type: str, payload: dict
     ) -> dict[str, Any]:
         if action_type == "vision_describe":
-            image_path: str = payload.get("image_path", "")
-            mime_type: str | None = payload.get("mime_type")
-            prompt: str | None = payload.get("prompt")
-            engine_name: str | None = payload.get("engine")
-            model: str | None = payload.get("model")
-
-            result = await self.describe_media(
-                image_path,
-                mime_type,
-                prompt,
-                engine_name,
-                model,
-            )
-            if result:
-                response: dict[str, Any] = {
-                    "status": "success",
-                    "description": result.description,
-                }
-                if result.language is not None:
-                    response["language"] = result.language
-                if result.confidence is not None:
-                    response["confidence"] = result.confidence
-                return response
-            return {"status": "error", "message": "Vision analysis returned no result."}
+            return await self._run_vision_describe(payload)
 
         return {"status": "error", "message": f"Unknown action: {action_type}"}
 
@@ -327,6 +335,193 @@ class IrisPlugin(AIPluginBase):
             )
         except Exception as exc:
             log_warning(f"[iris_plugin] refresh_config failed: {exc}")
+
+    async def _run_vision_describe(
+        self,
+        payload: dict[str, Any],
+        *,
+        bot: Any | None = None,
+        original_message: Any | None = None,
+    ) -> dict[str, Any]:
+        image_path = str(payload.get("image_path", "") or "").strip()
+        mime_type: str | None = payload.get("mime_type")
+        prompt: str | None = payload.get("prompt")
+        engine_name: str | None = payload.get("engine")
+        model: str | None = payload.get("model")
+
+        (
+            resolved_path,
+            should_cleanup,
+            effective_mime,
+        ) = await self._resolve_media_target(
+            image_path,
+            mime_type,
+            bot=bot,
+            original_message=original_message,
+        )
+        if not resolved_path:
+            return {
+                "status": "error",
+                "message": "No image available for vision analysis.",
+            }
+
+        try:
+            result = await self.describe_media(
+                resolved_path,
+                effective_mime,
+                prompt,
+                engine_name,
+                model,
+            )
+            if result:
+                response: dict[str, Any] = {
+                    "status": "success",
+                    "description": result.description,
+                }
+                if result.language is not None:
+                    response["language"] = result.language
+                if result.confidence is not None:
+                    response["confidence"] = result.confidence
+                return response
+            return {
+                "status": "error",
+                "message": "Vision analysis returned no result.",
+            }
+        finally:
+            if should_cleanup and resolved_path:
+                try:
+                    os.remove(resolved_path)
+                except OSError:
+                    pass
+
+    async def _resolve_media_target(
+        self,
+        image_path: str,
+        mime_type: str | None,
+        *,
+        bot: Any | None = None,
+        original_message: Any | None = None,
+    ) -> tuple[str | None, bool, str | None]:
+        if image_path and os.path.exists(image_path):
+            return image_path, False, mime_type
+
+        inline_path, inline_mime = self._materialize_inline_media(image_path, mime_type)
+        if inline_path:
+            return inline_path, True, inline_mime
+
+        if original_message is not None:
+            (
+                message_path,
+                should_cleanup,
+                message_mime,
+            ) = await self._materialize_message_media(
+                bot,
+                original_message,
+            )
+            if message_path:
+                return message_path, should_cleanup, message_mime or mime_type
+
+        return None, False, mime_type
+
+    @staticmethod
+    def _infer_interface_name(original_message: Any) -> str:
+        interface_name = getattr(original_message, "interface_name", None) or getattr(
+            original_message, "interface", None
+        )
+        if interface_name:
+            return str(interface_name)
+        interface_path = str(getattr(original_message, "interface_path", "") or "")
+        if "/" in interface_path:
+            return interface_path.split("/", 1)[0]
+        return interface_path
+
+    @staticmethod
+    def _mime_suffix(mime_type: str | None) -> str:
+        if not mime_type or "/" not in mime_type:
+            return ""
+        return f".{mime_type.split('/', 1)[1].split(';', 1)[0]}"
+
+    @classmethod
+    def _write_temp_media(
+        cls,
+        media_bytes: bytes,
+        mime_type: str | None,
+    ) -> str | None:
+        if not media_bytes:
+            return None
+        suffix = cls._mime_suffix(mime_type)
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            tmp.write(media_bytes)
+            return tmp.name
+
+    @classmethod
+    def _materialize_inline_media(
+        cls,
+        image_path: str,
+        mime_type: str | None,
+    ) -> tuple[str | None, str | None]:
+        if not image_path:
+            return None, mime_type
+
+        raw_value = image_path.strip()
+        effective_mime = mime_type
+        if raw_value.startswith("data:"):
+            header, _, raw_value = raw_value.partition(",")
+            if ";base64" not in header or not raw_value:
+                return None, mime_type
+            if effective_mime is None:
+                effective_mime = header[5:].split(";", 1)[0] or mime_type
+
+        compact_value = "".join(raw_value.split())
+        media_hint = bool(mime_type and mime_type.startswith(("image/", "video/")))
+        if not media_hint and len(compact_value) < 64:
+            return None, effective_mime
+
+        try:
+            media_bytes = base64.b64decode(compact_value, validate=True)
+        except Exception:
+            return None, effective_mime
+
+        return cls._write_temp_media(media_bytes, effective_mime), effective_mime
+
+    async def _materialize_message_media(
+        self,
+        bot: Any | None,
+        original_message: Any,
+    ) -> tuple[str | None, bool, str | None]:
+        try:
+            from core.plugin_instance import _extract_multimodal_attachments
+
+            interface_name = self._infer_interface_name(original_message)
+            attachments = await _extract_multimodal_attachments(
+                bot,
+                original_message,
+                interface_name,
+            )
+        except Exception as exc:
+            log_warning(f"[iris_plugin] Failed to extract message attachments: {exc}")
+            return None, False, None
+
+        for attachment in attachments:
+            if not isinstance(attachment, dict):
+                continue
+            attachment_mime = str(attachment.get("mime_type") or "")
+            if not attachment_mime.startswith(("image/", "video/")):
+                continue
+
+            file_path = str(attachment.get("path") or attachment.get("file_path") or "")
+            if file_path and os.path.exists(file_path):
+                return file_path, False, attachment_mime
+
+            inline_data = str(attachment.get("data") or attachment.get("base64") or "")
+            inline_path, effective_mime = self._materialize_inline_media(
+                inline_data,
+                attachment_mime,
+            )
+            if inline_path:
+                return inline_path, True, effective_mime or attachment_mime
+
+        return None, False, None
 
     # ------------------------------------------------------------------
     # Internal

--- a/tests/test_external_endpoints_adapter.py
+++ b/tests/test_external_endpoints_adapter.py
@@ -5,6 +5,7 @@ import pytest
 
 from core.external_endpoints.adapters.base import ModelInfo
 from core.external_endpoints.adapters.openai_compat import OpenAICompatAdapter
+from core.external_endpoints.models import EndpointProtocol, ExternalEndpoint
 
 
 class FakeAiohttpResponse:
@@ -337,10 +338,20 @@ async def test_openai_compat_chat_completion_uses_reasoning_content(monkeypatch)
 async def test_external_cortex_engine_falls_back_to_first_available_model(monkeypatch):
     from core.external_endpoints.bridges.cortex_bridge import ExternalCortexEngine
 
-    endpoint = SimpleNamespace(
+    endpoint = ExternalEndpoint(
+        id=1,
         name="lmstudio",
-        default_model=None,
+        display_label="LM Studio",
+        protocol=EndpointProtocol.OPENAI,
+        base_url="http://localhost:1234",
+        api_key_enc=None,
+        enabled=True,
+        capabilities={},
+        subsystem_map={"cortex": True},
         available_models=["qwen/qwen3.5-9b"],
+        default_model=None,
+        probe_status="success",
+        last_probe_at=None,
         extra_config={},
     )
     called: dict[str, Any] = {}
@@ -355,6 +366,67 @@ async def test_external_cortex_engine_falls_back_to_first_available_model(monkey
 
     assert response == "ok"
     assert called["model"] == "qwen/qwen3.5-9b"
+
+
+@pytest.mark.asyncio
+async def test_external_cortex_engine_redacts_prompt_and_sends_multimodal_parts():
+    from core.external_endpoints.bridges.cortex_bridge import ExternalCortexEngine
+
+    endpoint = ExternalEndpoint(
+        id=2,
+        name="lmstudio",
+        display_label="LM Studio",
+        protocol=EndpointProtocol.OPENAI,
+        base_url="http://localhost:1234",
+        api_key_enc=None,
+        enabled=True,
+        capabilities={},
+        subsystem_map={"cortex": True},
+        available_models=["default"],
+        default_model="default",
+        probe_status="success",
+        last_probe_at=None,
+        extra_config={},
+    )
+    captured: dict[str, Any] = {}
+
+    class FakeAdapter:
+        async def chat_completion(self, messages, model=None, **kwargs):
+            captured["messages"] = messages
+            captured["model"] = model
+            return SimpleNamespace(content="ok", model=model)
+
+    engine = ExternalCortexEngine(endpoint, FakeAdapter())
+    prompt = {
+        "instructions_verbose": "Use valid JSON.",
+        "input": {
+            "payload": {
+                "text": "What is in this image?",
+                "attachments": [
+                    {
+                        "mime_type": "image/png",
+                        "filename": "img.png",
+                        "data": "YWJjZA==",
+                    }
+                ],
+            }
+        },
+    }
+
+    response = await engine.handle_incoming_message(None, None, prompt)
+
+    assert response == "ok"
+    assert captured["model"] == "default"
+    assert captured["messages"][0]["role"] == "system"
+    assert captured["messages"][0]["content"] == "Use valid JSON."
+
+    user_content = captured["messages"][1]["content"]
+    assert isinstance(user_content, list)
+    assert user_content[0]["type"] == "text"
+    assert "<redacted: 8 chars>" in user_content[0]["text"]
+    assert "YWJjZA==" not in user_content[0]["text"]
+    assert user_content[1]["type"] == "image_url"
+    assert user_content[1]["image_url"]["url"] == "data:image/png;base64,YWJjZA=="
 
 
 @pytest.mark.asyncio

--- a/tests/test_iris.py
+++ b/tests/test_iris.py
@@ -325,11 +325,18 @@ async def test_gemini_adapter_uses_model_override(tmp_path) -> None:  # type: ig
     genai_module.types = types_module
     google_module.genai = genai_module
 
-    with patch.dict(sys.modules, {
-        "google": google_module,
-        "google.genai": genai_module,
-        "google.genai.types": types_module,
-    }, clear=False), patch.object(GeminiAdapter, "_get_client", return_value=dummy_client):
+    with (
+        patch.dict(
+            sys.modules,
+            {
+                "google": google_module,
+                "google.genai": genai_module,
+                "google.genai.types": types_module,
+            },
+            clear=False,
+        ),
+        patch.object(GeminiAdapter, "_get_client", return_value=dummy_client),
+    ):
         adapter = GeminiAdapter(api_key="unused")
         result = await adapter.describe_image(
             b"\xff\xd8\xff",
@@ -391,7 +398,9 @@ async def test_describe_attachment_images_with_iris() -> None:
 
 
 @pytest.mark.asyncio
-async def test_describe_attachment_images_with_iris_disabled_engine_returns_placeholder() -> None:
+async def test_describe_attachment_images_with_iris_disabled_engine_returns_placeholder() -> (
+    None
+):
     from core.plugin_instance import _describe_attachment_images_with_iris
     from plugins.iris_plugin import IrisPlugin
 
@@ -401,20 +410,28 @@ async def test_describe_attachment_images_with_iris_disabled_engine_returns_plac
 
     attachment = {"mime_type": "image/png", "data": "ZmFrZQ=="}
 
-    with patch.dict(
-        "core.core_initializer.PLUGIN_REGISTRY",
-        {"iris_plugin": plugin},
-        clear=True,
-    ), patch.object(plugin, "refresh_config"):
+    with (
+        patch.dict(
+            "core.core_initializer.PLUGIN_REGISTRY",
+            {"iris_plugin": plugin},
+            clear=True,
+        ),
+        patch.object(plugin, "refresh_config"),
+    ):
         description = await _describe_attachment_images_with_iris(
             [attachment], prompt="Describe this image."
         )
 
-    assert description == "User attached a image/png but the vision engine could not see it."
+    assert (
+        description
+        == "User attached a image/png but the vision engine could not see it."
+    )
 
 
 @pytest.mark.asyncio
-async def test_describe_attachment_images_with_iris_engine_failure_returns_placeholder() -> None:
+async def test_describe_attachment_images_with_iris_engine_failure_returns_placeholder() -> (
+    None
+):
     from core.iris_registry import IrisRegistry
     from core.plugin_instance import _describe_attachment_images_with_iris
     from plugins.iris_base import IrisEngineBase
@@ -456,7 +473,10 @@ async def test_describe_attachment_images_with_iris_engine_failure_returns_place
             [attachment], prompt="Describe this image."
         )
 
-    assert description == "User attached a image/jpeg but the vision engine could not see it."
+    assert (
+        description
+        == "User attached a image/jpeg but the vision engine could not see it."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -522,6 +542,64 @@ async def test_handle_custom_action_vision_describe(tmp_path) -> None:  # type: 
             response = await plugin.handle_custom_action(
                 "vision_describe",
                 {"image_path": str(test_file), "mime_type": "image/png"},
+            )
+
+    assert response["status"] == "success"
+    assert response["description"] == "mountains"
+    assert response["language"] == "en"
+    assert response["confidence"] == 0.9
+
+
+@pytest.mark.asyncio
+async def test_execute_action_vision_describe_uses_current_attachment() -> None:  # type: ignore[no-untyped-def]
+    from plugins.iris_base import IrisEngineBase, IrisResult
+
+    class MockEngine(IrisEngineBase):
+        def describe_image(
+            self,
+            file_path: str,
+            mime_type: str | None = None,
+            prompt: str | None = None,
+        ) -> IrisResult | None:
+            with open(file_path, "rb") as fh:
+                assert fh.read() == b"\x89PNG"
+            assert mime_type == "image/png"
+            return IrisResult(description="mountains", language="en", confidence=0.9)
+
+    attachment_b64 = base64.b64encode(b"\x89PNG").decode("ascii")
+    fake_message = types.SimpleNamespace(
+        interface_path="custom/123",
+        attachments=[
+            {
+                "mime_type": "image/png",
+                "filename": "img.png",
+                "data": attachment_b64,
+            }
+        ],
+    )
+
+    with patch("core.core_initializer.register_plugin"):
+        from plugins.iris_plugin import IrisPlugin
+        from core.iris_registry import IrisRegistry
+
+        reg = IrisRegistry()
+        reg.register_instance("mock", MockEngine(), label="Mock")
+
+        plugin = IrisPlugin.__new__(IrisPlugin)
+        plugin._active_engine_name = "mock"
+        plugin._engine_settings = {}
+        plugin._default_prompt = "Describe."
+        plugin._default_model = ""
+
+        with (
+            patch("plugins.iris_plugin.IRIS_REGISTRY", reg),
+            patch.object(plugin, "refresh_config"),
+        ):
+            response = await plugin.execute_action(
+                {"type": "vision_describe", "payload": {}},
+                {},
+                None,
+                fake_message,
             )
 
     assert response["status"] == "success"

--- a/tests/test_message_chain_corrector.py
+++ b/tests/test_message_chain_corrector.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -67,7 +68,7 @@ async def test_message_chain_triggers_corrector_for_unregistered_action(monkeypa
     msg.from_cortex = True
 
     # Call the message chain as if the source was LLM
-    result = await message_chain.handle_incoming_message(
+    await message_chain.handle_incoming_message(
         bot=None,
         message=msg,
         text='{"actions":[{"type":"message","payload":{"text":"hello","interface_path":"telegram_bot/123"}}]}',
@@ -131,13 +132,180 @@ async def test_message_chain_triggers_corrector_for_unregistered_top_level_key(
         chat_id=123, interface_path="telegram_bot/123", from_cortex=True
     )
 
-    result = await message_chain.handle_incoming_message(
+    await message_chain.handle_incoming_message(
         bot=None,
         message=msg,
         text='{"actions": [{"type": "create_personal_diary_entry", "payload": {"interaction_summary": "x"}}], "message": "ciao"}',
         source="llm",
         context={},
     )
+
+
+@pytest.mark.asyncio
+async def test_message_chain_honors_prompt_scoped_allowed_action_types(monkeypatch):
+    corrector_calls: list[str] = []
+    run_actions_calls: list[dict] = []
+
+    async def fake_corrector(
+        text, bot=None, context=None, chat_id=None, thread_id=None
+    ):
+        corrector_calls.append(text)
+        return None
+
+    def fake_extract_json(text, return_metadata=False):
+        parsed = {
+            "actions": [
+                {
+                    "type": "vision_describe",
+                    "payload": {"prompt": "Describe this image."},
+                }
+            ]
+        }
+        return (parsed, {})
+
+    async def fake_run_actions(actions, context, bot, original_message):
+        run_actions_calls.append({"actions": actions, "context": context})
+        return {
+            "processed": list(actions or []),
+            "failed_actions": [],
+            "errors": [],
+        }
+
+    monkeypatch.setattr(
+        action_parser,
+        "get_supported_action_types",
+        lambda: set(),
+    )
+    monkeypatch.setattr(
+        "core.transport_layer.run_corrector_middleware",
+        fake_corrector,
+    )
+    monkeypatch.setattr(
+        "core.transport_layer.extract_json_from_text",
+        fake_extract_json,
+    )
+    monkeypatch.setattr("core.action_parser.run_actions", fake_run_actions)
+    monkeypatch.setattr("core.persona_manager.get_persona_manager", lambda: None)
+
+    msg = SimpleNamespace(
+        chat_id=123,
+        interface_path="telegram_bot/123",
+        from_cortex=True,
+    )
+
+    result = await message_chain.handle_incoming_message(
+        bot=None,
+        message=msg,
+        text='{"actions":[{"type":"vision_describe","payload":{"prompt":"Describe this image."}}]}',
+        source="llm",
+        context={
+            "interface_path": "telegram_bot/123",
+            "allowed_action_types": ["vision_describe"],
+        },
+    )
+
+    assert result == message_chain.ACTIONS_EXECUTED
+    assert not corrector_calls
+    assert run_actions_calls
+    assert run_actions_calls[0]["actions"][0]["type"] == "vision_describe"
+
+
+@pytest.mark.asyncio
+async def test_invalid_emotions_corrector_uses_full_run_action_signature(monkeypatch):
+    scheduled = asyncio.Event()
+    captured: dict[str, object] = {}
+
+    class FakePersonaManager:
+        def process_llm_message_for_emotions(self, text: str) -> None:
+            return None
+
+        def get_emotion_validation_corrector(self) -> str:
+            return "invalid emotions"
+
+    async def fake_run_action(action, context, bot, original_message):
+        captured["action"] = action
+        captured["context"] = context
+        captured["bot"] = bot
+        captured["original_message"] = original_message
+        scheduled.set()
+        return {"status": "ok"}
+
+    def fake_extract_json(text, return_metadata=False):
+        parsed = {
+            "actions": [
+                {
+                    "type": "message_telegram_bot",
+                    "payload": {
+                        "text": "hello",
+                        "interface_path": "telegram_bot/123",
+                    },
+                }
+            ]
+        }
+        return (parsed, {})
+
+    async def fake_run_actions(actions, context, bot, original_message):
+        return {
+            "processed": list(actions or []),
+            "failed_actions": [],
+            "errors": [],
+        }
+
+    monkeypatch.setattr(
+        "core.persona_manager.get_persona_manager",
+        lambda: FakePersonaManager(),
+    )
+    monkeypatch.setattr("core.action_parser.run_action", fake_run_action)
+    monkeypatch.setattr("core.action_parser.run_actions", fake_run_actions)
+    monkeypatch.setattr(
+        action_parser,
+        "get_supported_action_types",
+        lambda: {"message_telegram_bot"},
+    )
+    monkeypatch.setattr(
+        "core.transport_layer.extract_json_from_text",
+        fake_extract_json,
+    )
+
+    bot = object()
+    msg = SimpleNamespace(
+        chat_id=123,
+        interface_path="telegram_bot/123",
+        from_cortex=True,
+    )
+
+    result = await message_chain.handle_incoming_message(
+        bot=bot,
+        message=msg,
+        text='{"actions":[{"type":"message_telegram_bot","payload":{"text":"hello","interface_path":"telegram_bot/123"}}]}',
+        source="llm",
+        context={
+            "chat_id": 123,
+            "interface_path": "telegram_bot/123",
+            "allowed_action_types": ["message_telegram_bot"],
+        },
+    )
+
+    await asyncio.wait_for(scheduled.wait(), timeout=0.2)
+
+    assert result == message_chain.ACTIONS_EXECUTED
+    assert captured["bot"] is bot
+    assert captured["original_message"] is msg
+    context = captured["context"]
+    assert isinstance(context, dict)
+    assert context["chat_id"] == 123
+    assert context["interface_path"] == "telegram_bot/123"
+    assert context["allowed_action_types"] == ["message_telegram_bot"]
+    assert context["from_cortex"] is True
+    assert captured["action"] == {
+        "type": "send_corrector_message",
+        "payload": {
+            "correction_type": "invalid_emotions",
+            "message": "invalid emotions",
+            "interface_path": "telegram_bot/123",
+            "chat_id": 123,
+        },
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_prompt_logging.py
+++ b/tests/test_prompt_logging.py
@@ -1,3 +1,6 @@
+import json
+
+
 def make_dummy_message():
     class Dummy:
         text = "hello"
@@ -35,3 +38,67 @@ async def test_prompt_and_llm_logging(monkeypatch, capsys):
     # logs produced during both calls will still be on stdout
     _ = capsys.readouterr()
     assert result == "dummy-response"
+
+
+def test_redact_multimodal_for_logging_redacts_attachment_data() -> None:
+    from core.json_utils import redact_multimodal_for_logging
+
+    prompt = {
+        "input": {
+            "payload": {
+                "text": "describe this image",
+                "attachments": [
+                    {
+                        "mime_type": "image/jpeg",
+                        "data": "A" * 1024,
+                        "file_name": "image.jpg",
+                    }
+                ],
+            }
+        },
+        "actions": {
+            "vision_describe": {
+                "schema": {
+                    "properties": {
+                        "image_path": {"description": "Path to the source image."}
+                    }
+                }
+            }
+        },
+    }
+
+    redacted = redact_multimodal_for_logging(prompt)
+
+    assert redacted["input"]["payload"]["attachments"][0]["data"] == (
+        "<redacted: 1024 chars>"
+    )
+    assert (
+        redacted["actions"]["vision_describe"]["schema"]["properties"]["image_path"][
+            "description"
+        ]
+        == "Path to the source image."
+    )
+
+
+def test_redact_multimodal_for_logging_parses_json_response_strings() -> None:
+    from core.json_utils import redact_multimodal_for_logging
+
+    response = json.dumps(
+        {
+            "actions": [
+                {
+                    "type": "vision_describe",
+                    "payload": {
+                        "image_path": "A" * 768,
+                        "mime_type": "image/jpeg",
+                    },
+                }
+            ]
+        }
+    )
+
+    redacted = redact_multimodal_for_logging(response)
+
+    assert redacted["actions"][0]["payload"]["image_path"] == (
+        "<redacted-inline-media: 768 chars>"
+    )


### PR DESCRIPTION
## Summary

This PR brings 15 commits from Scarlet-Raine/feat/iris ahead of the upstream
`feat/iris` base, covering four areas: Gemini Live API modernization, a new
model-agnostic live tool-call pipeline, corrector reliability fixes, and
AI-agent development tooling.

**Fully tested, interface output fails extremely rarely only due to correction not managing to fix it**
---

## What's Changed

### 🎙 Gemini Live — Gemini 3.1 + Session Resilience

**`5b7f43f`** `feat(gemini): update to Gemini 3.1 Live and refresh all API docs`
- Targets Gemini 3.1 Flash Live throughout; refreshes all `docs/gemini/*.md`
  to the current API surface (liveapi, live sessions, live tools, deprecations).
- Adds `fetch_gemini_docs.py` helper to keep docs current.
- Misc improvements: `action_parser`, `config`, `message_queue`,
  `plugin_instance`, `prompt_engine`, `grillo` outreach plugin,
  `telegram_bot`, `test_live_session_manager`, `uv.lock`.

**`aab8f89`** `feat(live): add session resumption and context window compression`
- Implements Google's recommended resilience approach for long-running sessions:
  - `SessionResumptionConfig` passed in every `LiveConnectConfig`; server
    delivers `SessionResumptionUpdate` messages whose handle is stored in
    `LiveSessionState.resumption_handle`.
  - `GoAway` messages trigger a proactive reconnect at the next turn boundary.
  - `_reconnect_inner`: fast-path resumes via stored handle (no cold restart);
    fallback rebuilds system instruction + tools from scratch.
  - `ContextWindowCompressionConfig` with `SlidingWindow` keeps audio-only
    sessions alive beyond the 15-min raw limit (effectively unlimited with
    compression enabled).

**`9016c21`** `fix(live): restore text reply templating for voice sync`

**`ecc7898`** `patch(core): refine live sequencing and scoped context`

**`d41c86d`** `fix(live): fix voice session reading system prompt and emotion tags aloud`
- Skip kick-text injection on session resumption to prevent unsolicited model
  turns before any audio.
- Strip numeric intensities from emotion NL in live system instruction
  (`"devotion (5.0 - moderate)"` → `"moderate devotion"`).
- Filter bot self-messages and internal agents (grillo, ai_diary) from live
  context updates to prevent feedback loops.
- Cap diary blob length to prevent 50 k+ char merged entries flooding the
  prompt context.
- Elevate persona + verbose instructions to Gemini system instruction.
- Suppress false-positive `CryptoError` log noise from `discord-ext-voice-recv`
  RTCP PSFB packets (known upstream non-fatal limitation).

---

### 🔧 Model-Agnostic Live Tool-Call Infrastructure

**`3e068c0`** `feat(live): implement model-agnostic live tool call infrastructure`

Replaces the Gemini-locked `_build_gemini_tool_declarations` approach with a
fully engine-agnostic pipeline:

| New module | Purpose |
|---|---|
| `core/live_tool_registry.py` | `ToolManifest` + `LiveToolRegistry` — reads `get_action_plugin_instructions()` into model-agnostic manifests |
| `core/live_tool_executor.py` | `LiveToolExecutor` — dispatches `TOOL_CALL` `LiveEvent`s to `run_action` with per-tool timeout and bot resolution |
| `core/live_tool_adapters/gemini.py` | `GeminiToolAdapter` — manifests → `genai.types.Tool`; honours `async_ok` + `engine_supports_nonblocking` for Gemini 2.5 `NON_BLOCKING` mode |
| `core/live_tool_adapters/openai_realtime.py` | Stub adapter for future OpenAI Realtime engine (standard JSON Schema format) |
| `docs/gemini/live-tool-calls-plan.md` | Architecture plan and 5-phase migration (no breaking changes) |

Updated: `plugins/live_base.py` (new `TOOL_CALL` event type, `ToolCallPayload`,
`send_tool_response()`), `plugins/live_engines/gemini.py` (full implementation),
`core/live_session_manager.py` (history config, `inject_initial_context()`,
`set_tool_executor()`), `interface/discord_interface.py` (wired new adapters).

---

### 🐛 Bug Fixes

**`5f5ec27`** `fix(corrector): use CORRECTION NEEDED prompt when no actions succeeded`
- **Root cause:** When the LLM emitted bare dict actions without a `type` field
  (e.g. `{"arousal": 5}`), `run_corrector_middleware` built a
  `"PARTIAL SUCCESS — 0 actions succeeded … do NOT repeat successful ones"`
  message — a self-contradictory instruction. The LLM returned an empty string
  all 4 attempts, exhausted retries, and fell back to the `😵` emoji.
- **Fix:** Gate on `if successful_actions:` before using the PARTIAL SUCCESS
  path. When the list is empty, emit a plain `CORRECTION NEEDED` prompt asking
  for a full resend and explicitly stating that emotion names must not be used
  as action types.
- **Hardening:** Added `"Every action object inside 'actions' MUST have a
  'type' field"` to `strict_requirements`. Partial-success path (≥1 action)
  is unchanged.

**`b07f342`** `fix(gemini): fix non-JSON output, null model crash, and missing cortex_api logging`
- Remove spurious `PluginBase` from `GeminiAPIPlugin` inheritance (MRO / registry pollution).
- Guard `_get_gemini_model()` against `None` return from `get_current_model()`.
- Filter `thought=True` parts from Gemini responses before returning to the
  message chain.
- Add `log_cortex_request/log_cortex_response` to `ExternalCortexEngine.generate_response`
  so `cortex_api.log` is populated regardless of which cortex engine is active.

**`f91cd9a`** `fix(persona): inject persona into instructions_verbose and load likes/dislikes from config`
- Prepend `static_persona` to `instructions_verbose` so all LLM engines see it.
- Load `SYNTH_LIKES`/`SYNTH_DISLIKES` from `config_registry` in `load_persona()`
  instead of hardcoding `[]`.
- Skip empty Likes/Dislikes/Interests lines in `get_static_injection()`.
- Add `responseMimeType: application/json` to Gemini REST `generationConfig`.
- Add IDENTITY INTEGRITY and PRONOUN CONSISTENCY rules to chat instructions.
- Fix `history_engine` verbosity slicing to apply per-group after dedup.

**`016683a`** `Fix AI diary SQL bug, fix TTS fallback, and include unstaged core improvements`
- `ai_diary.py`: Fix SQL format string bug in diary consolidation.
- `vox_plugin.py`: Fix TTS fallback suppression when auto-injected.
- `message_queue.py`: Fix `"bound to different event loop"` via
  `global _queue/_lock` fixes.
- `live_session_manager.py`: Add cold-restart history injection,
  `turn_was_interrupted` flag.
- `discord_interface.py`: Add bot-left VSU guard, image attachment injection.
- `config.py`: Add `LIVE_AUDIO_MIN_RMS` config var.

---

### 🤖 AI-Agent Development Tooling

**`135e072`** `feat(agents): add synth-logs MCP server and agent development tooling`
- New `mcp_servers/synth_logs.py`: stdio MCP server with four tools
  (`list_log_files`, `search_logs`, `tail_log`, `get_recent_errors`) that
  transparently span log rotations (logs rotate at 2000 lines in DEBUG mode).
- Wired into `.mcp.json` (Claude Code / Antigravity), `.vscode/mcp.json`
  (Copilot); `.vscode/mcp.json` unignored so the config ships on clone.
- `AGENTS.md` extended with: first-time setup instructions, DB table quick
  reference (§13), config registry key reference (§14), and known-issues
  registry (§12) with agent instruction to document new issues in-place.
- `CLAUDE.md` extended with: MCP tools reference, debugging SOP, token trap
  warnings, and known-issues documentation rule.
- `README.md`: AI-assisted development section added for contributors.

---

### 📄 Housekeeping

**`be2910b`** `feat(core): implement robust LLM action normalization and resolve 2B persona warnings`

**`52af9c3`** `chore(skins): gitignore 2B persona.json and remove from tracking`

**`5e5caf7`** `docs: update README with Windows DB warning and remove outdated selenium engines`

**`b38a9d3`** `chore(docs): update gitnexus index stats and add skill reference files`
- `CLAUDE.md`: bump gitnexus index counts to 7489 symbols / 24 879 relationships.
- `.claude/skills/gitnexus/`: add six skill reference files (exploring,
  debugging, impact-analysis, refactoring, guide, cli) for AI agents.

---

## Commits (15)

| Hash | Scope | Subject |
|---|---|---|
| `5b7f43f` | gemini | update to Gemini 3.1 Live and refresh all API docs |
| `3e068c0` | live | implement model-agnostic live tool call infrastructure |
| `aab8f89` | live | add session resumption and context window compression |
| `016683a` | — | Fix AI diary SQL bug, fix TTS fallback, and include unstaged core improvements |
| `d41c86d` | live | fix voice session reading system prompt and emotion tags aloud |
| `b07f342` | gemini | fix non-JSON output, null model crash, and missing cortex_api logging |
| `ecc7898` | core | refine live sequencing and scoped context |
| `9016c21` | live | restore text reply templating for voice sync |
| `be2910b` | core | implement robust LLM action normalization and resolve 2B persona warnings |
| `f91cd9a` | persona | inject persona into instructions_verbose and load likes/dislikes from config |
| `135e072` | agents | add synth-logs MCP server and agent development tooling |
| `5f5ec27` | corrector | use CORRECTION NEEDED prompt when no actions succeeded |
| `52af9c3` | skins | gitignore 2B persona.json and remove from tracking |
| `5e5caf7` | docs | update README with Windows DB warning and remove outdated selenium engines |
| `b38a9d3` | docs | update gitnexus index stats and add skill reference files |

---

## Testing

- `uv run pytest` — all corrector, message chain, and live session manager tests pass.
- Pre-existing failure in `test_corrector_on_top_level_message.py` confirmed pre-existing (documented in AGENTS.md §12); not introduced by this PR.
- Gemini Live tested end-to-end via Discord voice channel with session resumption and tool calls.