### PR TITLE
Full Postgres database migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -815,6 +815,14 @@ docker exec synth-dev tail -f /app/logs/synth.log | grep -E "\[grillo\]|grillo"
 
 ---
 
+### Stale `synth` image after branch switch can keep the old MySQL code path  <!-- 2026-05-11 -->
+**Symptom:** On `feat/postgres-migration`, `synth-db` (Postgres) is healthy and `docker compose config` resolves `DB_HOST=synth-db` / `DB_PORT=5432`, but WebUI still fails with TLS EOF and `synth` logs show `aiomysql` errors such as `OperationalError(2013, 'Lost connection to MySQL server during query')` or `Can't connect to MySQL server on 'synth-db'`.
+**Location:** Docker runtime / rebuilt state of the `synth` application container after changing branches.
+**Status:** known / operational workaround.
+**Notes:** The running `synth` container can still contain code from the previous branch even though the workspace and compose file are already on the Postgres migration branch. In the observed case, `/app/core/db.py` inside the live container still defaulted `_get_db_type()` to `mariadb`, while the workspace version defaulted to `postgres`. Safe recovery was: `docker compose up -d --build synth`, then verify the live container code and recheck `https://localhost:8000`.
+
+---
+
 ### Repo-wide lint still has unrelated failures, but broad pytest is green  <!-- 2026-05-07 -->
 **Symptom:** `uv run ruff check --fix .` can still fail on pre-existing files outside most feature slices (observed in `interface/message_send_utils.py`, `interface_dev/reddit_interface.py`, `interface_dev/telethon_userbot.py`, `interface_dev/x_interface.py`, `plugins/bio_manager.py`), but broad `uv run pytest --ignore=tests/plugins/test_selenium_ttsfree.py -q --disable-warnings` passed on `2026-05-07` with `1185 passed, 15 skipped`.
 **Location:** Mixed pre-existing validation debt across interfaces, plugins, and broad regression suite.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -807,6 +807,14 @@ docker exec synth-dev tail -f /app/logs/synth.log | grep -E "\[grillo\]|grillo"
 
 ---
 
+### Orphan `synth-soul-db` can block the Postgres-first runtime on port 5432  <!-- 2026-05-11 -->
+**Symptom:** The browser can show `Unsafe attempt to load URL https://localhost:8000/ from frame with URL chrome-error://chromewebdata/`, `curl -kI https://localhost:8000` fails with TLS EOF / broken pipe, and `synth` logs loop on startup with `Legacy DB cutover failed: [Errno -2] Name or service not known`.
+**Location:** Docker Compose runtime state after switching to the Postgres-first stack; stale orphan containers such as `synth-soul-db` and `synth-db-backup` can survive from the older topology.
+**Status:** known / operational workaround.
+**Notes:** In the observed failure, the current `synth-db` service could not bind host port `5432` because orphan `synth-soul-db` still owned it. `docker compose up -d --force-recreate synth-db synth` then left `synth` and `synth-legacy-db` on `synth_network` while `synth-db` never came up correctly, so `synth` could resolve `synth-legacy-db` but not `synth-db`. Safe recovery was: stop the orphan containers without deleting volumes, then rerun `docker compose up -d --force-recreate synth-db synth`. After that, `docker exec synth getent hosts synth-db synth-legacy-db` resolved both hosts and `https://localhost:8000` returned `200 OK` again.
+
+---
+
 ### Repo-wide lint still has unrelated failures, but broad pytest is green  <!-- 2026-05-07 -->
 **Symptom:** `uv run ruff check --fix .` can still fail on pre-existing files outside most feature slices (observed in `interface/message_send_utils.py`, `interface_dev/reddit_interface.py`, `interface_dev/telethon_userbot.py`, `interface_dev/x_interface.py`, `plugins/bio_manager.py`), but broad `uv run pytest --ignore=tests/plugins/test_selenium_ttsfree.py -q --disable-warnings` passed on `2026-05-07` with `1185 passed, 15 skipped`.
 **Location:** Mixed pre-existing validation debt across interfaces, plugins, and broad regression suite.
@@ -932,6 +940,22 @@ docker exec synth-dev tail -f /app/logs/synth.log | grep -E "\[grillo\]|grillo"
 **Location:** `interface/telegram_bot.py` throughout.
 **Status:** known, not fixed — all pre-existing before any session modifications.
 **Notes:** These are python-telegram-bot optional-chaining patterns that `ty` doesn't resolve without stub annotations. Any agent editing this file will see the same errors and should confirm via `git diff` that their change is limited to a single line before concluding the errors are pre-existing.
+
+---
+
+### `core/webui.py` has broad pre-existing `ty check` noise  <!-- 2026-05-11 -->
+**Symptom:** `uv run ty check core/webui.py` emits a long list of pre-existing diagnostics such as Starlette middleware callable mismatches, unresolved animation-handler attributes on stub unions, optional persona-manager attribute access, and deprecated `datetime.utcnow()` usage.
+**Location:** `core/webui.py` throughout.
+**Status:** known, not fixed.
+**Notes:** During the manual-backup WebUI work, `get_errors` stayed clean for the touched backup route/button code, but scoped `ty` still reported many unrelated historical issues across the file. Validate local WebUI edits with focused tests plus `get_errors`, and do not assume fresh `ty` noise in this file came from a small endpoint/template change.
+
+---
+
+### WebUI startup history replay could show the oldest prompt-context window instead of the recent chat  <!-- 2026-05-11 -->
+**Symptom:** After a restart, the WebUI could appear to have "lost" chat history even though `chat_history_cache` still contained the messages. Logs showed lines like `[context_manager] Loaded 10 messages for interface_path synth_webui/webui_default` and `[synth_webui] _replay_history: sent 10 messages ...`, but the replayed window reflected the oldest cached rows or only the smaller prompt-context deque.
+**Location:** `core/chat_history_cache.py` (`load_chat_history` ordering/limit), `core/webui.py` (`_ensure_session_history_loaded`), and `core/chat_context_manager.py` (prompt-context deque size).
+**Status:** fixed.
+**Notes:** Two separate issues combined here: `load_chat_history()` fetched `ORDER BY timestamp ASC LIMIT N`, which returned the oldest N rows instead of the most recent N, and WebUI startup bound `self.message_history` to the context-manager deque whose default maxlen is 10 even though the WebUI can hold far more. The fix now fetches the most recent N rows then reorders them chronologically, and WebUI rehydrates its visible history directly from persisted cache with `self.max_history` while still loading the smaller prompt context separately.
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates \
       openssl \
       htop net-tools iputils-ping \
-      ffmpeg mariadb-client libmariadb-dev \
+  ffmpeg mariadb-client libmariadb-dev postgresql-client \
       espeak \
       xz-utils \
     && rm -rf /var/lib/apt/lists/* \

--- a/README.md
+++ b/README.md
@@ -109,20 +109,24 @@ The project ships with an **Ollama-compatible interface** (`interface/ollama_com
 
 4.  Connect to the WebUI via HTTPS (default port is **8000**): `https://localhost:8000`.
 
-#### Optional: Enable SOUL PostgreSQL + pgvector backend
+#### Database runtime and automatic migration
 
-By default, SOUL uses in-memory persistence. To enable persistent SOUL storage:
+The Docker stack now runs the main Synthetic Heart runtime on **PostgreSQL** by default.
+SOUL shares that same runtime Postgres database as part of the default stack.
 
-1. Set these environment variables in your `.env`:
-   - `SYNTH_PRIMARY_DB=soul` if you want the main app DB to use the SOUL Postgres connection explicitly
-   - `SOUL_REPOSITORY_BACKEND=postgres`
-   - `SOUL_POSTGRES_DSN=postgresql://soul:soul@synth-soul-db:5432/soul_memory`
-   - Optional overrides: `SOUL_PG_HOST`, `SOUL_PG_PORT`, `SOUL_PG_DB`, `SOUL_PG_USER`, `SOUL_PG_PASSWORD`, `EXT_SOUL_DB_PORT`
-2. Start the SOUL DB service and apply schema:
-   - Linux/macOS: `bash scripts/bootstrap_soul_postgres.sh`
-   - Windows PowerShell: `./scripts/bootstrap_soul_postgres.ps1`
-3. Restart the stack:
-   - `docker compose up -d --build`
+If you are upgrading from an older MariaDB-based deployment:
+
+1. Keep the existing Docker volume and existing backups.
+2. Start the updated stack normally with `docker compose up -d --build`.
+3. On first boot, Synth will:
+   - import any legacy standalone SOUL Postgres data into the runtime Postgres when a legacy SOUL DSN is configured,
+   - archive the legacy MySQL source into the mounted `backups/` directory,
+   - migrate runtime data from the internal legacy MariaDB source into Postgres,
+   - resume normal startup entirely on Postgres.
+
+The legacy database is preserved for verification and archival purposes, but the active runtime uses a single Postgres database.
+
+Manual runtime backups are available from the WebUI Settings tab and write compressed dumps into the mounted `backups/` directory.
 
 #### Optional: Migrate Existing MariaDB memories into SOUL
 
@@ -147,7 +151,7 @@ Migration notes:
 
 > [!WARNING]
 > **DATABASE SETUP REQUIRED**
-> Database setup is **not automated** on Windows native environments. You must install MariaDB/MySQL separately, configure your local database (using the schema found in `init-db.sql`), and manually set the connection parameters in your `.env` file before running the application!
+> Database setup is **not automated** on Windows native environments. You must install PostgreSQL locally, create the application database, and configure the `DB_*` connection values in your `.env` file before running the application.
 
 For the fastest development experience on Windows, we recommend using **uv**. It handles Python installation, virtual environments, and dependencies automatically.
 
@@ -161,8 +165,8 @@ For the fastest development experience on Windows, we recommend using **uv**. It
     cd Synthetic_Heart
     ```
 3.  **Configure `.env` and Database:**
-    - Install MariaDB or MySQL.
-    - Create a database and run the `init-db.sql` script to set up the necessary tables.
+   - Install PostgreSQL.
+   - Create a database for Synthetic Heart.
     - Copy `.env.example` to `.env` and update the `DB_*` connection strings to match your local setup.
 4.  **Sync Dependencies:**
     ```powershell

--- a/core/chat_history_cache.py
+++ b/core/chat_history_cache.py
@@ -245,11 +245,13 @@ async def save_chat_message(
         return False
 
 
-async def load_chat_history(interface_path: str) -> deque:
+async def load_chat_history(interface_path: str, limit: int | None = None) -> deque:
     """Load chat history from cache for a specific interface path.
 
     Args:
         interface_path: The interface path (e.g., telegram_bot/123456/2)
+        limit: Optional explicit row limit. When omitted, uses the configured
+            history limit for the calling subsystem.
 
     Returns:
         deque of message objects in chronological order
@@ -260,15 +262,22 @@ async def load_chat_history(interface_path: str) -> deque:
     try:
         async with get_conn_ctx() as conn:
             async with conn.cursor() as cur:
-                history_limit = _get_history_limit(10)
-                # Load messages in chronological order
+                history_limit = (
+                    max(1, int(limit)) if limit is not None else _get_history_limit(10)
+                )
+                # Fetch the most recent N rows, then reorder them chronologically
+                # for downstream consumers such as WebUI replay and prompt context.
                 await cur.execute(
                     """
                     SELECT sender_name, sender_id, message_text, timestamp, interface_path, metadata
-                    FROM chat_history_cache
-                    WHERE interface_path = %s
+                    FROM (
+                        SELECT sender_name, sender_id, message_text, timestamp, interface_path, metadata, id
+                        FROM chat_history_cache
+                        WHERE interface_path = %s
+                        ORDER BY timestamp DESC, id DESC
+                        LIMIT %s
+                    ) AS recent_messages
                     ORDER BY timestamp ASC, id ASC
-                    LIMIT %s
                 """,
                     (interface_path, history_limit),
                 )

--- a/core/db.py
+++ b/core/db.py
@@ -4,7 +4,8 @@ from datetime import datetime, timezone, timedelta
 import calendar
 import asyncio
 import time
-from urllib.parse import unquote, urlparse
+from pathlib import Path
+from urllib.parse import quote, unquote, urlparse
 
 from types import SimpleNamespace
 from typing import Any
@@ -13,7 +14,7 @@ from typing import Any
 # minimal stub when it's not installed so modules depending on ``core.db`` can
 # still be imported during tests.
 try:  # pragma: no cover - import guard
-    import aiomysql  # type: ignore
+    import aiomysql
 except Exception:  # pragma: no cover - executed when aiomysql missing
 
     async def _missing_connect(*args, **kwargs):
@@ -22,7 +23,7 @@ except Exception:  # pragma: no cover - executed when aiomysql missing
     # Provide a minimal stub exposing the async connect/create_pool API so
     # calling sites receive a clear RuntimeError instead of an AttributeError
     # when aiomysql is not installed.
-    aiomysql = SimpleNamespace(  # type: ignore
+    aiomysql: Any = SimpleNamespace(
         Connection=object,
         DictCursor=object,
         Cursor=object,
@@ -31,7 +32,7 @@ except Exception:  # pragma: no cover - executed when aiomysql missing
     )
 
 if not hasattr(aiomysql, "DictCursor"):
-    aiomysql.DictCursor = object  # type: ignore[attr-defined]
+    aiomysql.DictCursor = object
 
 from core.db_backends import (
     PostgresCompatConnection,
@@ -95,6 +96,15 @@ def _get_db_dsn() -> str | None:
     return os.getenv("DATABASE_URL") or os.getenv("DB_DSN")
 
 
+def build_postgres_dsn(
+    *, host: str, port: int, user: str, password: str, database: str
+) -> str:
+    return (
+        f"postgresql://{quote(str(user))}:{quote(str(password))}@"
+        f"{host}:{port}/{quote(str(database))}"
+    )
+
+
 def _get_db_type() -> str:
     target = _get_primary_db_target()
     if target == "memory":
@@ -102,7 +112,18 @@ def _get_db_type() -> str:
     if target == "soul":
         return "postgres"
 
-    value = os.getenv("SYNTH_DB_TYPE", os.getenv("DB_TYPE", "mariadb"))
+    value = os.getenv("SYNTH_DB_TYPE", os.getenv("DB_TYPE", "postgres"))
+    normalized = str(value or "postgres").strip().lower()
+    if normalized in {"mysql", "mariadb"}:
+        return "mariadb"
+    if normalized in {"postgres", "postgresql"}:
+        return "postgres"
+    return "postgres"
+    return "mariadb"
+
+
+def _get_source_db_type() -> str:
+    value = os.getenv("SOURCE_DB_TYPE", "mariadb")
     normalized = str(value or "mariadb").strip().lower()
     if normalized in {"mysql", "mariadb"}:
         return "mariadb"
@@ -176,6 +197,90 @@ def _read_db_config():
     return host, port, user, passwd, dbname
 
 
+def _read_source_db_config() -> tuple[str, int, str, str, str]:
+    backend = _get_source_db_type()
+    default_port = 5432 if backend == "postgres" else 3306
+
+    if backend == "postgres":
+        source_dsn = os.getenv("SOURCE_DB_DSN") or os.getenv("SOURCE_DATABASE_URL")
+        dsn_host, dsn_port, dsn_user, dsn_pass, dsn_name = _parse_dsn_components(
+            source_dsn
+        )
+        host = str(os.getenv("SOURCE_DB_HOST") or dsn_host or "localhost")
+        try:
+            port = int(os.getenv("SOURCE_DB_PORT") or dsn_port or default_port)
+        except Exception:
+            port = dsn_port or default_port
+        user = str(os.getenv("SOURCE_DB_USER") or dsn_user or "synth")
+        passwd = str(
+            os.getenv("SOURCE_DB_PASSWORD")
+            or os.getenv("SOURCE_DB_PASS")
+            or dsn_pass
+            or "synth"
+        )
+        dbname = str(os.getenv("SOURCE_DB_NAME") or dsn_name or "synth")
+        return host, port, user, passwd, dbname
+
+    runtime_defaults = _read_db_config() if _get_db_type() == "mariadb" else None
+    host = str(
+        os.getenv("SOURCE_DB_HOST")
+        or (runtime_defaults[0] if runtime_defaults is not None else "synth-legacy-db")
+    )
+    try:
+        port = int(
+            os.getenv("SOURCE_DB_PORT")
+            or (runtime_defaults[1] if runtime_defaults is not None else default_port)
+        )
+    except Exception:
+        port = runtime_defaults[1] if runtime_defaults is not None else default_port
+    user = str(
+        os.getenv("SOURCE_DB_USER")
+        or (runtime_defaults[2] if runtime_defaults is not None else "synth")
+    )
+    passwd = str(
+        os.getenv("SOURCE_DB_PASSWORD")
+        or os.getenv("SOURCE_DB_PASS")
+        or (runtime_defaults[3] if runtime_defaults is not None else "synth")
+    )
+    dbname = str(
+        os.getenv("SOURCE_DB_NAME")
+        or (runtime_defaults[4] if runtime_defaults is not None else "synth")
+    )
+    return host, port, user, passwd, dbname
+
+
+def build_runtime_postgres_dsn() -> str:
+    dsn = _get_db_dsn()
+    if dsn:
+        return str(dsn)
+    if _get_db_type() != "postgres":
+        return ""
+    host, port, user, passwd, dbname = _read_db_config()
+    return build_postgres_dsn(
+        host=str(host),
+        port=int(port),
+        user=str(user),
+        password=str(passwd),
+        database=str(dbname),
+    )
+
+
+def build_source_postgres_dsn() -> str:
+    dsn = os.getenv("SOURCE_DB_DSN") or os.getenv("SOURCE_DATABASE_URL")
+    if dsn:
+        return str(dsn)
+    if _get_source_db_type() != "postgres":
+        return ""
+    host, port, user, passwd, dbname = _read_source_db_config()
+    return build_postgres_dsn(
+        host=str(host),
+        port=int(port),
+        user=str(user),
+        password=str(passwd),
+        database=str(dbname),
+    )
+
+
 # Test di connessione con retry e logging dettagliato
 async def wait_for_db(max_attempts=10, delay=3):
     """Wait for the DB to be reachable, with retry and detailed logging."""
@@ -214,6 +319,58 @@ async def wait_for_db(max_attempts=10, delay=3):
     return False
 
 
+async def connect_runtime_postgres() -> Any:
+    if _get_db_type() != "postgres":
+        raise RuntimeError("Runtime database is not configured as postgres")
+    host, port, user, passwd, dbname = _read_db_config()
+    return await probe_postgres_connection(
+        host=host,
+        port=port,
+        user=user,
+        password=passwd,
+        database=dbname,
+        dsn=build_runtime_postgres_dsn() or None,
+    )
+
+
+async def connect_postgres_dsn(dsn: str) -> Any:
+    if not str(dsn or "").strip():
+        raise RuntimeError("Postgres DSN is empty")
+    host, port, user, passwd, dbname = _parse_dsn_components(dsn)
+    return await probe_postgres_connection(
+        host=host or "localhost",
+        port=port or 5432,
+        user=user or "synth",
+        password=passwd or "",
+        database=dbname or "synth",
+        dsn=dsn,
+    )
+
+
+async def connect_source_db() -> Any:
+    backend = _get_source_db_type()
+    host, port, user, passwd, dbname = _read_source_db_config()
+    if backend == "postgres":
+        return await probe_postgres_connection(
+            host=host,
+            port=port,
+            user=user,
+            password=passwd,
+            database=dbname,
+            dsn=build_source_postgres_dsn() or None,
+        )
+    return await aiomysql.connect(
+        host=host,
+        port=port,
+        user=user,
+        password=passwd,
+        db=dbname,
+        charset="utf8mb4",
+        autocommit=True,
+        cursorclass=aiomysql.DictCursor,
+    )
+
+
 _db_logging_initialized = False
 
 # Track if we've already warned about unsupported `max_execution_time` so we don't spam logs
@@ -248,7 +405,10 @@ _last_db_log_time = 0
 
 # Database connection pool
 _pools_by_loop: dict[int, Any] = {}
+_pool: Any = None
 _pool_lock = asyncio.Lock()
+_named_postgres_pools_by_loop: dict[int, dict[str, Any]] = {}
+_named_postgres_pool_lock = asyncio.Lock()
 
 # Track active connections for leak detection and monitoring
 _active_conn_count = 0
@@ -256,17 +416,67 @@ _conn_acquired_times: dict[int, float] = {}
 _conn_acquired_stacks: dict[int, str] = {}
 
 
+def _get_current_loop_id() -> int:
+    try:
+        current_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return 0
+    return id(current_loop)
+
+
+async def get_named_postgres_pool(
+    *,
+    pool_key: str,
+    dsn: str,
+    minsize: int = 1,
+    maxsize: int = 5,
+    server_settings: dict[str, str] | None = None,
+) -> Any:
+    """Return a reusable named PostgreSQL pool managed by core.db.
+
+    Runtime slices that need a dedicated Postgres target (for example SOUL)
+    should request it through this helper instead of owning driver calls.
+    Pools are scoped per event loop to avoid cross-loop reuse errors.
+    """
+    if not str(pool_key or "").strip():
+        raise ValueError("pool_key is required")
+    if not str(dsn or "").strip():
+        raise ValueError("dsn is required")
+    if not postgres_driver_available():
+        raise RuntimeError("asyncpg is not installed")
+
+    loop_id = _get_current_loop_id()
+    loop_pools = _named_postgres_pools_by_loop.get(loop_id)
+    if loop_pools is not None and pool_key in loop_pools:
+        return loop_pools[pool_key]
+
+    async with _named_postgres_pool_lock:
+        loop_pools = _named_postgres_pools_by_loop.setdefault(loop_id, {})
+        pool = loop_pools.get(pool_key)
+        if pool is None:
+            log_info(
+                f"[db] Creating named postgres pool '{pool_key}' for loop id={loop_id}"
+            )
+            pool = await create_postgres_pool(
+                host="",
+                port=0,
+                user="",
+                password="",
+                database="",
+                minsize=max(1, int(minsize)),
+                maxsize=max(max(1, int(minsize)), int(maxsize)),
+                dsn=dsn,
+                server_settings=server_settings,
+            )
+            loop_pools[pool_key] = pool
+        return pool
+
+
 async def get_pool():
     """Get or create the database connection pool."""
     global _pool
     # Determine current event loop and use/create a pool bound to it.
-    try:
-        current_loop = asyncio.get_running_loop()
-    except RuntimeError:
-        # No running loop (sync context). Use loop id 0 as a fallback key.
-        current_loop = None
-
-    loop_id = id(current_loop) if current_loop is not None else 0
+    loop_id = _get_current_loop_id()
 
     pool = _pools_by_loop.get(loop_id)
     if pool is None:
@@ -364,7 +574,7 @@ def get_pool_debug_info(max_stacks: int = 3) -> dict:
     This is safe to call from sync code and used by debug endpoints.
     """
     try:
-        info = {
+        info: dict[str, Any] = {
             "active_connections": _active_conn_count,
             "acquired_count": len(_conn_acquired_times),
             "oldest_held_seconds": None,
@@ -520,10 +730,15 @@ async def get_conn() -> Any:
             # Only warn if we're at or very close to pool limit
             # For small pools (size 1-2), require actual connection pressure
             # For larger pools, warn when within 2 of limit
-            warning_threshold = (
-                max(maxsize - 2, maxsize) if maxsize and maxsize > 2 else maxsize
-            )
-            if maxsize and _active_conn_count >= warning_threshold:
+            warning_threshold: int | None = None
+            if isinstance(maxsize, int):
+                warning_threshold = (
+                    max(maxsize - 2, maxsize) if maxsize > 2 else maxsize
+                )
+            if (
+                warning_threshold is not None
+                and _active_conn_count >= warning_threshold
+            ):
                 # Compute the oldest-held connection age and include a stack
                 oldest_age = 0
                 oldest_id = None
@@ -984,6 +1199,30 @@ def _pick_preferred_cortex(candidates: set[str]) -> str | None:
     )[0]
 
 
+def _load_sql_statements(sql_path: Path) -> list[str]:
+    if not sql_path.exists():
+        raise FileNotFoundError(f"SQL schema file not found: {sql_path}")
+    filtered_lines = [
+        line
+        for line in sql_path.read_text(encoding="utf-8").splitlines()
+        if not line.strip().startswith("--")
+    ]
+    return [
+        statement.strip()
+        for statement in "\n".join(filtered_lines).split(";")
+        if statement.strip()
+    ]
+
+
+def _runtime_postgres_schema_path() -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "scripts"
+        / "sql"
+        / "app_main_postgres.sql"
+    )
+
+
 async def _heal_cortex_config(cur: Any) -> None:
     """Normalize stale cortex config without clobbering valid built-in engines."""
     try:
@@ -1052,21 +1291,27 @@ async def _heal_cortex_config(cur: Any) -> None:
 
 
 async def init_db() -> None:
-    """Asynchronously initialize essential MariaDB tables (core only)."""
+    """Asynchronously initialize essential runtime database tables."""
     async with get_conn_ctx() as conn:
         try:
             # Ensure we have a cursor to run schema creation for core tables
             async with conn.cursor() as cur:
-                await cur.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS config (
-                        `config_key` VARCHAR(255) PRIMARY KEY,
-                        `value` TEXT NOT NULL,
-                        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+                if _get_db_type() == "postgres":
+                    for statement in _load_sql_statements(
+                        _runtime_postgres_schema_path()
+                    ):
+                        await cur.execute(statement)
+                else:
+                    await cur.execute(
+                        """
+                        CREATE TABLE IF NOT EXISTS config (
+                            `config_key` VARCHAR(255) PRIMARY KEY,
+                            `value` TEXT NOT NULL,
+                            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+                        )
+                        """
                     )
-                    """
-                )
 
                 # Insert default config entries if they don't exist (use `config` table)
                 await cur.execute(
@@ -1126,6 +1371,28 @@ async def ensure_plugin_tables() -> None:
     hit 1146 "Table doesn't exist" errors.
     """
     try:
+        if _get_db_type() == "postgres":
+            await init_db()
+            init_fns: list[tuple[str, str]] = [
+                ("plugins.ai_diary", "init_diary_table"),
+                ("plugins.blocklist", "init_blocklist_table"),
+                ("plugins.recent_chats", "init_recent_chats_table"),
+                ("plugins.message_map", "init_message_map_table"),
+                ("plugins.bio_manager", "init_bio_table"),
+            ]
+            for module_name, attr_name in init_fns:
+                try:
+                    module = __import__(module_name, fromlist=[attr_name])
+                    init_fn = getattr(module, attr_name, None)
+                    if callable(init_fn):
+                        await init_fn()
+                except Exception as init_err:
+                    log_warning(
+                        f"[db] Postgres preflight init skipped for {module_name}.{attr_name}: {init_err}"
+                    )
+            log_debug("[db] ensure_plugin_tables completed (postgres path)")
+            return
+
         from contextlib import asynccontextmanager
 
         async def _resolve_conn_ctx() -> Any:
@@ -1591,9 +1858,9 @@ async def insert_scheduled_event(
     recurrence_type: str,
     description: str,
     created_by: str = "synth",
-    original_context: str = None,
-    conversation_user_message: str = None,
-    conversation_llm_response: str = None,
+    original_context: str | None = None,
+    conversation_user_message: str | None = None,
+    conversation_llm_response: str | None = None,
 ) -> None:
     """Insert a new scheduled event using local time and store next_run in UTC.
 
@@ -1878,7 +2145,7 @@ async def safe_db_execute(
     query: str,
     params: tuple | list = (),
     ensure_fn=None,
-) -> any:
+) -> Any:
     """Execute a SQL statement and retry once if table missing (error 1146).
 
     Args:

--- a/core/db_backends.py
+++ b/core/db_backends.py
@@ -4,9 +4,9 @@ import re
 from typing import Any, Iterable, Sequence
 
 try:  # pragma: no cover - import guard
-    import asyncpg  # type: ignore
+    import asyncpg
 except Exception:  # pragma: no cover - executed when asyncpg missing
-    asyncpg = None
+    asyncpg: Any = None
 
 
 _CONFLICT_KEYS: dict[str, tuple[str, ...]] = {
@@ -49,6 +49,7 @@ async def create_postgres_pool(
     minsize: int,
     maxsize: int,
     dsn: str | None = None,
+    server_settings: dict[str, str] | None = None,
 ) -> Any:
     if asyncpg is None:
         raise RuntimeError("asyncpg is not installed")
@@ -58,6 +59,8 @@ async def create_postgres_pool(
         "max_size": maxsize,
         "command_timeout": 30,
     }
+    if server_settings:
+        kwargs["server_settings"] = server_settings
     if dsn:
         kwargs["dsn"] = dsn
     else:

--- a/core/db_backup.py
+++ b/core/db_backup.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import asyncio
+import gzip
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from core.db import (
+    _get_db_type,
+    _get_source_db_type,
+    _read_db_config,
+    _read_source_db_config,
+)
+from core.logging_utils import log_error, log_info, log_warning
+
+
+@dataclass(slots=True)
+class DatabaseBackupPlan:
+    backend: str
+    database: str
+    output_path: Path
+    command: tuple[str, ...]
+    env: dict[str, str]
+
+
+_backup_task: asyncio.Task[None] | None = None
+
+
+def _backups_dir() -> Path:
+    backups_dir = Path(os.environ.get("SYNTH_BACKUPS_DIR", "backups")).expanduser()
+    backups_dir.mkdir(parents=True, exist_ok=True)
+    return backups_dir
+
+
+def _backup_interval_seconds() -> float:
+    raw_value = os.environ.get("SYNTH_DB_BACKUP_INTERVAL_HOURS", "24")
+    try:
+        hours = float(raw_value)
+    except (TypeError, ValueError):
+        hours = 24.0
+    return max(1.0, hours * 3600.0)
+
+
+def backups_enabled() -> bool:
+    value = str(os.environ.get("SYNTH_DB_BACKUP_ENABLED", "1") or "1").strip()
+    return value.lower() not in {"0", "false", "no", "off"}
+
+
+def build_database_backup_plan(
+    *,
+    now: datetime | None = None,
+    filename_prefix: str | None = None,
+) -> DatabaseBackupPlan:
+    backend = _get_db_type()
+    host, port, user, password, database = _read_db_config()
+    return build_database_backup_plan_for_connection(
+        backend=backend,
+        host=str(host),
+        port=int(port),
+        user=str(user),
+        password=str(password),
+        database=str(database),
+        filename_prefix=filename_prefix or f"runtime-{backend}",
+        now=now,
+    )
+
+
+def build_source_database_backup_plan(
+    *,
+    now: datetime | None = None,
+    filename_prefix: str | None = None,
+) -> DatabaseBackupPlan:
+    backend = _get_source_db_type()
+    host, port, user, password, database = _read_source_db_config()
+    return build_database_backup_plan_for_connection(
+        backend=backend,
+        host=str(host),
+        port=int(port),
+        user=str(user),
+        password=str(password),
+        database=str(database),
+        filename_prefix=filename_prefix or "legacy-source",
+        now=now,
+    )
+
+
+def build_database_backup_plan_for_connection(
+    *,
+    backend: str,
+    host: str,
+    port: int,
+    user: str,
+    password: str,
+    database: str,
+    filename_prefix: str,
+    now: datetime | None = None,
+) -> DatabaseBackupPlan:
+    backup_time = now or datetime.now(timezone.utc)
+    timestamp = backup_time.strftime("%Y%m%dT%H%M%SZ")
+    backup_root = _backups_dir()
+    env = os.environ.copy()
+
+    if backend == "postgres":
+        env["PGPASSWORD"] = str(password)
+        return DatabaseBackupPlan(
+            backend=backend,
+            database=str(database),
+            output_path=backup_root
+            / f"{filename_prefix}-{database}-{timestamp}.sql.gz",
+            command=(
+                shutil.which("pg_dump") or "pg_dump",
+                "--host",
+                host,
+                "--port",
+                str(port),
+                "--username",
+                user,
+                "--dbname",
+                database,
+                "--format=plain",
+                "--no-owner",
+                "--no-privileges",
+                "--encoding=UTF8",
+            ),
+            env=env,
+        )
+
+    env["MYSQL_PWD"] = str(password)
+    return DatabaseBackupPlan(
+        backend=backend,
+        database=str(database),
+        output_path=backup_root / f"{filename_prefix}-{database}-{timestamp}.sql.gz",
+        command=(
+            shutil.which("mysqldump") or "mysqldump",
+            "--host",
+            host,
+            "--port",
+            str(port),
+            "--user",
+            user,
+            "--single-transaction",
+            "--quick",
+            "--routines",
+            "--triggers",
+            "--skip-lock-tables",
+            database,
+        ),
+        env=env,
+    )
+
+
+def _run_backup_sync(plan: DatabaseBackupPlan) -> None:
+    executable = str(plan.command[0])
+    if not Path(executable).exists() and shutil.which(executable) is None:
+        raise RuntimeError(f"Backup executable not found: {executable}")
+
+    with subprocess.Popen(
+        plan.command,
+        env=plan.env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ) as process:
+        stdout_pipe = process.stdout
+        assert stdout_pipe is not None
+        with gzip.open(plan.output_path, "wb") as handle:
+            for chunk in iter(lambda: stdout_pipe.read(1024 * 1024), b""):
+                handle.write(chunk)
+        _, stderr_bytes = process.communicate()
+        return_code = process.returncode
+
+    if return_code == 0:
+        return
+
+    try:
+        plan.output_path.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+    stderr = stderr_bytes.decode("utf-8", errors="replace").strip()
+    raise RuntimeError(
+        f"{plan.backend} backup failed with exit code {return_code}: {stderr}"
+    )
+
+
+async def create_database_backup(
+    *,
+    reason: str = "scheduled",
+    force: bool = False,
+    filename_prefix: str | None = None,
+) -> Path | None:
+    if not force and not backups_enabled():
+        log_info("[db_backup] Backup scheduler disabled; skipping backup request")
+        return None
+
+    plan = build_database_backup_plan(filename_prefix=filename_prefix)
+    return await create_backup_from_plan(plan, reason=reason)
+
+
+async def create_source_database_backup(
+    *,
+    reason: str = "pre_migration",
+    filename_prefix: str | None = None,
+) -> Path | None:
+    plan = build_source_database_backup_plan(filename_prefix=filename_prefix)
+    return await create_backup_from_plan(plan, reason=reason)
+
+
+async def create_backup_from_plan(
+    plan: DatabaseBackupPlan, *, reason: str = "manual"
+) -> Path | None:
+    log_info(
+        f"[db_backup] Starting {reason} {plan.backend} backup to {plan.output_path.name}"
+    )
+    try:
+        await asyncio.to_thread(_run_backup_sync, plan)
+    except Exception as exc:
+        log_error(f"[db_backup] Backup failed: {exc}")
+        return None
+
+    log_info(f"[db_backup] Backup completed: {plan.output_path}")
+    return plan.output_path
+
+
+async def _backup_loop() -> None:
+    interval_seconds = _backup_interval_seconds()
+    log_info(
+        f"[db_backup] Embedded database backup scheduler active every {interval_seconds / 3600.0:.2f}h"
+    )
+    while True:
+        await asyncio.sleep(interval_seconds)
+        await create_database_backup(reason="scheduled")
+
+
+def start_database_backup_scheduler() -> asyncio.Task[None] | None:
+    global _backup_task
+    if not backups_enabled():
+        log_info("[db_backup] Embedded database backups disabled")
+        return None
+    if _backup_task is not None and not _backup_task.done():
+        return _backup_task
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        log_warning(
+            "[db_backup] No running event loop available; backup scheduler not started"
+        )
+        return None
+
+    _backup_task = loop.create_task(_backup_loop())
+    return _backup_task

--- a/core/db_cutover.py
+++ b/core/db_cutover.py
@@ -1,0 +1,568 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+from core.db import (
+    _get_db_type,
+    _get_source_db_type,
+    build_runtime_postgres_dsn,
+    connect_postgres_dsn,
+    connect_source_db,
+)
+from core.db_backup import (
+    DatabaseBackupPlan,
+    build_database_backup_plan_for_connection,
+    create_database_backup,
+    create_backup_from_plan,
+    create_source_database_backup,
+)
+from core.logging_utils import log_error, log_info, log_warning
+from core.main_db_migration import MainDbMigrator, build_default_migration_config
+from core.soul.repository import PostgresSoulRepository
+
+
+@dataclass(slots=True)
+class DbCutoverState:
+    status: str = "pending"
+    soul_status: str = "pending"
+    legacy_status: str = "pending"
+    started_at: str | None = None
+    finished_at: str | None = None
+    runtime_backup_path: str | None = None
+    legacy_backup_path: str | None = None
+    legacy_soul_backup_path: str | None = None
+    migrated_rows: int = 0
+    tables: dict[str, int] = field(default_factory=dict)
+    soul_migrated_rows: int = 0
+    soul_tables: dict[str, int] = field(default_factory=dict)
+    last_error: str | None = None
+
+
+@dataclass(slots=True)
+class _SoulTableSpec:
+    name: str
+    columns: tuple[str, ...]
+    conflict_keys: tuple[str, ...]
+    json_columns: tuple[str, ...] = ()
+    source_query: str | None = None
+    sequence_name: str | None = None
+
+
+_SOUL_TABLE_SPECS: tuple[_SoulTableSpec, ...] = (
+    _SoulTableSpec(
+        name="mem_cells",
+        columns=(
+            "id",
+            "session_id",
+            "episodic_trace",
+            "atomic_facts",
+            "emotional_tag",
+            "foresight_signals",
+            "timestamp",
+            "retrieval_count",
+            "explicit_importance",
+            "consolidated",
+            "scene_id",
+            "created_at",
+            "updated_at",
+        ),
+        conflict_keys=("id",),
+        json_columns=("atomic_facts", "emotional_tag", "foresight_signals"),
+    ),
+    _SoulTableSpec(
+        name="mem_cell_vectors",
+        columns=("mem_cell_id", "embedding"),
+        conflict_keys=("mem_cell_id",),
+        source_query="SELECT mem_cell_id, embedding::text AS embedding FROM mem_cell_vectors",
+    ),
+    _SoulTableSpec(
+        name="mem_scenes",
+        columns=("id", "title", "summary", "cell_ids", "created_at", "updated_at"),
+        conflict_keys=("id",),
+        json_columns=("cell_ids",),
+    ),
+    _SoulTableSpec(
+        name="kg_triples",
+        columns=(
+            "id",
+            "subject",
+            "predicate",
+            "object",
+            "valid_from",
+            "valid_until",
+            "scene_id",
+        ),
+        conflict_keys=("id",),
+        sequence_name="kg_triples_id_seq",
+    ),
+    _SoulTableSpec(
+        name="foresight_signals",
+        columns=(
+            "id",
+            "content",
+            "valid_until",
+            "trigger",
+            "emotional_implication",
+            "source_cell_id",
+            "priority",
+            "archived",
+            "created_at",
+            "updated_at",
+        ),
+        conflict_keys=("id",),
+        json_columns=("emotional_implication",),
+        sequence_name="foresight_signals_id_seq",
+    ),
+    _SoulTableSpec(
+        name="dsp_extractions",
+        columns=(
+            "id",
+            "session_id",
+            "extracted_at",
+            "user_facts",
+            "user_preferences",
+            "ai_self_facts",
+        ),
+        conflict_keys=("id",),
+        json_columns=("user_facts", "user_preferences", "ai_self_facts"),
+    ),
+    _SoulTableSpec(
+        name="dsp_versions",
+        columns=("id", "content", "created_at", "archived_at", "active"),
+        conflict_keys=("id",),
+    ),
+    _SoulTableSpec(
+        name="soul_emotion_snapshots",
+        columns=(
+            "id",
+            "joy",
+            "fear",
+            "sad",
+            "anger",
+            "source",
+            "context",
+            "created_at",
+        ),
+        conflict_keys=("id",),
+        sequence_name="soul_emotion_snapshots_id_seq",
+    ),
+    _SoulTableSpec(
+        name="soul_metrics",
+        columns=("metric_key", "metric_value", "measured_at"),
+        conflict_keys=("metric_key", "measured_at"),
+    ),
+)
+
+
+def _state_path() -> Path:
+    raw_path = os.environ.get(
+        "SYNTH_DB_CUTOVER_STATE_PATH", "/config/db-cutover-state.json"
+    )
+    path = Path(raw_path).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _load_state() -> DbCutoverState:
+    path = _state_path()
+    if not path.exists():
+        return DbCutoverState()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return DbCutoverState(status="pending")
+    return DbCutoverState(**{**asdict(DbCutoverState()), **payload})
+
+
+def _save_state(state: DbCutoverState) -> None:
+    _state_path().write_text(
+        json.dumps(asdict(state), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def auto_migration_enabled() -> bool:
+    value = str(os.environ.get("SYNTH_AUTO_MIGRATE_LEGACY_DB", "1") or "1").strip()
+    return value.lower() not in {"0", "false", "no", "off"}
+
+
+def _normalize_postgres_dsn(dsn: str) -> str:
+    parsed = urlparse(dsn)
+    username = unquote(parsed.username) if parsed.username else ""
+    password = unquote(parsed.password) if parsed.password else ""
+    hostname = parsed.hostname or ""
+    port = parsed.port or 5432
+    database = parsed.path.lstrip("/")
+    return f"postgresql://{username}:{password}@{hostname}:{port}/{database}"
+
+
+def _legacy_soul_source_schema() -> str:
+    return (
+        str(
+            os.environ.get("LEGACY_SOUL_POSTGRES_SCHEMA")
+            or os.environ.get("SOUL_POSTGRES_SCHEMA")
+            or "public"
+        ).strip()
+        or "public"
+    )
+
+
+def _legacy_soul_source_dsn() -> str:
+    runtime_dsn = build_runtime_postgres_dsn().strip()
+    candidates = [
+        os.environ.get("LEGACY_SOUL_POSTGRES_DSN"),
+        os.environ.get("LEGACY_SOUL_DSN"),
+        os.environ.get("SOUL_POSTGRES_DSN"),
+    ]
+    normalized_runtime = _normalize_postgres_dsn(runtime_dsn) if runtime_dsn else ""
+    for candidate in candidates:
+        raw_candidate = str(candidate or "").strip()
+        if not raw_candidate:
+            continue
+        normalized_candidate = _normalize_postgres_dsn(raw_candidate)
+        if normalized_candidate == normalized_runtime:
+            continue
+        return raw_candidate
+    return ""
+
+
+async def _legacy_soul_source_has_data(dsn: str, *, schema: str) -> bool:
+    if not dsn:
+        return False
+
+    source_conn = None
+    try:
+        source_conn = await connect_postgres_dsn(dsn)
+        qualified_table = f'"{schema}"."mem_cells"'
+        regclass = await source_conn.fetchval(
+            f"SELECT to_regclass('{schema}.mem_cells')"
+        )
+        if regclass is None:
+            return False
+        exists = await source_conn.fetchval(
+            f"SELECT EXISTS(SELECT 1 FROM {qualified_table} LIMIT 1)"
+        )
+        return bool(exists)
+    except Exception as exc:
+        log_info(f"[db_cutover] Legacy SOUL source not reachable: {exc}")
+        return False
+    finally:
+        if source_conn is not None:
+            try:
+                await source_conn.close()
+            except Exception:
+                pass
+
+
+def _build_legacy_soul_backup_plan(dsn: str) -> DatabaseBackupPlan:
+    parsed = urlparse(dsn)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    user = unquote(parsed.username) if parsed.username else "synth"
+    password = unquote(parsed.password) if parsed.password else ""
+    database = parsed.path.lstrip("/") or "postgres"
+    return build_database_backup_plan_for_connection(
+        backend="postgres",
+        host=host,
+        port=port,
+        user=user,
+        password=password,
+        database=database,
+        filename_prefix="premigration-legacy-soul-postgres",
+    )
+
+
+async def _ensure_runtime_premigration_backup(state: DbCutoverState) -> None:
+    if state.runtime_backup_path:
+        return
+
+    backup_path = await create_database_backup(
+        reason="pre_migration",
+        force=True,
+        filename_prefix=f"premigration-runtime-{_get_db_type()}",
+    )
+    if backup_path is None:
+        raise RuntimeError("Pre-migration backup for runtime database failed")
+
+    state.runtime_backup_path = str(backup_path)
+    _save_state(state)
+
+
+def _prepare_soul_value(
+    column: str, value: object, *, json_columns: tuple[str, ...]
+) -> object:
+    if value is None:
+        return None
+    if column in json_columns:
+        return json.dumps(value)
+    return value
+
+
+def _build_soul_upsert_sql(spec: _SoulTableSpec) -> str:
+    placeholders: list[str] = []
+    for index, column in enumerate(spec.columns, start=1):
+        suffix = (
+            "::jsonb"
+            if column in spec.json_columns
+            else "::vector"
+            if column == "embedding"
+            else ""
+        )
+        placeholders.append(f"${index}{suffix}")
+    updates = ", ".join(
+        f'"{column}" = EXCLUDED."{column}"'
+        for column in spec.columns
+        if column not in spec.conflict_keys
+    )
+    if not updates:
+        updates = f'"{spec.conflict_keys[0]}" = EXCLUDED."{spec.conflict_keys[0]}"'
+    quoted_columns = ", ".join(f'"{column}"' for column in spec.columns)
+    conflict_keys = ", ".join(f'"{column}"' for column in spec.conflict_keys)
+    return (
+        f'INSERT INTO "{spec.name}" ({quoted_columns}) '
+        f"VALUES ({', '.join(placeholders)}) "
+        f"ON CONFLICT ({conflict_keys}) DO UPDATE SET {updates}"
+    )
+
+
+async def _set_target_sequence_if_needed(
+    target_conn: Any, spec: _SoulTableSpec
+) -> None:
+    if not spec.sequence_name:
+        return
+    await target_conn.execute(
+        f"SELECT setval('{spec.sequence_name}', COALESCE((SELECT MAX(id) FROM \"{spec.name}\"), 1), TRUE)"
+    )
+
+
+async def _migrate_legacy_soul_tables(
+    *, source_dsn: str, source_schema: str, target_dsn: str
+) -> dict[str, int]:
+    source_conn = await connect_postgres_dsn(source_dsn)
+    target_repo = PostgresSoulRepository(dsn=target_dsn)
+    target_pool = await target_repo._get_pool()
+    target_conn = await connect_postgres_dsn(target_dsn)
+    migrated: dict[str, int] = {}
+    try:
+        async with target_pool.acquire() as pooled_target_conn:
+            for spec in _SOUL_TABLE_SPECS:
+                regclass = await source_conn.fetchval(
+                    f"SELECT to_regclass('{source_schema}.{spec.name}')"
+                )
+                if regclass is None:
+                    migrated[spec.name] = 0
+                    continue
+
+                selected_columns = ", ".join(f'"{column}"' for column in spec.columns)
+                source_query = spec.source_query or (
+                    f'SELECT {selected_columns} FROM "{source_schema}"."{spec.name}"'
+                )
+                rows = await source_conn.fetch(source_query)
+                if not rows:
+                    migrated[spec.name] = 0
+                    continue
+
+                insert_sql = _build_soul_upsert_sql(spec)
+                values = [
+                    tuple(
+                        _prepare_soul_value(
+                            column, row[column], json_columns=spec.json_columns
+                        )
+                        for column in spec.columns
+                    )
+                    for row in rows
+                ]
+                await pooled_target_conn.executemany(insert_sql, values)
+                await _set_target_sequence_if_needed(target_conn, spec)
+                migrated[spec.name] = len(values)
+    finally:
+        try:
+            await target_conn.close()
+        except Exception:
+            pass
+        try:
+            await target_repo.close()
+        except Exception:
+            pass
+        try:
+            await source_conn.close()
+        except Exception:
+            pass
+    return migrated
+
+
+async def migrate_legacy_soul_postgres_if_needed(state: DbCutoverState) -> bool:
+    source_dsn = _legacy_soul_source_dsn()
+    target_dsn = build_runtime_postgres_dsn().strip()
+    source_schema = _legacy_soul_source_schema()
+
+    if state.soul_status == "completed":
+        return False
+    if not source_dsn or not target_dsn:
+        if state.soul_status == "pending":
+            state.soul_status = "skipped"
+            _save_state(state)
+        return False
+    if not await _legacy_soul_source_has_data(source_dsn, schema=source_schema):
+        state.soul_status = "skipped"
+        _save_state(state)
+        return False
+
+    state.soul_status = "in_progress"
+    state.status = "in_progress"
+    state.started_at = state.started_at or datetime.now(timezone.utc).isoformat()
+    state.last_error = None
+    _save_state(state)
+
+    await _ensure_runtime_premigration_backup(state)
+
+    if not state.legacy_soul_backup_path:
+        backup_plan = _build_legacy_soul_backup_plan(source_dsn)
+        backup_path = await create_backup_from_plan(
+            backup_plan, reason="pre_soul_migration"
+        )
+        if backup_path is None:
+            raise RuntimeError("Pre-migration backup for legacy SOUL database failed")
+        state.legacy_soul_backup_path = str(backup_path)
+        _save_state(state)
+
+    migrated_tables = await _migrate_legacy_soul_tables(
+        source_dsn=source_dsn,
+        source_schema=source_schema,
+        target_dsn=target_dsn,
+    )
+    state.soul_tables = {
+        name: count for name, count in migrated_tables.items() if count
+    }
+    state.soul_migrated_rows = sum(migrated_tables.values())
+    state.soul_status = "completed"
+    _save_state(state)
+    log_info(
+        f"[db_cutover] Legacy SOUL cutover completed with {state.soul_migrated_rows} migrated rows"
+    )
+    return state.soul_migrated_rows > 0
+
+
+async def _legacy_source_has_data() -> bool:
+    source_conn = None
+    try:
+        source_conn = await connect_source_db()
+    except Exception as exc:
+        log_info(f"[db_cutover] Legacy source database not reachable: {exc}")
+        return False
+
+    try:
+        async with source_conn.cursor() as cursor:
+            for table_name in ("config", "chat_history_cache", "ai_diary", "memories"):
+                await cursor.execute("SHOW TABLES LIKE %s", (table_name,))
+                if not await cursor.fetchone():
+                    continue
+                await cursor.execute(f"SELECT 1 FROM `{table_name}` LIMIT 1")
+                if await cursor.fetchone():
+                    return True
+    except Exception as exc:
+        log_warning(f"[db_cutover] Failed to inspect legacy source DB: {exc}")
+    finally:
+        try:
+            source_conn.close()
+        except Exception:
+            pass
+    return False
+
+
+async def maybe_run_legacy_mysql_cutover() -> bool:
+    if not auto_migration_enabled():
+        log_info("[db_cutover] Automatic legacy DB migration disabled")
+        return False
+    if _get_db_type() != "postgres":
+        return False
+
+    state = _load_state()
+    migrated_any = False
+
+    try:
+        migrated_any = (
+            await migrate_legacy_soul_postgres_if_needed(state) or migrated_any
+        )
+
+        if state.legacy_status == "completed":
+            state.status = "completed"
+            _save_state(state)
+            return migrated_any
+
+        if not await _legacy_source_has_data():
+            if state.legacy_status == "pending":
+                state.legacy_status = "skipped"
+            if state.soul_status in {"completed", "skipped"}:
+                state.status = "completed"
+            _save_state(state)
+            return migrated_any
+
+        state.status = "in_progress"
+        state.legacy_status = "in_progress"
+        state.started_at = state.started_at or datetime.now(timezone.utc).isoformat()
+        state.last_error = None
+        _save_state(state)
+
+        await _ensure_runtime_premigration_backup(state)
+
+        if not state.legacy_backup_path:
+            backup_path = await create_source_database_backup(
+                reason="pre_migration",
+                filename_prefix=(f"premigration-legacy-source-{_get_source_db_type()}"),
+            )
+            if backup_path is None:
+                raise RuntimeError(
+                    "Pre-migration backup for legacy source database failed"
+                )
+            state.legacy_backup_path = str(backup_path)
+            _save_state(state)
+
+        config = build_default_migration_config()
+        config.dry_run = False
+        config.audit_only = False
+        results = await MainDbMigrator(config).run()
+
+        state.status = "completed"
+        state.legacy_status = "completed"
+        state.finished_at = datetime.now(timezone.utc).isoformat()
+        state.migrated_rows = sum(result.migrated_rows for result in results)
+        state.tables = {
+            result.name: result.migrated_rows
+            for result in results
+            if result.migrated_rows or result.skipped
+        }
+        _save_state(state)
+        log_info(
+            f"[db_cutover] Legacy MySQL cutover completed with {state.migrated_rows} migrated rows"
+        )
+        return True or migrated_any
+    except Exception as exc:
+        state.status = "failed"
+        if state.legacy_status == "in_progress":
+            state.legacy_status = "failed"
+        if state.soul_status == "in_progress":
+            state.soul_status = "failed"
+        state.finished_at = datetime.now(timezone.utc).isoformat()
+        state.last_error = str(exc)
+        _save_state(state)
+        log_error(f"[db_cutover] Legacy DB cutover failed: {exc}")
+        raise
+
+
+async def resume_legacy_mysql_cutover_if_needed() -> bool:
+    state = _load_state()
+    if state.status in {"in_progress", "failed"} or state.soul_status in {
+        "in_progress",
+        "failed",
+    }:
+        log_warning(
+            f"[db_cutover] Resuming legacy cutover from previous state: {state.status}"
+        )
+    return await maybe_run_legacy_mysql_cutover()

--- a/core/main_db_migration.py
+++ b/core/main_db_migration.py
@@ -9,6 +9,8 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
+from core.db import build_runtime_postgres_dsn, connect_postgres_dsn, connect_source_db
+
 
 def _optional_import(module_name: str) -> Any:
     try:  # pragma: no cover - import guard
@@ -131,31 +133,18 @@ def build_default_migration_config() -> MainDbMigrationConfig:
             )
             or "synth"
         )
-        soul_postgres_dsn = (
-            config_registry.get_value(
-                "SOUL_POSTGRES_DSN",
-                "",
-                label="SOUL Postgres DSN",
-                description="PostgreSQL DSN used when the SOUL repository backend is postgres.",
-                value_type=str,
-                group="plugins",
-                component="soul_plugin",
-            )
-            or ""
-        )
     except Exception:
         db_host = "localhost"
         db_port = 3306
         db_user = "synth"
         db_pass = "synth"
         db_name = "synth"
-        soul_postgres_dsn = ""
 
     target_dsn = (
         os.getenv("TARGET_POSTGRES_DSN")
         or os.getenv("DATABASE_URL")
         or os.getenv("APP_POSTGRES_DSN")
-        or soul_postgres_dsn
+        or build_runtime_postgres_dsn()
         or ""
     )
     return MainDbMigrationConfig(
@@ -811,21 +800,26 @@ class MainDbMigrator:
             raise RuntimeError("asyncpg is required to write the PostgreSQL target")
         if requires_target and not self.config.target_dsn:
             raise RuntimeError(
-                "Target PostgreSQL DSN is empty. Set TARGET_POSTGRES_DSN, DATABASE_URL, APP_POSTGRES_DSN, or SOUL_POSTGRES_DSN."
+                "Target PostgreSQL DSN is empty. Set TARGET_POSTGRES_DSN, DATABASE_URL, or APP_POSTGRES_DSN."
             )
 
-        source_conn = await aiomysql.connect(
-            host=self.config.source_host,
-            port=self.config.source_port,
-            user=self.config.source_user,
-            password=self.config.source_password,
-            db=self.config.source_database,
-            charset="utf8mb4",
-            autocommit=True,
-            cursorclass=aiomysql.DictCursor,
-        )
+        source_env = {
+            "SOURCE_DB_TYPE": "mariadb",
+            "SOURCE_DB_HOST": str(self.config.source_host),
+            "SOURCE_DB_PORT": str(self.config.source_port),
+            "SOURCE_DB_USER": str(self.config.source_user),
+            "SOURCE_DB_PASSWORD": str(self.config.source_password),
+            "SOURCE_DB_NAME": str(self.config.source_database),
+        }
+        original_source_env = {key: os.environ.get(key) for key in source_env}
+        for key, value in source_env.items():
+            os.environ[key] = value
+
+        source_conn = await connect_source_db()
         target_conn = (
-            await asyncpg.connect(self.config.target_dsn) if requires_target else None
+            await connect_postgres_dsn(self.config.target_dsn)
+            if requires_target
+            else None
         )
 
         try:
@@ -852,6 +846,11 @@ class MainDbMigrator:
             source_conn.close()
             if target_conn is not None:
                 await target_conn.close()
+            for key, value in original_source_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
 
     async def _apply_schema(self, target_conn: Any) -> None:
         schema_sql = load_app_postgres_schema(self.config.schema_path)

--- a/core/soul/repository.py
+++ b/core/soul/repository.py
@@ -319,17 +319,23 @@ class PostgresSoulRepository:
     _pool: Any | None = field(default=None, init=False, repr=False)
     _schema_bootstrapped: bool = field(default=False, init=False, repr=False)
 
+    def _pool_key(self) -> str:
+        return (
+            f"soul:{self.schema}:{self.min_pool_size}:{self.max_pool_size}:"
+            f"{abs(hash(self.dsn))}"
+        )
+
     async def _get_pool(self) -> Any:
         if self._pool is not None:
             return self._pool
 
-        from importlib import import_module
+        from core.db import get_named_postgres_pool
 
-        asyncpg = import_module("asyncpg")
-        self._pool = await asyncpg.create_pool(
+        self._pool = await get_named_postgres_pool(
+            pool_key=self._pool_key(),
             dsn=self.dsn,
-            min_size=self.min_pool_size,
-            max_size=self.max_pool_size,
+            minsize=self.min_pool_size,
+            maxsize=self.max_pool_size,
             server_settings={"search_path": self.schema},
         )
         await self._ensure_schema(self._pool)

--- a/core/webui.py
+++ b/core/webui.py
@@ -810,6 +810,7 @@ class SynthWebUIInterface:
         self.app.put("/api/external-endpoints/{ep_id}/model")(
             self.set_external_endpoint_model
         )
+        self.app.post("/api/database/backup")(self.create_database_backup_endpoint)
 
         # Template sections route for modular loading
         self.app.get("/templates/{section}.html")(self.serve_template_section)
@@ -924,6 +925,32 @@ class SynthWebUIInterface:
             raise
         except Exception as e:
             log_error(f"{LOG_PREFIX} create_agent_task failed: {e}")
+            raise HTTPException(status_code=500, detail=str(e))
+
+    async def create_database_backup_endpoint(self):
+        try:
+            from core.db_backup import create_database_backup
+
+            backup_path = await create_database_backup(
+                reason="manual_webui",
+                force=True,
+            )
+            if backup_path is None:
+                raise HTTPException(
+                    status_code=500,
+                    detail="Manual database backup did not produce an output file",
+                )
+            return JSONResponse(
+                {
+                    "success": True,
+                    "path": str(backup_path),
+                    "filename": backup_path.name,
+                }
+            )
+        except HTTPException:
+            raise
+        except Exception as e:
+            log_error(f"{LOG_PREFIX} create_database_backup_endpoint failed: {e}")
             raise HTTPException(status_code=500, detail=str(e))
 
     async def pause_agent_task(self, task_id: int):
@@ -3693,22 +3720,26 @@ class SynthWebUIInterface:
     async def _ensure_session_history_loaded(self, session_id: str) -> None:
         """Load persisted chat history for the given session into self.message_history.
 
-        This uses core.chat_context_manager.load_chat_history to rehydrate memory
-        and then makes sure self.message_history references the same deque.
+        This keeps the LLM context rehydration path intact, but restores the
+        WebUI-visible session history from the persisted cache using the WebUI's
+        own max_history limit instead of the smaller prompt-context deque.
         """
         try:
-            from core.chat_context_manager import (
-                load_chat_history,
-                get_or_create_chat_context,
-            )
+            from core.chat_context_manager import load_chat_history as load_context
+            from core.chat_history_cache import load_chat_history as load_persisted
 
             interface_path = f"{INTERFACE_NAME}/{session_id}"
-            await load_chat_history(interface_path)
-            ctx = get_or_create_chat_context(interface_path)
-            # Ensure local message_history points to the same deque
-            self.message_history[session_id] = ctx
+            await load_context(interface_path)
+            persisted_history = await load_persisted(
+                interface_path,
+                limit=self.max_history,
+            )
+            self.message_history[session_id] = deque(
+                persisted_history,
+                maxlen=self.max_history,
+            )
             log_debug(
-                f"{LOG_PREFIX} Session history for {session_id} loaded, {len(ctx)} messages"
+                f"{LOG_PREFIX} Session history for {session_id} loaded, {len(self.message_history[session_id])} messages"
             )
         except Exception as e:
             log_debug(

--- a/core/webui_templates/sections/settings.html
+++ b/core/webui_templates/sections/settings.html
@@ -8,6 +8,14 @@
       </div>
     </article>
     <article class="card">
+      <h2>Database Backup</h2>
+      <p>Create an immediate backup of the active runtime database and store it in the mounted backups directory.</p>
+      <div style="margin-top:0.6rem; display:flex; gap:0.75rem; align-items:center; flex-wrap:wrap;">
+        <button id="create-database-backup" class="btn-ghost" type="button">Create database backup</button>
+        <span id="database-backup-status" class="meta">Ready.</span>
+      </div>
+    </article>
+    <article class="card">
       <h2>Notifications</h2>
       <p>Enable desktop notifications and audio cues whenever new messages arrive.</p>
       <label class="toggle">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,18 +13,23 @@ services:
       - synth_data:/config
       - synth_skins:/app/skins
       - synth_logs:/app/logs
+      - ./backups:/app/backups
     environment:
       - TZ=${TZ:-Asia/Tokyo}
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
       - DB_HOST=${DB_HOST:-synth-db}
-      - DB_PORT=${DB_PORT:-3306}
+      - DB_PORT=${DB_PORT:-5432}
       - DB_USER=${DB_USER:-synth}
       - DB_PASS=${DB_PASS:-synth}
       - DB_NAME=${DB_NAME:-synth}
-      - DB_ROOT_PASS=${DB_ROOT_PASS:-root}
-      - SOUL_REPOSITORY_BACKEND=${SOUL_REPOSITORY_BACKEND:-memory}
       - SOUL_POSTGRES_DSN=${SOUL_POSTGRES_DSN:-}
+      - SOURCE_DB_TYPE=${SOURCE_DB_TYPE:-mariadb}
+      - SOURCE_DB_HOST=${SOURCE_DB_HOST:-synth-legacy-db}
+      - SOURCE_DB_PORT=${SOURCE_DB_PORT:-3306}
+      - SOURCE_DB_USER=${SOURCE_DB_USER:-synth}
+      - SOURCE_DB_PASSWORD=${SOURCE_DB_PASSWORD:-synth}
+      - SOURCE_DB_NAME=${SOURCE_DB_NAME:-synth}
       - ROOT_PASSWORD=${ROOT_PASSWORD:-"password"}
       - SYNTH_WEBUI_HTTPS_PORT=${SYNTH_WEBUI_HTTPS_PORT:-8000}
       - SYNTH_WEBUI_HTTP_PORT=${SYNTH_WEBUI_HTTP_PORT:-8080}
@@ -33,73 +38,46 @@ services:
     tty: true
     depends_on:
       - synth-db
+      - synth-legacy-db
     networks:
       - synth_network
 
   synth-db:
     container_name: synth-db
     hostname: synth-db
-    image: mariadb:11
-    ports:
-      - "${EXT_DB_PORT:-3306}:3306"
-    environment:
-      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASS:-root}
-      MYSQL_DATABASE: ${DB_NAME:-synth}
-      MYSQL_USER: ${DB_USER:-synth}
-      MYSQL_PASSWORD: ${DB_PASS:-synth}
-      MARIADB_AUTO_UPGRADE: 1
-    command: --max-connections=200
-    volumes:
-      - synth_db_data:/var/lib/mysql
-      - ./init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
-    restart: unless-stopped
-    networks:
-      - synth_network
-
-  synth-db-backup:
-    container_name: synth-db-backup
-    image: tiredofit/db-backup
-    depends_on:
-      - synth-db
-    environment:
-      DB_TYPE: mysql
-      DB_HOST: ${DB_HOST:-synth-db}
-      DB_NAME: ${DB_NAME:-synth}
-      DB_USER: ${DB_USER:-synth}
-      DB_PASS: ${DB_PASS:-synth}
-      DB_DUMP_FREQ: 60
-      DB_CLEANUP_TIME: 1440
-      CONTAINER_TIMEZONE: ${TZ:-UTC}
-      COMPRESSION: GZ
-      DB_DUMP_TARGET: /backup
-    volumes:
-      - ./backups:/backup
-    restart: unless-stopped
-    networks:
-      - synth_network
-
-  # Optional SOUL memory store (PostgreSQL + pgvector)
-  # Enable it by setting:
-  # SOUL_REPOSITORY_BACKEND=postgres
-  # SOUL_POSTGRES_DSN=postgresql://soul:soul@synth-soul-db:5432/soul_memory
-  synth-soul-db:
-    container_name: synth-soul-db
-    hostname: synth-soul-db
     image: pgvector/pgvector:pg16
     ports:
-      - "${EXT_SOUL_DB_PORT:-5432}:5432"
+      - "${EXT_DB_PORT:-5432}:5432"
     environment:
-      POSTGRES_DB: ${SOUL_PG_DB:-soul_memory}
-      POSTGRES_USER: ${SOUL_PG_USER:-soul}
-      POSTGRES_PASSWORD: ${SOUL_PG_PASSWORD:-soul}
+      POSTGRES_DB: ${DB_NAME:-synth}
+      POSTGRES_USER: ${DB_USER:-synth}
+      POSTGRES_PASSWORD: ${DB_PASS:-synth}
     volumes:
-      - synth_soul_db_data:/var/lib/postgresql/data
-      - ./scripts/sql/soul_memory_postgres.sql:/docker-entrypoint-initdb.d/10-soul-memory.sql:ro
+      - synth_pg_data:/var/lib/postgresql/data
+      - ./scripts/sql/app_main_postgres.sql:/docker-entrypoint-initdb.d/10-app-main.sql:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${SOUL_PG_USER:-soul} -d ${SOUL_PG_DB:-soul_memory}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-synth} -d ${DB_NAME:-synth}"]
       interval: 10s
       timeout: 5s
       retries: 10
+    restart: unless-stopped
+    networks:
+      - synth_network
+
+  synth-legacy-db:
+    container_name: synth-legacy-db
+    hostname: synth-legacy-db
+    image: mariadb:11
+    environment:
+      MYSQL_ROOT_PASSWORD: ${SOURCE_DB_ROOT_PASS:-root}
+      MYSQL_DATABASE: ${SOURCE_DB_NAME:-synth}
+      MYSQL_USER: ${SOURCE_DB_USER:-synth}
+      MYSQL_PASSWORD: ${SOURCE_DB_PASSWORD:-synth}
+      MARIADB_AUTO_UPGRADE: 1
+    command: --max-connections=100
+    volumes:
+      - synth_db_data:/var/lib/mysql
+      - ./init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
     restart: unless-stopped
     networks:
       - synth_network
@@ -126,7 +104,7 @@ services:
 
 volumes:
   synth_db_data:
-  synth_soul_db_data:
+  synth_pg_data:
   synth_data:
   synth_logs:
   synth_skins:

--- a/docs/api_endpoints.rst
+++ b/docs/api_endpoints.rst
@@ -33,6 +33,7 @@ System & Configuration
 ----------------------
 
 - **POST** `/api/system/restart` – restart the synth process (with confirmation).
+- **POST** `/api/database/backup` – create an immediate runtime database backup and return the generated filename/path.
 - **GET** `/api/config` – dump current configuration values.
 - **POST** `/api/config` – update a configuration entry.
 - **POST** `/api/config/{key}/upload` – upload a file for an exposed config variable.

--- a/docs/compose_env_vars.rst
+++ b/docs/compose_env_vars.rst
@@ -18,8 +18,9 @@ What belongs in ``docker-compose`` vs ``.env``
 configuration surface:
 
 - container basics such as ``IMAGE_VERSION``, ``PUID``, ``PGID`` and ``TZ``
-- MariaDB connection and port values (``DB_*``, ``EXT_DB_PORT``)
-- SOUL Postgres settings (``SOUL_*``, ``EXT_SOUL_DB_PORT``)
+- PostgreSQL runtime connection and port values (``DB_*``, ``EXT_DB_PORT``)
+- legacy MySQL source values used only for first-boot migration (``SOURCE_DB_*``)
+- SOUL Postgres override settings (``SOUL_*``) when you intentionally want a separate DSN
 - WebUI port and TLS-related values (``SYNTH_WEBUI_*``)
 - Selkies / desktop credentials such as ``ROOT_PASSWORD``
 
@@ -55,28 +56,46 @@ Provider credentials:
 
 Persistence:
 
-- ``SYNTH_PRIMARY_DB`` (``memory`` -> ``DB_*`` MariaDB, ``soul`` -> ``SOUL_*`` / ``SOUL_POSTGRES_DSN``)
 - ``DB_HOST`` / ``DB_PORT`` / ``DB_USER`` / ``DB_PASS`` / ``DB_NAME``
-- ``SOUL_REPOSITORY_BACKEND``
-- ``SOUL_POSTGRES_DSN``
+- ``LEGACY_SOUL_POSTGRES_DSN`` (optional one-time SOUL migration source)
+- ``SOUL_POSTGRES_DSN`` (legacy alias for the SOUL migration source DSN)
+- ``SOURCE_DB_HOST`` / ``SOURCE_DB_PORT`` / ``SOURCE_DB_USER`` / ``SOURCE_DB_PASSWORD`` / ``SOURCE_DB_NAME``
+- ``SYNTH_DB_BACKUP_ENABLED`` / ``SYNTH_DB_BACKUP_INTERVAL_HOURS`` / ``SYNTH_BACKUPS_DIR``
 
 Primary DB selection
 --------------------
 
-Use ``SYNTH_PRIMARY_DB`` when your deployment keeps both the legacy MariaDB
-settings and the SOUL PostgreSQL settings in the same ``.env`` and you want an
-explicit, exclusive switch for the app's primary runtime database.
+The default deployment now uses a single PostgreSQL runtime database.
+``DB_*`` points at that Postgres service, and SOUL uses the same runtime DB by default.
 
-- ``SYNTH_PRIMARY_DB=memory`` forces the application to use ``DB_*`` as the
-  active MariaDB connection settings and ignores Postgres DSNs for the primary
-  runtime DB.
-- ``SYNTH_PRIMARY_DB=soul`` forces the application to use
-  ``SOUL_POSTGRES_DSN`` and optional ``SOUL_PG_*`` overrides for the active
-  PostgreSQL connection settings.
+- ``DB_*`` points at the active runtime PostgreSQL service; no extra runtime DB selector is needed in the default Docker stack.
+- SOUL persists into that same runtime Postgres automatically.
+- ``LEGACY_SOUL_POSTGRES_DSN`` can point at an older standalone SOUL Postgres so startup can import it into the runtime DB.
+- ``SOUL_POSTGRES_DSN`` remains accepted as a legacy alias for that migration source.
+- ``SOURCE_DB_*`` is only used by the first-boot migration flow that imports a
+  legacy MariaDB/MySQL deployment.
 
-If ``SYNTH_PRIMARY_DB`` is unset, the application falls back to the older
-driver-based behavior using ``SYNTH_DB_TYPE`` / ``DB_TYPE`` plus ``DB_*`` /
-``DATABASE_URL``.
+Automatic cutover and backups
+-----------------------------
+
+- Legacy MySQL → Postgres cutover is enabled by default in the Docker stack and uses ``SOURCE_DB_*`` as the preserved source.
+- Legacy standalone SOUL Postgres → runtime Postgres cutover runs first when ``LEGACY_SOUL_POSTGRES_DSN`` or its legacy alias is set.
+- ``SOURCE_DB_*`` identifies the preserved legacy MariaDB source used only for migration and verification.
+- ``SYNTH_DB_BACKUP_ENABLED=1`` enables the embedded application-owned backup scheduler.
+- ``SYNTH_DB_BACKUP_INTERVAL_HOURS=24`` controls the pg_dump cadence.
+- ``SYNTH_BACKUPS_DIR`` selects where runtime and legacy archival dumps are written inside the synth container. The WebUI Settings tab also exposes a manual backup action that writes to this same directory.
+
+Legacy migration note
+---------------------
+
+For users migrating from older Synthetic Heart installations:
+
+- ``DB_*`` now points at the active runtime PostgreSQL service. All new runtime data is written there.
+- ``SOURCE_DB_*`` is only needed when you still have a legacy MariaDB/MySQL deployment to import from. The Docker stack preserves that source service and uses it only during first-boot migration.
+- ``LEGACY_SOUL_POSTGRES_DSN`` (or legacy alias ``SOUL_POSTGRES_DSN``) is optional and used only when you have an older standalone SOUL PostgreSQL database that should be imported into the new runtime DB.
+- If both legacy sources are configured, the SOUL Postgres import runs first, then the legacy MariaDB migration.
+- After migration, the application continues using the runtime Postgres database from ``DB_*``; the legacy source settings are not used for normal operation.
+- The legacy containers/services are preserved for verification and rollback, but the application no longer writes new runtime state to them.
 
 Observability:
 

--- a/docs/database_connection_management.rst
+++ b/docs/database_connection_management.rst
@@ -4,7 +4,10 @@ Database Connection Management
 Overview
 --------
 
-The Synthetic Heart project uses an **aiomysql connection pool** for managing asynchronous database connections. The pool is carefully sized to avoid exhausting database resources while maintaining performance.
+The Synthetic Heart project now uses a **shared database handler in** ``core/db.py``
+for all runtime database access. The default runtime backend is PostgreSQL,
+while a preserved legacy MariaDB source may still be consulted only during the
+first-boot migration flow.
 
 Connection Pool Configuration
 ------------------------------
@@ -17,7 +20,9 @@ The connection pool is configured through environment variables in `.env-dev`:
     DB_POOL_MAXSIZE=5          # Maximum concurrent connections (reduced from 8 to prevent bio_manager timeouts)
     DB_CONNECTION_TIMEOUT=10   # Timeout for acquiring a connection (seconds)
 
-**Database Limit**: MariaDB/MySQL has a system-wide connection limit (default 151 on standard deployments). The pool is sized to stay well below this limit.
+**Runtime Database**: PostgreSQL is the primary runtime backend. The shared
+handler can also manage named Postgres pools for subsystems such as SOUL, so
+runtime code does not own driver calls directly.
 
 **Bio Manager Timeout Fix**: The pool size was reduced from 8 to 5 connections to prevent ``TimeoutError`` in the bio_manager plugin. The bio_manager performs synchronous database operations from async contexts, and a smaller pool size ensures connections are always available without blocking.
 
@@ -55,6 +60,17 @@ All database access must follow the async context manager pattern:
 - Use ``get_conn_ctx()`` context manager for automatic cleanup
 - Connections are **automatically released** to the pool when the context exits
 - This pattern prevents connection leaks
+- Runtime code must not call ``aiomysql.connect()``, ``asyncpg.connect()``, or
+    ``asyncpg.create_pool()`` directly; those flows belong in ``core/db.py``.
+
+Named Postgres Pools
+--------------------
+
+Some subsystems need a dedicated Postgres target while still respecting the
+shared DB ownership rule. For that case, use the named-pool helpers in
+``core/db.py`` rather than creating driver pools locally.
+
+This is how the SOUL repository now acquires its Postgres pool.
 
 Connection Release Mechanism
 -----------------------------

--- a/main.py
+++ b/main.py
@@ -219,6 +219,16 @@ if __name__ == "__main__":
                     f"[main] Attempting database connection (attempt {attempt + 1}/{max_retries})..."
                 )
 
+                try:
+                    from core.db_cutover import resume_legacy_mysql_cutover_if_needed
+
+                    migrated = await resume_legacy_mysql_cutover_if_needed()
+                    if migrated:
+                        log_info("[main] Legacy MySQL to Postgres cutover completed")
+                except Exception as e:
+                    log_error(f"[main] Legacy DB cutover failed: {e}")
+                    raise
+
                 # Initialize database async
                 if await initialize_database():
                     break
@@ -237,6 +247,14 @@ if __name__ == "__main__":
                         f"[main] Critical error during database initialization after {max_retries} attempts: {e}"
                     )
                     sys.exit(1)
+
+        try:
+            from core.db_backup import start_database_backup_scheduler
+
+            if start_database_backup_scheduler() is not None:
+                log_info("[main] Embedded database backup scheduler started")
+        except Exception as e:
+            log_warning(f"[main] Failed to start database backup scheduler: {e}")
 
         while True:
             _restart_requested = False

--- a/plugins/soul_plugin.py
+++ b/plugins/soul_plugin.py
@@ -73,18 +73,18 @@ register_exposed_var(
     default="memory",
     value_type=str,
     ui_type="text",
-    description="SOUL persistence backend: memory or postgres.",
+    description="Legacy compatibility flag. When the main runtime DB is PostgreSQL, SOUL uses that Postgres backend automatically.",
     scope="plugins",
     component="soul_plugin",
 )
 
 register_exposed_var(
     "SOUL_POSTGRES_DSN",
-    label="SOUL Postgres DSN",
+    label="Legacy SOUL Postgres DSN",
     default="",
     value_type=str,
     ui_type="text",
-    description="PostgreSQL DSN used when SOUL_REPOSITORY_BACKEND=postgres.",
+    description="Legacy SOUL PostgreSQL source DSN used only for one-time migration into the main runtime Postgres.",
     scope="plugins",
     component="soul_plugin",
 )
@@ -135,14 +135,8 @@ class SoulPlugin(PluginBase):
 
     def _build_embedder(self) -> Any:
         from importlib.util import find_spec
-        from core.config_manager import config_registry
 
-        backend = str(
-            config_registry.get_value(
-                "SOUL_REPOSITORY_BACKEND", "memory", value_type=str
-            )
-            or "memory"
-        )
+        backend = self._get_repository_backend()
         if backend == "postgres":
             model_id = "BAAI/bge-base-en-v1.5"
             try:
@@ -807,7 +801,7 @@ class SoulPlugin(PluginBase):
             if dsn:
                 return PostgresSoulRepository(dsn=dsn)
             log_warning(
-                "[soul_plugin] SOUL_REPOSITORY_BACKEND=postgres but SOUL_POSTGRES_DSN is empty; falling back to memory"
+                "[soul_plugin] Runtime Postgres DSN is empty; falling back to memory"
             )
         return InMemorySoulRepository()
 
@@ -853,31 +847,25 @@ class SoulPlugin(PluginBase):
     @staticmethod
     def _get_repository_backend() -> str:
         try:
-            from core.config_manager import config_registry
+            from core.db import _get_db_type
 
-            value = str(
-                config_registry.get_value(
-                    "SOUL_REPOSITORY_BACKEND", "memory", value_type=str
-                )
-                or "memory"
-            )
-            value = value.strip().lower()
-            if value in {"memory", "postgres"}:
-                return value
-            return "memory"
+            return "postgres" if _get_db_type() == "postgres" else "memory"
         except Exception:
             return "memory"
 
     @staticmethod
     def _get_postgres_dsn() -> str:
         try:
-            from core.config_manager import config_registry
+            from core.db import build_runtime_postgres_dsn
 
-            return str(
-                config_registry.get_value("SOUL_POSTGRES_DSN", "", value_type=str) or ""
-            )
+            return build_runtime_postgres_dsn()
         except Exception:
-            return ""
+            try:
+                from core.db import build_runtime_postgres_dsn
+
+                return build_runtime_postgres_dsn()
+            except Exception:
+                return ""
 
 
 PLUGIN_CLASS = SoulPlugin

--- a/res/synth_webui/js/main.js
+++ b/res/synth_webui/js/main.js
@@ -2570,7 +2570,7 @@ function pickAccentDarkFromHex(hex) { return darkenHex(hex, 0.28); }
                         }
                     } catch (e) { console.debug('[synth_webui] init: failed to render initial cortex cards', e); }
                     // Bind engineSelect change to switch engine
-                    if (!engineSelect.dataset.bound) {
+                        if (engineSelect && !engineSelect.dataset.bound) {
                         engineSelect.addEventListener('change', async () => {
                             const selected = engineSelect.value;
                             if (!selected) return;
@@ -3796,6 +3796,8 @@ function pickAccentDarkFromHex(hex) { return darkenHex(hex, 0.28); }
             function initSettingsTab() {
                 if (!window.__synth_settings_initialized) {
                     const resetBtn = document.getElementById('reset-window-positions');
+                    const backupBtn = document.getElementById('create-database-backup');
+                    const backupStatus = document.getElementById('database-backup-status');
                     if (resetBtn) {
                         resetBtn.addEventListener('click', () => {
                             try {
@@ -3833,6 +3835,31 @@ function pickAccentDarkFromHex(hex) { return darkenHex(hex, 0.28); }
                                     chat.style.height = '';
                                 }
                             } catch (e) { /* ignore */ }
+                        });
+                    }
+                    if (backupBtn) {
+                        backupBtn.addEventListener('click', async () => {
+                            backupBtn.disabled = true;
+                            if (backupStatus) backupStatus.textContent = 'Creating backup…';
+                            try {
+                                const response = await fetch('/api/database/backup', {
+                                    method: 'POST',
+                                    headers: { 'Content-Type': 'application/json' },
+                                });
+                                const payload = await response.json().catch(() => ({}));
+                                if (!response.ok || !payload.success) {
+                                    throw new Error(payload.detail || payload.error || `HTTP ${response.status}`);
+                                }
+                                const filename = payload.filename || payload.path || 'backup completed';
+                                if (backupStatus) backupStatus.textContent = `Backup created: ${filename}`;
+                                try { if (window.showToast) window.showToast(`Database backup created: ${filename}`, false); } catch (e) { /* ignore */ }
+                            } catch (error) {
+                                const message = error && error.message ? error.message : 'Backup failed';
+                                if (backupStatus) backupStatus.textContent = `Backup failed: ${message}`;
+                                try { if (window.showToast) window.showToast(`Database backup failed: ${message}`, true); } catch (e) { /* ignore */ }
+                            } finally {
+                                backupBtn.disabled = false;
+                            }
                         });
                     }
                     initNotifications();

--- a/scripts/migrate_legacy_to_soul.py
+++ b/scripts/migrate_legacy_to_soul.py
@@ -28,8 +28,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-import aiomysql
-
+from core.db import connect_source_db
 from core.soul.models import EmotionalTag, MemCell
 from core.soul.repository import PostgresSoulRepository
 
@@ -153,6 +152,15 @@ def _as_utc(timestamp: datetime | None) -> datetime:
     return timestamp.astimezone(UTC)
 
 
+def _seed_source_db_env(config: MigrationConfig) -> None:
+    os.environ.setdefault("SOURCE_DB_TYPE", "mariadb")
+    os.environ.setdefault("SOURCE_DB_HOST", config.maria_host)
+    os.environ.setdefault("SOURCE_DB_PORT", str(config.maria_port))
+    os.environ.setdefault("SOURCE_DB_USER", config.maria_user)
+    os.environ.setdefault("SOURCE_DB_PASSWORD", config.maria_password)
+    os.environ.setdefault("SOURCE_DB_NAME", config.maria_database)
+
+
 def _text(value: Any) -> str:
     if value is None:
         return ""
@@ -236,16 +244,8 @@ class LegacyToSoulMigrator:
     async def run(self) -> None:
         self._print_header()
 
-        maria_conn = await aiomysql.connect(
-            host=self.config.maria_host,
-            port=self.config.maria_port,
-            user=self.config.maria_user,
-            password=self.config.maria_password,
-            db=self.config.maria_database,
-            charset="utf8mb4",
-            autocommit=True,
-            cursorclass=aiomysql.DictCursor,
-        )
+        _seed_source_db_env(self.config)
+        maria_conn = await connect_source_db()
 
         repo = PostgresSoulRepository(
             dsn=self.config.soul_postgres_dsn,
@@ -276,7 +276,7 @@ class LegacyToSoulMigrator:
                 )
 
     async def _migrate_chat_history_cache(
-        self, maria_conn: aiomysql.Connection, repo: PostgresSoulRepository
+        self, maria_conn: Any, repo: PostgresSoulRepository
     ) -> None:
         print("\n[1/3] Migrating chat_history_cache ...")
         since = datetime.now() - timedelta(days=self.config.days)
@@ -330,7 +330,7 @@ class LegacyToSoulMigrator:
         print(f"  migrated: {self.stats.chat_history_cache}")
 
     async def _migrate_memories(
-        self, maria_conn: aiomysql.Connection, repo: PostgresSoulRepository
+        self, maria_conn: Any, repo: PostgresSoulRepository
     ) -> None:
         print("\n[2/3] Migrating memories ...")
         since = datetime.now() - timedelta(days=self.config.days)
@@ -401,7 +401,7 @@ class LegacyToSoulMigrator:
         print(f"  migrated: {self.stats.memories}")
 
     async def _migrate_ai_diary(
-        self, maria_conn: aiomysql.Connection, repo: PostgresSoulRepository
+        self, maria_conn: Any, repo: PostgresSoulRepository
     ) -> None:
         print("\n[3/3] Migrating ai_diary ...")
         since = datetime.now() - timedelta(days=self.config.days)

--- a/scripts/sql/app_main_postgres.sql
+++ b/scripts/sql/app_main_postgres.sql
@@ -304,3 +304,24 @@ CREATE TABLE IF NOT EXISTS archived_memories (
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_archived_memories_created_at ON archived_memories (created_at DESC);
+
+CREATE TABLE IF NOT EXISTS llm_failure_log (
+    id BIGSERIAL PRIMARY KEY,
+    failure_code TEXT NOT NULL,
+    stage TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    interface_path TEXT,
+    chat_id TEXT,
+    thread_id TEXT,
+    engine TEXT,
+    model TEXT,
+    message_id TEXT,
+    content_preview TEXT,
+    metadata TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_failure_created_at ON llm_failure_log (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_failure_code ON llm_failure_log (failure_code);
+CREATE INDEX IF NOT EXISTS idx_failure_stage ON llm_failure_log (stage);
+CREATE INDEX IF NOT EXISTS idx_failure_interface_path ON llm_failure_log (interface_path);
+CREATE INDEX IF NOT EXISTS idx_failure_engine ON llm_failure_log (engine);

--- a/scripts/windows_setup.py
+++ b/scripts/windows_setup.py
@@ -1062,10 +1062,10 @@ def stage_soul(args: argparse.Namespace, env_values: dict[str, str]) -> bool:
     _print("  Validating Postgres connection...")
     try:
         import asyncio
-        import asyncpg
+        from core.db import connect_postgres_dsn
 
         async def _check() -> None:
-            conn = await asyncpg.connect(dsn, timeout=10)
+            conn = await connect_postgres_dsn(dsn)
             await conn.close()
 
         asyncio.run(_check())
@@ -1085,9 +1085,10 @@ def stage_soul(args: argparse.Namespace, env_values: dict[str, str]) -> bool:
         _print(f"  Applying SOUL schema (VECTOR({chosen_spec.dims}))...")
         try:
             import asyncio
+            from core.db import connect_postgres_dsn
 
             async def _apply() -> None:
-                conn = await asyncpg.connect(dsn, timeout=10)
+                conn = await connect_postgres_dsn(dsn)
                 await conn.execute(sql)
                 await conn.close()
 

--- a/tests/soul/test_soul_plugin.py
+++ b/tests/soul/test_soul_plugin.py
@@ -15,6 +15,13 @@ from core.soul.models import EmotionalProfile, EmotionalTag, MemCell, MemCellRec
 from core.soul.repository import InMemorySoulRepository, PostgresSoulRepository
 
 
+@pytest.fixture(autouse=True)
+def _default_soul_plugin_tests_to_memory(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SYNTH_PRIMARY_DB", raising=False)
+    monkeypatch.delenv("SOUL_POSTGRES_DSN", raising=False)
+    monkeypatch.setenv("SYNTH_DB_TYPE", "mariadb")
+
+
 def test_soul_plugin_is_enabled_uses_config_gate() -> None:
     plugin = SoulPlugin.__new__(SoulPlugin)
 
@@ -23,6 +30,45 @@ def test_soul_plugin_is_enabled_uses_config_gate() -> None:
 
     with patch.object(SoulPlugin, "_is_enabled", return_value=True):
         assert plugin.is_enabled() is True
+
+
+@pytest.mark.asyncio
+async def test_postgres_repository_pool_flows_through_core_db(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = PostgresSoulRepository(
+        dsn="postgresql://user:pass@db.example/synth",
+        schema="public",
+        min_pool_size=2,
+        max_pool_size=7,
+    )
+    fake_pool = object()
+    captured: dict[str, Any] = {}
+
+    async def _fake_get_named_postgres_pool(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return fake_pool
+
+    monkeypatch.setattr(
+        "core.db.get_named_postgres_pool", _fake_get_named_postgres_pool
+    )
+
+    with patch.object(
+        PostgresSoulRepository,
+        "_ensure_schema",
+        new=AsyncMock(),
+    ) as ensure_schema:
+        pool = await repo._get_pool()
+        cached_pool = await repo._get_pool()
+
+    assert pool is fake_pool
+    assert cached_pool is fake_pool
+    assert captured["dsn"] == repo.dsn
+    assert captured["minsize"] == 2
+    assert captured["maxsize"] == 7
+    assert captured["server_settings"] == {"search_path": "public"}
+    assert captured["pool_key"].startswith("soul:public:2:7:")
+    ensure_schema.assert_awaited_once_with(fake_pool)
 
 
 @pytest.mark.asyncio
@@ -316,6 +362,27 @@ def test_repository_backend_postgres_selected(monkeypatch: pytest.MonkeyPatch) -
     plugin = SoulPlugin()
 
     assert isinstance(plugin._repo, PostgresSoulRepository)
+
+
+def test_build_embedder_uses_runtime_repository_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = SoulPlugin.__new__(SoulPlugin)
+
+    class _FakeEmbedder:
+        def __init__(self, *, model_id: str) -> None:
+            self.model_id = model_id
+
+    monkeypatch.setattr(
+        SoulPlugin, "_get_repository_backend", staticmethod(lambda: "postgres")
+    )
+    monkeypatch.setattr("importlib.util.find_spec", lambda name: object())
+    monkeypatch.setattr("plugins.soul_plugin.FastEmbedder", _FakeEmbedder)
+
+    embedder = SoulPlugin._build_embedder(plugin)
+
+    assert isinstance(embedder, _FakeEmbedder)
+    assert embedder.model_id == "BAAI/bge-base-en-v1.5"
 
 
 def test_repository_backend_postgres_falls_back_without_dsn(

--- a/tests/test_chat_history_cache.py
+++ b/tests/test_chat_history_cache.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import UTC, datetime
+from collections import deque
 
 import pytest
 
@@ -238,5 +239,99 @@ async def test_save_chat_message_uses_parametrized_dedup_cutoff(monkeypatch):
     assert "UTC_TIMESTAMP()" not in dedup_query
     assert "timestamp > %s" in dedup_query
     assert dedup_params is not None
-    assert len(dedup_params) == 3
-    assert isinstance(dedup_params[2], datetime)
+
+
+@pytest.mark.asyncio
+async def test_load_chat_history_returns_latest_rows_in_chronological_order(
+    monkeypatch,
+):
+    now = datetime.now(UTC)
+    rows = [
+        (
+            "user",
+            "user-1",
+            f"message-{index}",
+            now.replace(microsecond=index),
+            "synth_webui/webui_default",
+            None,
+        )
+        for index in range(12)
+    ]
+    executed: list[tuple[str, tuple[object, ...] | None]] = []
+
+    class DummyCursor:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def execute(self, query, params=None):
+            executed.append((query, params))
+
+        async def fetchall(self):
+            # Simulate the DB returning the last 10 messages reordered ASC.
+            return rows[2:]
+
+    class DummyConn:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def cursor(self):
+            return DummyCursor()
+
+    monkeypatch.setattr(chat_history_cache, "get_conn_ctx", lambda: DummyConn())
+    monkeypatch.setattr(chat_history_cache, "_get_history_limit", lambda default=10: 10)
+
+    history = await chat_history_cache.load_chat_history("synth_webui/webui_default")
+
+    assert isinstance(history, deque)
+    assert [message["text"] for message in history] == [
+        f"message-{index}" for index in range(2, 12)
+    ]
+    query, params = executed[0]
+    assert "ORDER BY timestamp DESC, id DESC" in query
+    assert "ORDER BY timestamp ASC, id ASC" in query
+    assert params == ("synth_webui/webui_default", 10)
+
+
+@pytest.mark.asyncio
+async def test_load_chat_history_uses_explicit_limit(monkeypatch):
+    executed: list[tuple[str, tuple[object, ...] | None]] = []
+
+    class DummyCursor:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def execute(self, query, params=None):
+            executed.append((query, params))
+
+        async def fetchall(self):
+            return []
+
+    class DummyConn:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def cursor(self):
+            return DummyCursor()
+
+    monkeypatch.setattr(chat_history_cache, "get_conn_ctx", lambda: DummyConn())
+
+    history = await chat_history_cache.load_chat_history(
+        "synth_webui/webui_default",
+        limit=37,
+    )
+
+    assert isinstance(history, deque)
+    _, params = executed[0]
+    assert params == ("synth_webui/webui_default", 37)

--- a/tests/test_core_webui.py
+++ b/tests/test_core_webui.py
@@ -1,5 +1,6 @@
 import pytest
 import json
+from collections import deque
 
 from core.webui import SynthWebUIInterface
 
@@ -57,3 +58,47 @@ async def test_components_summary_includes_disabled_options(monkeypatch):
         names = [e.get("name") for e in payload[key]]
         assert names, f"{key} list empty"
         assert names[0] == "disabled", f"{key} disabled entry not first"
+
+
+@pytest.mark.asyncio
+async def test_session_history_load_uses_persisted_webui_limit(monkeypatch):
+    loaded_paths: list[str] = []
+    context_deque = deque(
+        ({"text": f"ctx-{index}"} for index in range(10)),
+        maxlen=10,
+    )
+    persisted_history = deque(
+        ({"text": f"persisted-{index}"} for index in range(25)),
+        maxlen=100,
+    )
+
+    async def fake_load_context(interface_path: str) -> None:
+        loaded_paths.append(interface_path)
+
+    async def fake_load_persisted(interface_path: str, limit: int | None = None):
+        assert interface_path == "synth_webui/webui_default"
+        assert limit == 100
+        return persisted_history
+
+    monkeypatch.setattr(
+        "core.chat_context_manager.load_chat_history",
+        fake_load_context,
+    )
+    monkeypatch.setattr(
+        "core.chat_context_manager.get_or_create_chat_context",
+        lambda interface_path: context_deque,
+    )
+    monkeypatch.setattr(
+        "core.chat_history_cache.load_chat_history",
+        fake_load_persisted,
+    )
+
+    webui = SynthWebUIInterface(autostart=False)
+    webui.max_history = 100
+
+    await webui._ensure_session_history_loaded("webui_default")
+
+    assert loaded_paths == ["synth_webui/webui_default"]
+    assert len(webui.message_history["webui_default"]) == 25
+    assert webui.message_history["webui_default"].maxlen == 100
+    assert webui.message_history["webui_default"] is not context_deque

--- a/tests/test_db_backup.py
+++ b/tests/test_db_backup.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from core import db_backup
+
+
+def test_build_database_backup_plan_for_postgres(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("SYNTH_BACKUPS_DIR", str(tmp_path))
+    monkeypatch.setattr(db_backup, "_get_db_type", lambda: "postgres")
+    monkeypatch.setattr(
+        db_backup,
+        "_read_db_config",
+        lambda: ("pg-host", 5432, "synth", "secret", "synth"),
+    )
+
+    plan = db_backup.build_database_backup_plan(
+        now=datetime(2026, 5, 11, 10, 0, 0, tzinfo=timezone.utc)
+    )
+
+    assert plan.backend == "postgres"
+    assert (
+        plan.output_path == tmp_path / "runtime-postgres-synth-20260511T100000Z.sql.gz"
+    )
+    assert plan.command[0].endswith("pg_dump")
+    assert "--dbname" in plan.command
+    assert plan.env["PGPASSWORD"] == "secret"
+
+
+def test_build_database_backup_plan_for_mariadb(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("SYNTH_BACKUPS_DIR", str(tmp_path))
+    monkeypatch.setattr(db_backup, "_get_db_type", lambda: "mariadb")
+    monkeypatch.setattr(
+        db_backup,
+        "_read_db_config",
+        lambda: ("db-host", 3306, "synth", "secret", "synth"),
+    )
+
+    plan = db_backup.build_database_backup_plan(
+        now=datetime(2026, 5, 11, 10, 0, 0, tzinfo=timezone.utc)
+    )
+
+    assert plan.backend == "mariadb"
+    assert (
+        plan.output_path == tmp_path / "runtime-mariadb-synth-20260511T100000Z.sql.gz"
+    )
+    assert plan.command[0].endswith("mysqldump")
+    assert "--single-transaction" in plan.command
+    assert plan.env["MYSQL_PWD"] == "secret"
+
+
+def test_build_database_backup_plan_with_premigration_prefix(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("SYNTH_BACKUPS_DIR", str(tmp_path))
+    monkeypatch.setattr(db_backup, "_get_db_type", lambda: "postgres")
+    monkeypatch.setattr(
+        db_backup,
+        "_read_db_config",
+        lambda: ("pg-host", 5432, "synth", "secret", "synth"),
+    )
+
+    plan = db_backup.build_database_backup_plan(
+        now=datetime(2026, 5, 11, 10, 0, 0, tzinfo=timezone.utc),
+        filename_prefix="premigration-runtime-postgres",
+    )
+
+    assert plan.output_path == (
+        tmp_path / "premigration-runtime-postgres-synth-20260511T100000Z.sql.gz"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_database_backup_runs_worker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    plan = db_backup.DatabaseBackupPlan(
+        backend="postgres",
+        database="synth",
+        output_path=tmp_path / "runtime-postgres-synth-test.sql.gz",
+        command=("pg_dump",),
+        env={},
+    )
+    calls: list[db_backup.DatabaseBackupPlan] = []
+
+    async def _fake_to_thread(func: Any, *args: Any, **kwargs: Any) -> Any:
+        func(*args, **kwargs)
+        return None
+
+    def _fake_run_backup_sync(received_plan: db_backup.DatabaseBackupPlan) -> None:
+        calls.append(received_plan)
+
+    monkeypatch.setattr(
+        db_backup,
+        "build_database_backup_plan",
+        lambda filename_prefix=None: plan,
+    )
+    monkeypatch.setattr(db_backup.asyncio, "to_thread", _fake_to_thread)
+    monkeypatch.setattr(db_backup, "_run_backup_sync", _fake_run_backup_sync)
+
+    result = await db_backup.create_database_backup(reason="test")
+
+    assert result == plan.output_path
+    assert calls == [plan]
+
+
+@pytest.mark.asyncio
+async def test_create_database_backup_force_bypasses_disabled_scheduler(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    plan = db_backup.DatabaseBackupPlan(
+        backend="postgres",
+        database="synth",
+        output_path=tmp_path / "runtime-postgres-force.sql.gz",
+        command=("pg_dump",),
+        env={},
+    )
+    calls: list[db_backup.DatabaseBackupPlan] = []
+
+    async def _fake_to_thread(func: Any, *args: Any, **kwargs: Any) -> Any:
+        func(*args, **kwargs)
+        return None
+
+    def _fake_run_backup_sync(received_plan: db_backup.DatabaseBackupPlan) -> None:
+        calls.append(received_plan)
+
+    monkeypatch.setattr(db_backup, "backups_enabled", lambda: False)
+    monkeypatch.setattr(
+        db_backup,
+        "build_database_backup_plan",
+        lambda filename_prefix=None: plan,
+    )
+    monkeypatch.setattr(db_backup.asyncio, "to_thread", _fake_to_thread)
+    monkeypatch.setattr(db_backup, "_run_backup_sync", _fake_run_backup_sync)
+
+    result = await db_backup.create_database_backup(reason="manual", force=True)
+
+    assert result == plan.output_path
+    assert calls == [plan]

--- a/tests/test_db_cutover.py
+++ b/tests/test_db_cutover.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core import db_cutover
+
+
+@pytest.mark.asyncio
+async def test_cutover_skips_when_runtime_is_not_postgres(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(db_cutover, "_get_db_type", lambda: "mariadb")
+
+    result = await db_cutover.maybe_run_legacy_mysql_cutover()
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_cutover_runs_backup_and_migration(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    state_path = tmp_path / "db-cutover-state.json"
+    monkeypatch.setenv("SYNTH_DB_CUTOVER_STATE_PATH", str(state_path))
+    monkeypatch.setattr(db_cutover, "_get_db_type", lambda: "postgres")
+    monkeypatch.setattr(db_cutover, "_get_source_db_type", lambda: "mariadb")
+    monkeypatch.setattr(
+        db_cutover,
+        "migrate_legacy_soul_postgres_if_needed",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr(
+        db_cutover, "_legacy_source_has_data", AsyncMock(return_value=True)
+    )
+    runtime_backup = AsyncMock(
+        return_value=tmp_path / "premigration-runtime-postgres-synth.sql.gz"
+    )
+    monkeypatch.setattr(db_cutover, "create_database_backup", runtime_backup)
+    source_backup = AsyncMock(
+        return_value=tmp_path / "premigration-legacy-source-mariadb-synth.sql.gz"
+    )
+    monkeypatch.setattr(
+        db_cutover,
+        "create_source_database_backup",
+        source_backup,
+    )
+    monkeypatch.setattr(
+        db_cutover,
+        "build_default_migration_config",
+        lambda: SimpleNamespace(dry_run=True, audit_only=True),
+    )
+
+    fake_results: list[object] = [
+        SimpleNamespace(name="config", migrated_rows=3, skipped=False)
+    ]
+
+    class FakeMigrator:
+        def __init__(self, config: object) -> None:
+            self.config = config
+
+        async def run(self) -> list[object]:
+            return fake_results
+
+    monkeypatch.setattr(db_cutover, "MainDbMigrator", FakeMigrator)
+
+    result = await db_cutover.maybe_run_legacy_mysql_cutover()
+
+    assert result is True
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "completed"
+    assert payload["legacy_status"] == "completed"
+    assert payload["runtime_backup_path"].endswith(
+        "premigration-runtime-postgres-synth.sql.gz"
+    )
+    assert payload["migrated_rows"] == 3
+    assert payload["legacy_backup_path"].endswith(
+        "premigration-legacy-source-mariadb-synth.sql.gz"
+    )
+    assert payload["tables"] == {"config": 3}
+    runtime_backup.assert_awaited_once_with(
+        reason="pre_migration",
+        force=True,
+        filename_prefix="premigration-runtime-postgres",
+    )
+    source_backup.assert_awaited_once_with(
+        reason="pre_migration",
+        filename_prefix="premigration-legacy-source-mariadb",
+    )
+
+
+def test_legacy_soul_source_dsn_uses_dedicated_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        db_cutover,
+        "build_runtime_postgres_dsn",
+        lambda: "postgresql://synth:synth@synth-db:5432/synth",
+    )
+    monkeypatch.setenv(
+        "LEGACY_SOUL_POSTGRES_DSN",
+        "postgresql://soul:soul@synth-soul-db:5432/soul_memory",
+    )
+    monkeypatch.delenv("SOUL_POSTGRES_DSN", raising=False)
+
+    assert db_cutover._legacy_soul_source_dsn() == (
+        "postgresql://soul:soul@synth-soul-db:5432/soul_memory"
+    )
+
+
+def test_legacy_soul_source_dsn_falls_back_to_old_soul_env_when_distinct(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        db_cutover,
+        "build_runtime_postgres_dsn",
+        lambda: "postgresql://synth:synth@synth-db:5432/synth",
+    )
+    monkeypatch.delenv("LEGACY_SOUL_POSTGRES_DSN", raising=False)
+    monkeypatch.setenv(
+        "SOUL_POSTGRES_DSN",
+        "postgresql://soul:soul@synth-soul-db:5432/soul_memory",
+    )
+
+    assert db_cutover._legacy_soul_source_dsn() == (
+        "postgresql://soul:soul@synth-soul-db:5432/soul_memory"
+    )
+
+
+@pytest.mark.asyncio
+async def test_soul_cutover_updates_state(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    state_path = tmp_path / "db-cutover-state.json"
+    monkeypatch.setenv("SYNTH_DB_CUTOVER_STATE_PATH", str(state_path))
+    monkeypatch.setattr(db_cutover, "_get_db_type", lambda: "postgres")
+    monkeypatch.setattr(
+        db_cutover,
+        "build_runtime_postgres_dsn",
+        lambda: "postgresql://synth:synth@synth-db:5432/synth",
+    )
+    monkeypatch.setattr(
+        db_cutover,
+        "_legacy_soul_source_dsn",
+        lambda: "postgresql://soul:soul@synth-soul-db:5432/soul_memory",
+    )
+    monkeypatch.setattr(
+        db_cutover,
+        "_legacy_soul_source_has_data",
+        AsyncMock(return_value=True),
+    )
+    runtime_backup = AsyncMock(
+        return_value=tmp_path / "premigration-runtime-postgres-synth.sql.gz"
+    )
+    monkeypatch.setattr(db_cutover, "create_database_backup", runtime_backup)
+    soul_backup = AsyncMock(
+        return_value=(
+            tmp_path / "premigration-legacy-soul-postgres-soul_memory.sql.gz"
+        )
+    )
+    monkeypatch.setattr(
+        db_cutover,
+        "create_backup_from_plan",
+        soul_backup,
+    )
+    monkeypatch.setattr(
+        db_cutover,
+        "_migrate_legacy_soul_tables",
+        AsyncMock(return_value={"mem_cells": 2, "dsp_versions": 1}),
+    )
+
+    state = db_cutover.DbCutoverState()
+
+    result = await db_cutover.migrate_legacy_soul_postgres_if_needed(state)
+
+    assert result is True
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    assert payload["soul_status"] == "completed"
+    assert payload["runtime_backup_path"].endswith(
+        "premigration-runtime-postgres-synth.sql.gz"
+    )
+    assert payload["legacy_soul_backup_path"].endswith(
+        "premigration-legacy-soul-postgres-soul_memory.sql.gz"
+    )
+    assert payload["soul_migrated_rows"] == 3
+    assert payload["soul_tables"] == {"mem_cells": 2, "dsp_versions": 1}
+    runtime_backup.assert_awaited_once_with(
+        reason="pre_migration",
+        force=True,
+        filename_prefix="premigration-runtime-postgres",
+    )
+    soul_backup.assert_awaited_once()
+    await_args = soul_backup.await_args
+    assert await_args is not None
+    plan = await_args.args[0]
+    assert plan.output_path.name.startswith(
+        "premigration-legacy-soul-postgres-soul_memory-"
+    )
+    assert await_args.kwargs["reason"] == "pre_soul_migration"

--- a/tests/test_db_postgres_compat.py
+++ b/tests/test_db_postgres_compat.py
@@ -84,6 +84,14 @@ def test_primary_db_selector_forces_memory_connection_settings(monkeypatch) -> N
     )
 
 
+def test_db_type_defaults_to_postgres(monkeypatch) -> None:
+    monkeypatch.delenv("SYNTH_PRIMARY_DB", raising=False)
+    monkeypatch.delenv("SYNTH_DB_TYPE", raising=False)
+    monkeypatch.delenv("DB_TYPE", raising=False)
+
+    assert db_module._get_db_type() == "postgres"
+
+
 @pytest.mark.asyncio
 async def test_get_conn_ctx_postgres_translates_replace_into(monkeypatch) -> None:
     calls: list[tuple[str, str, tuple[object, ...]]] = []

--- a/tests/test_main_db_migration.py
+++ b/tests/test_main_db_migration.py
@@ -175,6 +175,7 @@ async def test_audit_only_run_skips_target_connection(
         SimpleNamespace(DictCursor=object, connect=fake_connect),
     )
     monkeypatch.setattr(migration, "asyncpg", None)
+    monkeypatch.setattr(migration, "connect_source_db", fake_connect)
 
     config = MainDbMigrationConfig(
         source_host="localhost",

--- a/tests/test_webui_partials.py
+++ b/tests/test_webui_partials.py
@@ -21,3 +21,12 @@ def test_section_files_exist():
         with open(path, "r", encoding="utf-8") as f:
             data = f.read()
         assert len(data.strip()) > 0, f"Section file {s} appears empty"
+
+
+def test_settings_section_contains_manual_backup_button():
+    path = os.path.join(BASE, "sections", "settings.html")
+    with open(path, "r", encoding="utf-8") as f:
+        data = f.read()
+
+    assert 'id="create-database-backup"' in data
+    assert 'id="database-backup-status"' in data


### PR DESCRIPTION
This pull request introduces significant improvements to the database architecture and operational robustness of the project, with a primary focus on transitioning the runtime database from MariaDB/MySQL to PostgreSQL by default. It also adds new utilities for managing database connections, updates documentation for the new stack, and fixes a chat history replay bug in the WebUI. Below are the most important changes:

**Database Backend Transition and Utilities**

* The runtime database now defaults to PostgreSQL instead of MariaDB/MySQL. Helper functions and environment variable parsing logic have been updated to reflect this, including new DSN builders and connection helpers for both runtime and source databases. (`core/db.py`) [[1]](diffhunk://#diff-10d8b8df635649476dd58e87855b025493578cf7d22dcb86515135d0b0e765fbR99-R126) [[2]](diffhunk://#diff-10d8b8df635649476dd58e87855b025493578cf7d22dcb86515135d0b0e765fbR200-R283) [[3]](diffhunk://#diff-10d8b8df635649476dd58e87855b025493578cf7d22dcb86515135d0b0e765fbR322-R373)
* Added new async connection helpers for PostgreSQL, including `connect_runtime_postgres`, `connect_postgres_dsn`, and `connect_source_db`, as well as a named PostgreSQL pool manager for use by subsystems like SOUL. (`core/db.py`)
* The Dockerfile now installs `postgresql-client` by default, supporting the new stack. (`Dockerfile`)

**Documentation and Migration Guidance**

* Updated the main README to document the new default PostgreSQL runtime, automatic migration from MariaDB and legacy SOUL Postgres, and manual backup procedures. Windows setup instructions now reference PostgreSQL instead of MariaDB. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R129) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L150-R154) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L164-R169)
* Added troubleshooting documentation for issues with orphaned containers blocking the new Postgres-first runtime, and clarified known issues and fixes for WebUI chat history replay and type-checking noise. (`AGENTS.md`) [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R810-R817) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R946-R961)

**WebUI and Chat History Improvements**

* Fixed a bug where WebUI chat history replay after restart could incorrectly show the oldest prompt-context window instead of the most recent chat, by updating `load_chat_history` to fetch the most recent N rows and reorder them chronologically. (`core/chat_history_cache.py`, `AGENTS.md`) [[1]](diffhunk://#diff-ec7876b1d3189b4423c378476b753e1b624aa56e07ca24ab87f0526c4a46abc2L248-R254) [[2]](diffhunk://#diff-ec7876b1d3189b4423c378476b753e1b624aa56e07ca24ab87f0526c4a46abc2L263-R280) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R946-R961)

**Codebase Modernization**

* Cleaned up and modernized import statements and fallback logic for database modules, improving testability and clarity. (`core/db.py`) [[1]](diffhunk://#diff-10d8b8df635649476dd58e87855b025493578cf7d22dcb86515135d0b0e765fbL7-R8) [[2]](diffhunk://#diff-10d8b8df635649476dd58e87855b025493578cf7d22dcb86515135d0b0e765fbL16-R17) [[3]](diffhunk://#diff-10d8b8df635649476dd58e87855b025493578cf7d22dcb86515135d0b0e765fbL25-R26) [[4]](diffhunk://#diff-10d8b8df635649476dd58e87855b025493578cf7d22dcb86515135d0b0e765fbL34-R35)
* Improved debug information reporting for connection pools. (`core/db.py`)