### PR TITLE
fix: load DB configs before async plugin start to prevent stale defaults

### DIFF
--- a/core/core_initializer.py
+++ b/core/core_initializer.py
@@ -224,6 +224,36 @@ class CoreInitializer:
                 "[core_initializer] ✅ _register_component_validation_rules() completed"
             )
 
+            # 2.5.5. Load all configurations from DB BEFORE starting async plugins.
+            # This ensures plugins start with correct DB values, not hardcoded defaults.
+            # The weather plugin's daily report flag is a prime example: if the weather
+            # loop starts before DB configs are loaded, it uses the default (False) and
+            # the daily report never fires even though the user set it to True in the UI.
+            log_info(
+                "[core_initializer] Loading configurations from DB (pre-plugin-start)..."
+            )
+            try:
+                from core.config_manager import config_registry
+
+                await config_registry.load_all_from_db()
+                log_info(
+                    "[core_initializer] ✅ Configurations loaded from DB (pre-plugin-start)"
+                )
+
+                # Notify all listeners so components can update their instance variables
+                # before their async loops start running.
+                log_info(
+                    "[core_initializer] Notifying all config listeners (pre-plugin-start)..."
+                )
+                config_registry.notify_all_listeners()
+                log_info(
+                    "[core_initializer] ✅ All config listeners notified (pre-plugin-start)"
+                )
+            except Exception as load_exc:
+                log_warning(
+                    f"[core_initializer] Failed to load configurations from DB (pre-plugin-start): {load_exc}"
+                )
+
             # 2.6. Start any async plugins that were deferred due to no running event loop
             try:
                 await self.start_pending_async_plugins()

--- a/core/external_endpoints/adapters/openai_compat.py
+++ b/core/external_endpoints/adapters/openai_compat.py
@@ -372,11 +372,11 @@ class OpenAICompatAdapter(BaseProtocolAdapter):
         # Some OpenAI-compatible endpoints return dict-like entries, others
         # return SDK model objects. Support both.
         if isinstance(entry, dict):
-            entry_id = str(entry.get("id", ""))
+            entry_id = str(entry.get("id", "") or entry.get("model_id", "") or "")
             capabilities = self._normalize_capabilities(entry.get("capabilities", {}))
             return ModelInfo(
                 id=entry_id,
-                name=str(entry.get("name", entry_id)),
+                name=str(entry.get("name", entry_id) or entry.get("display_name", entry_id)),
                 owned_by=str(entry.get("owned_by", "")),
                 capabilities=capabilities,
             )

--- a/core/webui_templates/sections/engines.html
+++ b/core/webui_templates/sections/engines.html
@@ -362,6 +362,7 @@
             <button class="ext-ep-edit-btn pill secondary" style="padding:5px 12px; font-size:0.85rem;">Edit</button>
             <button class="ext-ep-toggle-btn pill" style="padding:5px 12px; font-size:0.85rem;"></button>
             <button class="ext-ep-probe-btn pill" style="padding:5px 12px; font-size:0.85rem;">Probe</button>
+            <span class="ext-ep-probe-echo" style="font-size:0.85rem; margin-left:2px;"></span>
             <button class="ext-ep-delete-btn pill" style="padding:5px 12px; font-size:0.85rem; background:var(--danger,#c0392b); color:#fff;">Delete</button>
         </div>
 
@@ -378,9 +379,10 @@
         <!-- Model selector -->
         <div class="ext-ep-model-row" style="display:flex; align-items:center; gap:10px; flex-wrap:wrap;">
             <label style="font-size:0.85rem; font-weight:600; min-width:110px;">Available Models</label>
-            <input class="ext-ep-model-select" type="text" autocomplete="off"
-                style="padding:6px 10px; background:var(--background); color:var(--text); border:1px solid var(--primary); border-radius:8px; min-width:220px; flex:1; max-width:400px;">
-            <datalist class="ext-ep-model-datalist"></datalist>
+            <select class="ext-ep-model-dropdown"
+                style="padding:6px 10px; background:var(--background); color:var(--text); border:1px solid var(--primary); border-radius:8px; min-width:220px; flex:1; max-width:400px;"></select>
+            <input class="ext-ep-model-select" type="text" autocomplete="off" placeholder="Enter a model name…"
+                style="display:none; padding:6px 10px; background:var(--background); color:var(--text); border:1px solid var(--primary); border-radius:8px; min-width:220px; flex:1; max-width:400px;">
             <button class="ext-ep-model-test pill secondary" style="padding:5px 12px; font-size:0.85rem;">Test</button>
             <span class="ext-ep-model-test-echo" style="font-size:0.85rem; margin-left:2px;"></span>
         </div>

--- a/plugins/weather_plugin.py
+++ b/plugins/weather_plugin.py
@@ -11,7 +11,7 @@ import concurrent.futures
 from core.core_initializer import register_plugin
 from core.logging_utils import log_debug, log_info, log_warning, log_error
 from core.time_zone_utils import get_local_location, utc_to_local
-from core.config_manager import config_registry
+from core.config_manager import config_registry, ConfigVar
 from core.variables_engine import register_exposed_var
 
 # Injection priority for weather information
@@ -107,10 +107,33 @@ class WeatherPlugin:
         self._last_fetch: float = 0.0
         self._update_task: Optional[asyncio.Task] = None
 
-        # Register configuration with config_registry
-        self.fetch_minutes = config_registry.get_value(
+        # Use ConfigVar for always-fresh reads from config_registry.
+        # ConfigVar fetches the latest value on every access, so it never
+        # goes out of sync — even if the value is updated in the DB after
+        # the plugin starts. This replaces the fragile listener-based pattern
+        # that could miss updates due to startup timing.
+        self._fetch_minutes_var = ConfigVar(
+            "WEATHER_FETCH_TIME", registry=config_registry
+        )
+        self._daily_report_enabled_var = ConfigVar(
+            "WEATHER_DAILY_REPORT_ENABLED", registry=config_registry
+        )
+        self._daily_report_time_var = ConfigVar(
+            "WEATHER_DAILY_REPORT_TIME", registry=config_registry
+        )
+        self._daily_report_language_var = ConfigVar(
+            "WEATHER_DAILY_REPORT_LANGUAGE", registry=config_registry
+        )
+        self._daily_report_interface_var = ConfigVar(
+            "WEATHER_DAILY_REPORT_INTERFACE", registry=config_registry
+        )
+
+        # Ensure these vars are registered in config_registry with proper defaults
+        # (ConfigVar only reads, doesn't register — so we do a get_value call to
+        # ensure each key is defined before any ConfigVar tries to read it).
+        config_registry.get_value(
             "WEATHER_FETCH_TIME",
-            60,  # Default 60 minutes as requested
+            60,
             label="Weather Fetch Interval",
             description="Minutes between weather data fetches",
             value_type=int,
@@ -118,7 +141,7 @@ class WeatherPlugin:
             component="weather_plugin",
             advanced=False,
         )
-        self.daily_report_enabled = config_registry.get_value(
+        config_registry.get_value(
             "WEATHER_DAILY_REPORT_ENABLED",
             False,
             label="Daily Weather Report",
@@ -128,7 +151,7 @@ class WeatherPlugin:
             component="weather_plugin",
             advanced=False,
         )
-        self.daily_report_time = config_registry.get_value(
+        config_registry.get_value(
             "WEATHER_DAILY_REPORT_TIME",
             "06:00",
             label="Daily Weather Report Time",
@@ -138,7 +161,7 @@ class WeatherPlugin:
             component="weather_plugin",
             advanced=False,
         )
-        self.daily_report_language = config_registry.get_value(
+        config_registry.get_value(
             "WEATHER_DAILY_REPORT_LANGUAGE",
             "",
             label="Daily Weather Report Language",
@@ -148,7 +171,7 @@ class WeatherPlugin:
             component="weather_plugin",
             advanced=False,
         )
-        self.daily_report_interface = config_registry.get_value(
+        config_registry.get_value(
             "WEATHER_DAILY_REPORT_INTERFACE",
             "synth_webui",
             label="Daily Weather Report Interface",
@@ -159,65 +182,6 @@ class WeatherPlugin:
             advanced=True,
         )
 
-        # Add listener to update fetch_minutes when config changes
-        def _update_fetch_minutes(value):
-            try:
-                self.fetch_minutes = int(value) if value is not None else 60
-                log_info(
-                    f"[weather_plugin] Fetch interval updated to {self.fetch_minutes} minutes"
-                )
-            except (ValueError, TypeError):
-                log_warning(
-                    f"[weather_plugin] Invalid WEATHER_FETCH_TIME value: {value}, using default 60"
-                )
-                self.fetch_minutes = 60
-
-        config_registry.add_listener("WEATHER_FETCH_TIME", _update_fetch_minutes)
-
-        def _update_daily_report_enabled(value):
-            try:
-                self.daily_report_enabled = bool(value)
-                log_info(
-                    f"[weather_plugin] Daily report enabled: {self.daily_report_enabled}"
-                )
-            except Exception:
-                self.daily_report_enabled = False
-
-        def _update_daily_report_interface(value):
-            try:
-                self.daily_report_interface = str(value) if value else ""
-                log_info(
-                    f"[weather_plugin] Daily report interface set to: {self.daily_report_interface or 'none'}"
-                )
-            except Exception:
-                self.daily_report_interface = ""
-
-        def _update_daily_report_time(value):
-            try:
-                self.daily_report_time = str(value) if value else "06:00"
-            except Exception:
-                self.daily_report_time = "06:00"
-            self._apply_daily_report_time()
-
-        def _update_daily_report_language(value):
-            try:
-                self.daily_report_language = str(value) if value else ""
-            except Exception:
-                self.daily_report_language = ""
-
-        config_registry.add_listener(
-            "WEATHER_DAILY_REPORT_ENABLED", _update_daily_report_enabled
-        )
-        config_registry.add_listener(
-            "WEATHER_DAILY_REPORT_INTERFACE", _update_daily_report_interface
-        )
-        config_registry.add_listener(
-            "WEATHER_DAILY_REPORT_TIME", _update_daily_report_time
-        )
-        config_registry.add_listener(
-            "WEATHER_DAILY_REPORT_LANGUAGE", _update_daily_report_language
-        )
-
         # Use a dedicated executor so we don't depend on the event loop's default executor
         # which may be shut down during interpreter shutdown.
         self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=2)
@@ -225,32 +189,36 @@ class WeatherPlugin:
         self._scheduler_task = None
         self._scheduler_running = False
         self._last_daily_report_date = None
-        self._daily_report_hour = 6
-        self._daily_report_minute = 0
-        self._apply_daily_report_time()
 
-    def _apply_daily_report_time(self) -> None:
-        raw = str(self.daily_report_time or "").strip()
-        hour = 6
-        minute = 0
-        if raw:
-            try:
-                parts = raw.split(":")
-                if len(parts) >= 2:
-                    hour = int(parts[0])
-                    minute = int(parts[1])
-                elif len(parts) == 1:
-                    hour = int(parts[0])
-                    minute = 0
-            except Exception:
-                hour = 6
-                minute = 0
-        if hour < 0 or hour > 23:
-            hour = 6
-        if minute < 0 or minute > 59:
-            minute = 0
-        self._daily_report_hour = hour
-        self._daily_report_minute = minute
+    @property
+    def fetch_minutes(self) -> int:
+        """Return fetch interval in minutes, always fresh from registry."""
+        raw = str(self._fetch_minutes_var.value or "60")
+        try:
+            return int(raw)
+        except (ValueError, TypeError):
+            return 60
+
+    @property
+    def daily_report_enabled(self) -> bool:
+        """Return whether daily report is enabled, always fresh from registry."""
+        raw = str(self._daily_report_enabled_var.value or "false")
+        return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+    @property
+    def daily_report_time(self) -> str:
+        """Return daily report time, always fresh from registry."""
+        return str(self._daily_report_time_var.value or "06:00")
+
+    @property
+    def daily_report_language(self) -> str:
+        """Return daily report language hint, always fresh from registry."""
+        return str(self._daily_report_language_var.value or "")
+
+    @property
+    def daily_report_interface(self) -> str:
+        """Return daily report interface ID, always fresh from registry."""
+        return str(self._daily_report_interface_var.value or "")
 
     # Plugin action registration
     def get_supported_action_types(self):
@@ -562,12 +530,26 @@ class WeatherPlugin:
                 try:
                     await self._ensure_weather()
                     if self.daily_report_enabled:
-                        self._apply_daily_report_time()
+                        report_time_str = self.daily_report_time
+                        report_hour, report_minute = 6, 0
+                        if report_time_str:
+                            try:
+                                parts = report_time_str.split(":")
+                                if len(parts) >= 2:
+                                    report_hour = int(parts[0])
+                                    report_minute = int(parts[1])
+                                elif len(parts) == 1:
+                                    report_hour = int(parts[0])
+                            except Exception:
+                                pass
+                        report_hour = max(0, min(23, report_hour))
+                        report_minute = max(0, min(59, report_minute))
+
                         now_local = utc_to_local(datetime.utcnow())
                         today_key = now_local.date().isoformat()
                         if (
-                            now_local.hour == self._daily_report_hour
-                            and now_local.minute == self._daily_report_minute
+                            now_local.hour == report_hour
+                            and now_local.minute == report_minute
                         ):
                             if self._last_daily_report_date != today_key:
                                 if await self._trigger_daily_report():

--- a/res/synth_webui/js/engines.js
+++ b/res/synth_webui/js/engines.js
@@ -135,34 +135,66 @@
             subsysEl.appendChild(pill);
         }
 
-        // Model selector
+        // Model selector — dropdown (probed models) + custom text input fallback
+        const modelDropdown = card.querySelector('.ext-ep-model-dropdown');
         const modelInput = card.querySelector('.ext-ep-model-select');
-        const datalist = card.querySelector('.ext-ep-model-datalist');
-        const listId = 'ext-ep-models-' + ep.id;
-        datalist.id = listId;
-        modelInput.setAttribute('list', listId);
+        const CUSTOM_VALUE = '__custom__';
 
         const models = Array.isArray(ep.available_models) ? ep.available_models : [];
-        if (models.length === 0) {
-            modelInput.placeholder = ep.probe_status === 'never'
-                ? 'Type a model name or probe first...'
-                : 'Type a model name or probe to refresh...';
-            modelInput.disabled = false;
-        } else {
-            modelInput.placeholder = 'Type to search, select, or enter a model...';
-            modelInput.disabled = false;
-            for (const m of models) {
-                const opt = document.createElement('option');
-                opt.value = m;
-                datalist.appendChild(opt);
-            }
-        }
-        if (ep.default_model) {
-            modelInput.value = ep.default_model;
+        const current = ep.default_model || '';
+
+        // Populate the dropdown: a leading placeholder, all probed models, then a
+        // "custom" entry that reveals the free-text input.
+        modelDropdown.innerHTML = '';
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = models.length === 0
+            ? (ep.probe_status === 'never' ? '— probe first or enter custom —' : '— no models found, enter custom —')
+            : '— select a model —';
+        modelDropdown.appendChild(placeholder);
+
+        for (const m of models) {
+            const opt = document.createElement('option');
+            opt.value = m;
+            opt.textContent = m;
+            modelDropdown.appendChild(opt);
         }
 
+        const customOpt = document.createElement('option');
+        customOpt.value = CUSTOM_VALUE;
+        customOpt.textContent = '✏️ Custom…';
+        modelDropdown.appendChild(customOpt);
+
+        // Helper to read the effective model value (dropdown or custom input).
+        const readModel = () =>
+            modelDropdown.value === CUSTOM_VALUE ? modelInput.value.trim() : modelDropdown.value;
+
+        // Initial selection: match the saved default against the known models.
+        if (current && models.includes(current)) {
+            modelDropdown.value = current;
+            modelInput.style.display = 'none';
+        } else if (current) {
+            // Saved model not in the probed list → treat as custom.
+            modelDropdown.value = CUSTOM_VALUE;
+            modelInput.value = current;
+            modelInput.style.display = '';
+        } else {
+            modelDropdown.value = '';
+            modelInput.style.display = 'none';
+        }
+
+        modelDropdown.addEventListener('change', () => {
+            if (modelDropdown.value === CUSTOM_VALUE) {
+                modelInput.style.display = '';
+                modelInput.focus();
+                return; // wait for the user to type + blur before saving
+            }
+            modelInput.style.display = 'none';
+            handleSetModel(ep.id, modelDropdown.value, card);
+        });
+
         modelInput.addEventListener('change', () => {
-            handleSetModel(ep.id, modelInput.value, card);
+            handleSetModel(ep.id, readModel(), card);
         });
 
         // Probe time
@@ -179,11 +211,10 @@
         toggleBtn.style.color = '#fff';
         toggleBtn.addEventListener('click', () => handleToggle(ep.id, !ep.enabled));
 
-        card.querySelector('.ext-ep-probe-btn').addEventListener('click', () => handleProbe(ep.id));
+        card.querySelector('.ext-ep-probe-btn').addEventListener('click', () => handleProbe(ep.id, card));
         card.querySelector('.ext-ep-delete-btn').addEventListener('click', () => handleDelete(ep.id, ep.display_label || ep.name));
         card.querySelector('.ext-ep-model-test').addEventListener('click', () => {
-            const model = modelInput.value;
-            handleTestModel(ep.id, model, card);
+            handleTestModel(ep.id, readModel(), card);
         });
 
         return card;
@@ -205,20 +236,28 @@
         }
     }
 
-    async function handleProbe(id) {
+    async function handleProbe(id, card) {
+        const echoEl = card ? card.querySelector('.ext-ep-probe-echo') : null;
+        if (echoEl) { echoEl.textContent = 'Probing endpoint…'; echoEl.style.color = 'var(--muted)'; }
         try {
-            setStatus('Probing endpoint…', '');
             const result = await apiFetch(`/api/external-endpoints/${id}/probe`, { method: 'POST' });
             const capStr = Object.entries(result.capabilities || {})
                 .filter(([, v]) => v).map(([k]) => k).join(', ') || 'none';
-            setStatus(
-                `Probe ${result.status}: capabilities=[${capStr}] models=${result.models?.length ?? 0}`,
-                result.status === 'success' ? 'var(--success,#27ae60)' : 'var(--danger,#c0392b)'
-            );
+            const msg = `Probe ${result.status}: capabilities=[${capStr}] models=${result.models?.length ?? 0}`;
+            const color = result.status === 'success' ? 'var(--success,#27ae60)' : 'var(--danger,#c0392b)';
             await loadEndpoints();
             window.SynthWebUI?.loadEnginesSummary?.();
+            // loadEndpoints() rebuilds all cards, so re-select the refreshed card by id.
+            const newEcho = document.querySelector(`.ext-ep-card[data-id="${id}"] .ext-ep-probe-echo`);
+            if (newEcho) {
+                newEcho.textContent = msg;
+                newEcho.style.color = color;
+            }
         } catch (e) {
-            setStatus('Probe error: ' + e.message, 'var(--danger,#c0392b)');
+            if (echoEl) {
+                echoEl.textContent = 'Probe error: ' + e.message;
+                echoEl.style.color = 'var(--danger,#c0392b)';
+            }
         }
     }
 


### PR DESCRIPTION
- Load all configurations from DB and notify listeners before starting async plugins
- Fixes weather plugin daily report flag not reflecting user's UI setting
- Enhance OpenAI-compatible adapter to fallback to model_id/display_name
- Replace external endpoint model text input with dropdown and add probe echo