### PR TITLE
feat(vessel): add lowest-priority passive activity to the motor tick

### DIFF
--- a/core/vessel_beat.py
+++ b/core/vessel_beat.py
@@ -1528,6 +1528,27 @@ def resolve_reflection_min_interval(config_get: Any, default: int = 60) -> float
     return max(10.0, min(3600.0, value))
 
 
+def is_passive_activity_enabled(config_get: Any) -> bool:
+    """Return whether the **passive activity** layer is enabled.
+
+    Passive activity is the lowest-priority embodiment layer, below the motor
+    tick: when the body has no goal to pursue (before the first will beat, or
+    between a finished goal and the next one) a connector may opportunistically
+    work a nearby low-risk affordance or explore, instead of the body going
+    inert. It is a lease-bounded fallback inside the connector's existing
+    ``motor_step`` — never a new prompt, cognition turn or agentic loop — and
+    always yields to a real goal, danger, an in-flight deliberate action, or an
+    actively chatting player (see ``interface.vessel_interface._maybe_run_motor_tick``
+    and ``plugins.rift_vessel.minecraft.MinecraftConnector._run_passive_activity``).
+    Reads ``VESSEL_PASSIVE_ACTIVITY_ENABLED``. Fail-safe: any error → ``True``
+    (on by default, matching the config registration).
+    """
+    try:
+        return bool(config_get("VESSEL_PASSIVE_ACTIVITY_ENABLED", True))
+    except Exception:
+        return True
+
+
 def is_goal_beat_enabled(config_get: Any) -> bool:
     """Return whether the dedicated **goal beat** is enabled.
 

--- a/docs/rift_vessel.rst
+++ b/docs/rift_vessel.rst
@@ -345,6 +345,8 @@ Key                             Purpose
 ``VESSEL_ACTION_INTERVAL_SEC``  Seconds between action beats — LLM Fast-Lane turn (20, clamped 3–300)
 ``VESSEL_MOTOR_ENABLED``        Enable the fast motorics reflex (``True`` default)
 ``VESSEL_MOTOR_INTERVAL_SEC``   Seconds between fast motor ticks — no LLM (3, clamped 1–60)
+``VESSEL_PASSIVE_ACTIVITY_ENABLED``  Enable the lowest-priority passive-activity layer for a goal-less motor tick (``True`` default)
+``VESSEL_PASSIVE_ACTIVITY_LEASE_TICKS``  Consecutive motor ticks one passive selection may be pursued before it is let go (12, clamped 2–200)
 ``VESSEL_REFLECTION_ENABLED``   Enable the deliberate reflection pause (``True`` default)
 ``VESSEL_REFLECTION_DURATION_SEC``  Reflection window seconds — will/action beats held off, motor keeps moving (15, clamped 3–300)
 ``VESSEL_REFLECTION_MIN_INTERVAL_SEC``  Anti-thrash floor between two reflection pauses (60, clamped 10–3600)
@@ -578,6 +580,46 @@ Entities are never mined (mining is block-only). The reflex still **never reads
 the goal's free text**. The base ``VesselConnectorBase.motor_step`` is a no-op
 returning ``{"acted": False, "reason": "no_motorics"}``, so a world without
 motorics degrades gracefully.
+
+**Passive activity — staying embodied while cognition is busy (fast, no LLM,
+lowest priority).** Below the motor tick sits one more layer, added to close a
+specific gap: before the first will beat, or between a finished goal and the
+next one, ``goal`` is ``None`` and the motor tick had nothing to do — the body
+simply stood inert. Passive activity fills exactly that gap and *only* that
+gap; it reuses ``motor_step`` itself (no new prompt, cognition turn, Agent
+Lane task or Drone — see AGENTS.md §5c) and is deliberately the
+lowest-priority layer of all: the survival guard and the
+``deliberate_action_in_flight`` busy check both still run *before* the
+``no goal`` branch, so danger and an in-flight deliberate action pre-empt it
+by construction, and a fresh goal drops any pending selection immediately
+(``MinecraftConnector._passive_activity`` is cleared the moment ``goal`` is
+truthy again).
+
+Gated by ``VESSEL_PASSIVE_ACTIVITY_ENABLED`` (default True) and — before the
+connector is even called — by the interface scheduler's
+``passive_activity_allowed`` flag, resolved once per tick in
+``_maybe_run_motor_tick`` from the same player-quiet window
+(``VESSEL_WILL_QUIET_SEC``) that defers en-route sighting perceptions, so a
+player actively chatting suppresses passive selection too. When allowed, the
+Minecraft connector's ``_run_passive_activity`` mirrors the goal-directed
+reflex's benign-affordance handling: pick the nearest benign affordance (verb
+``use``/``mine``, hostile ``attack`` and light/utility blocks in
+``_REFLEX_NO_MINE_BLOCKS`` skipped), mine a block or use an entity within
+``_MOTOR_REACH``, else ``goto`` toward it; with nothing benign nearby it falls
+back to the same directional-march exploration the goal-directed reflex uses.
+A selection is a **lease**, not a commitment: it is pursued for at most
+``VESSEL_PASSIVE_ACTIVITY_LEASE_TICKS`` consecutive motor ticks (default 12,
+clamped ``[2, 200]``) or until it stops being a live affordance, whichever
+comes first; once its lease expires that exact target is excluded from the
+immediate reselection, so a perpetually-nearest affordance cannot simply be
+re-picked on the spot and pursued forever. Results carry
+``"reason": "passive_activity"`` so it is distinguishable in logs from
+ordinary goal-directed motorics. Purely structural (affordance shape/distance)
+— never keyword/goal-text driven, and never a new agentic loop. Connectors
+without a passive-activity implementation are unaffected: the base
+``VesselConnectorBase.motor_step`` accepts the same
+``passive_activity_allowed`` keyword and still degrades to the plain
+``no_motorics`` no-op.
 
 **Reflection pause — deliberate stop-and-think (LLM, elevated priority).** On
 top of the three speeds sits a *reflection pause*. Because the single message

--- a/interface/vessel_interface.py
+++ b/interface/vessel_interface.py
@@ -2904,6 +2904,13 @@ class VesselInterface:
         (2) ``VESSEL_MOTOR_ENABLED`` must be on; (3) a Vessel session must be
         active; (4) at least ``VESSEL_MOTOR_INTERVAL_SEC`` must have elapsed.
         Never creates an Agent Lane task, Drone or diary entry.
+
+        Also resolves and forwards ``passive_activity_allowed`` — whether the
+        connector's lowest-priority passive-activity fallback (no goal at all)
+        may engage this tick, per ``VESSEL_PASSIVE_ACTIVITY_ENABLED`` and the
+        player-quiet window — so a connector can stay embodied instead of
+        idle while cognition has not yet authored a goal. See
+        docs/rift_vessel.rst.
         """
         try:
             from core import vessel_beat
@@ -2938,8 +2945,41 @@ class VesselInterface:
         # element collection, so the fast tick never double-polls the connector.
         world, world_state = await self._read_active_world_state()
         goal = self._goal_from_world_state(world_state)
+
+        # Whether the connector's lowest-priority passive-activity fallback
+        # (see docs/rift_vessel.rst) may engage this tick. Computed here,
+        # *before* motor_step, so a connector can suppress passive selection
+        # while a player is actively chatting — the same quiet window used
+        # below to defer en-route sighting perceptions, and structural
+        # (actor-based via ``_last_player_activity_at``), never keyword
+        # matching.
         try:
-            result = await connector.motor_step(goal)
+            from core import vessel_beat as _vb
+
+            quiet_sec = _vb.resolve_will_quiet_sec(_cfg)
+            passive_enabled = _vb.is_passive_activity_enabled(_cfg)
+        except Exception:  # pragma: no cover - defensive
+            quiet_sec = 0
+            passive_enabled = True
+        player_active = (
+            quiet_sec > 0 and now - self._last_player_activity_at < quiet_sec
+        )
+        passive_allowed = passive_enabled and not player_active
+
+        try:
+            result = await connector.motor_step(
+                goal, passive_activity_allowed=passive_allowed
+            )
+        except TypeError:
+            # Older connector override without the passive-activity kwarg —
+            # degrade gracefully rather than skipping motor_step for it
+            # entirely (Vessel connectors are additive plugins; removing/not
+            # updating one must never break the scheduler).
+            try:
+                result = await connector.motor_step(goal)
+            except Exception as exc:
+                log_debug(f"[vessel_interface] motor_step failed: {exc}")
+                return
         except Exception as exc:
             log_debug(f"[vessel_interface] motor_step failed: {exc}")
             return
@@ -2964,13 +3004,9 @@ class VesselInterface:
         # window keeps the consumer free to pick up the player chat promptly.
         # Mirrors the will/action-beat deferral; structural (actor-based via
         # ``_last_player_activity_at``), never keyword matching; ``0`` disables it.
-        try:
-            from core import vessel_beat as _vb
-
-            quiet_sec = _vb.resolve_will_quiet_sec(_cfg)
-        except Exception:  # pragma: no cover - defensive
-            quiet_sec = 0
-        if quiet_sec > 0 and now - self._last_player_activity_at < quiet_sec:
+        # ``player_active`` was already computed above (shared with the
+        # passive-activity gate).
+        if player_active:
             log_debug(
                 "[vessel_interface] En-route sightings deferred: player active "
                 f"{now - self._last_player_activity_at:.0f}s ago "

--- a/plugins/rift_vessel/minecraft/minecraft.py
+++ b/plugins/rift_vessel/minecraft/minecraft.py
@@ -383,6 +383,18 @@ class MinecraftConnector(VesselConnectorBase):
         self._last_target_result: str | None = None
         self._last_target_name: str | None = None
         self._last_target_kind: str | None = None
+        # --- Passive activity state (in-memory, no DB) ---------------------
+        # Lowest-priority embodiment layer (see docs/rift_vessel.rst —
+        # "Passive activity"): when ``motor_step`` is called with no goal at
+        # all, the reflex would otherwise leave the body doing nothing. This
+        # tracks the currently-pursued passive selection (a nearby benign
+        # affordance) so consecutive ticks keep working the *same* target
+        # instead of re-rolling one every tick, bounded by
+        # ``_passive_activity_lease_ticks`` so it can never commit to one
+        # target forever. Cleared the moment a real goal takes over. Purely
+        # structural — never goal text/keywords.
+        self._passive_activity: Dict[str, Any] | None = None
+        self._passive_activity_lease_ticks: int = self._PASSIVE_ACTIVITY_LEASE_TICKS
         # --- Self-preservation reflex state (in-memory, no DB) ------------
         # The survival guard runs at the very top of every motor tick and
         # pre-empts normal movement when the body is in danger (drowning, in
@@ -2800,6 +2812,15 @@ class MinecraftConnector(VesselConnectorBase):
     _STATIC_WARD_RADIUS = 2.0
     _STATIC_WARD_TICKS = 8
 
+    # How many consecutive motor ticks a *passive-activity* selection (see
+    # ``_run_passive_activity``) may be pursued before the reflex lets go and
+    # reselects, even if the target is still a live affordance. This is the
+    # "must have a short-lived lease" guarantee from the passive-activity
+    # design: without it the body could keep chasing one unreachable target
+    # forever whenever there is no goal to override it. Purely a tick counter,
+    # like every other watchdog in this reflex — no timers, no keywords.
+    _PASSIVE_ACTIVITY_LEASE_TICKS = 12
+
     # Turn applied to the exploration heading each time a stale destination is
     # reprojected, so successive self-directed reprojections fan out across the
     # world instead of retracing the same straight line. ~2.4 rad ≈ 137° (a
@@ -3178,6 +3199,15 @@ class MinecraftConnector(VesselConnectorBase):
             self._static_ward_radius = min(max(radius, 0.5), 32.0)
             limit = _intv("VESSEL_STATICITY_TICKS", int(self._STATIC_WARD_TICKS))
             self._static_ward_limit = min(max(limit, 2), 1000)
+            # Passive activity: how long one selection may be pursued (see
+            # ``_run_passive_activity``). Enablement itself is gated upstream
+            # by the interface scheduler's ``passive_activity_allowed`` kwarg
+            # (``core.vessel_beat.is_passive_activity_enabled``), not here.
+            lease_ticks = _intv(
+                "VESSEL_PASSIVE_ACTIVITY_LEASE_TICKS",
+                int(self._PASSIVE_ACTIVITY_LEASE_TICKS),
+            )
+            self._passive_activity_lease_ticks = min(max(lease_ticks, 2), 200)
         except Exception as exc:  # pragma: no cover - defensive
             log_debug(f"{LOG_PREFIX} self-preservation config load failed: {exc}")
 
@@ -4332,7 +4362,140 @@ class MinecraftConnector(VesselConnectorBase):
             log_debug(f"[minecraft] on_entity_killed failed: {exc}")
         return None
 
-    async def motor_step(self, goal: Dict[str, Any] | None) -> Dict[str, Any]:
+    async def _run_passive_activity(self, state: "WorldState") -> Dict[str, Any]:
+        """Lowest-priority embodiment layer: act when there is genuinely no goal.
+
+        Only ever called from :meth:`motor_step`'s ``no goal`` branch — i.e.
+        *after* the survival guard and ``deliberate_action_in_flight`` have
+        already had first refusal, so danger and deliberate cognition-driven
+        actions always pre-empt this by construction. Mirrors the
+        goal-directed reflex's benign-affordance interaction (mine/use nearby,
+        skip hostile targets and light/utility blocks via
+        ``_REFLEX_NO_MINE_BLOCKS``) so the body stays doing something low-risk
+        and structural instead of standing inert while cognition has not yet
+        authored a goal — exactly the "walk around / mine nearby resources"
+        behaviour the passive-activity design calls for.
+
+        A selection is pursued for up to ``_passive_activity_lease_ticks``
+        consecutive ticks (or until it stops being a live affordance),
+        whichever comes first, so it can never commit to one unreachable
+        target forever; once its lease expires that exact target is excluded
+        from the immediate reselection (a target that merely stopped being a
+        live affordance carries no such exclusion), so a perpetually-nearest
+        affordance cannot simply be re-picked on the spot and continued
+        forever. When nothing benign is nearby (or the only one is the
+        just-expired target), falls back to the same directional-march
+        exploration used elsewhere in this reflex, so passive wandering looks
+        identical to purposeful exploration rather than a separate mechanism.
+        Purely structural (affordance shape/distance) — never keyword/
+        goal-text driven.
+        """
+        affordances = (state.extra or {}).get("affordances") or []
+        benign = [
+            a
+            for a in affordances
+            if isinstance(a, dict)
+            and a.get("verb") in ("use", "mine")
+            and not (
+                a.get("kind") == "block"
+                and a.get("target") in self._REFLEX_NO_MINE_BLOCKS
+            )
+        ]
+
+        active: Dict[str, Any] | None = self._passive_activity
+        # Key of a target whose *lease* (not just its presence) just expired —
+        # excluded from reselection below so a perpetually-nearest affordance
+        # cannot simply be re-picked on the spot and continued forever, which
+        # would defeat the lease entirely. A target that merely stopped being
+        # a live affordance (walked away / consumed) carries no such exclusion.
+        expired_key: str | None = None
+        if active is not None:
+            still_present = any(
+                isinstance(a, dict)
+                and a.get("kind") == active.get("target_kind")
+                and a.get("target") == active.get("target")
+                for a in benign
+            )
+            lease_hit = active.get("ticks", 0) >= self._passive_activity_lease_ticks
+            if not still_present or lease_hit:
+                if lease_hit:
+                    expired_key = f"{active.get('target_kind')}:{active.get('target')}"
+                active = None
+
+        if active is None and benign:
+            candidates = [
+                a
+                for a in benign
+                if expired_key is None
+                or f"{a.get('kind')}:{a.get('target')}" != expired_key
+            ]
+            chosen = candidates[0] if candidates else None
+            if chosen is not None:
+                active = {
+                    "target": chosen.get("target"),
+                    "target_kind": chosen.get("kind"),
+                    "ticks": 0,
+                }
+
+        self._passive_activity = active
+
+        if active is not None:
+            active["ticks"] = active.get("ticks", 0) + 1
+            name = active["target"]
+            distance = next(
+                (
+                    a.get("distance")
+                    for a in benign
+                    if a.get("kind") == active["target_kind"]
+                    and a.get("target") == name
+                ),
+                None,
+            )
+            if isinstance(distance, (int, float)) and distance <= self._MOTOR_REACH:
+                # Blocks are always mined, never merely "used" — mirroring the
+                # goal-directed reflex, which acts on a block's *kind* rather
+                # than trusting the affordance's own ``verb`` (every block
+                # affordance from ``_build_affordances`` is tagged ``use``;
+                # ``mine`` is this reflex's own structural decision).
+                verb = "mine" if active["target_kind"] == "block" else "use"
+                await self.act(verb, {"target": name})
+                return {
+                    "acted": True,
+                    "action": verb,
+                    "target": name,
+                    "target_kind": active["target_kind"],
+                    "reason": "passive_activity",
+                }
+            await self.act("goto", {"target": name})
+            return {
+                "acted": True,
+                "action": "goto",
+                "target": name,
+                "target_kind": active["target_kind"],
+                "reason": "passive_activity",
+            }
+
+        # Nothing benign nearby: march a safe exploration heading, the same
+        # pattern the goal-directed reflex uses when it has nothing to work
+        # with either.
+        forward = self._reproject_forward(state.position, self._explore_heading)
+        if forward is not None:
+            await self.act("goto", {"x": forward["x"], "z": forward["z"]})
+            return {
+                "acted": True,
+                "action": "goto",
+                "destination": forward,
+                "reason": "passive_activity",
+            }
+        await self.act("wander", {})
+        return {"acted": True, "action": "wander", "reason": "passive_activity"}
+
+    async def motor_step(
+        self,
+        goal: Dict[str, Any] | None,
+        *,
+        passive_activity_allowed: bool = True,
+    ) -> Dict[str, Any]:
         """Fast reflexive step toward the active goal — **no LLM, no cognition**.
 
         Called on a short timer by the interface scheduler (see
@@ -4348,8 +4511,14 @@ class MinecraftConnector(VesselConnectorBase):
 
         Rules (no keywords — purely on affordance shape/distance and numeric
         coordinates):
-          * No connection or no goal → do nothing (idle until the will beat
-            gives the body something to pursue).
+          * No connection → do nothing.
+          * No goal at all → the lowest-priority **passive activity** layer
+            (see ``_run_passive_activity`` and docs/rift_vessel.rst) engages
+            instead of idling, when ``passive_activity_allowed`` is ``True``
+            and ``VESSEL_PASSIVE_ACTIVITY_ENABLED`` is on: work a nearby
+            low-risk affordance or explore, leased so it never commits to one
+            target forever. Otherwise idle until the will beat gives the body
+            something to pursue.
           * A benign affordance already **within reach** → interact with it via
             its structural ``verb`` (``use`` / ``mine``), regardless of any
             distant destination — grab what is right in front of you. Hostile
@@ -4390,10 +4559,11 @@ class MinecraftConnector(VesselConnectorBase):
                 return {"acted": False, "reason": "no_world_state"}
 
             # Highest-priority reflex: survive. Runs every tick, pre-empting all
-            # normal movement, and is the only branch allowed to act with no
-            # goal. Structural only (numeric health/oxygen/distance + game enum
-            # block/entity ids) — never keyword matching. Returns a completed
-            # result dict when it acted, else None to fall through.
+            # normal movement — including passive activity below, the only
+            # *other* branch allowed to act with no goal. Structural only
+            # (numeric health/oxygen/distance + game enum block/entity ids) —
+            # never keyword matching. Returns a completed result dict when it
+            # acted, else None to fall through.
             survival = await self._run_survival_guard(state)
             if survival is not None:
                 return survival
@@ -4439,7 +4609,25 @@ class MinecraftConnector(VesselConnectorBase):
                 return {"acted": True, "action": "wander", "reason": "staticity_ward"}
 
             if not goal:
+                # Lowest-priority embodiment layer: instead of standing inert
+                # while cognition has not yet authored a goal, opportunistically
+                # work a nearby low-risk affordance or explore.
+                # ``passive_activity_allowed`` is resolved upstream by the
+                # interface scheduler and already folds in both the
+                # ``VESSEL_PASSIVE_ACTIVITY_ENABLED`` master toggle
+                # (``core.vessel_beat.is_passive_activity_enabled``) and the
+                # player-quiet window, so a single flag here is enough to
+                # restore the plain no-op below when either disables it.
+                if passive_activity_allowed:
+                    return await self._run_passive_activity(state)
+                self._passive_activity = None
                 return {"acted": False, "reason": "no_goal"}
+
+            # A real goal has taken over — drop any pending passive-activity
+            # lease so a later goal-less tick starts fresh instead of resuming
+            # something stale. Immediate interruption by a conscious goal
+            # change, per the passive-activity design.
+            self._passive_activity = None
 
             affordances = (state.extra or {}).get("affordances") or []
             # Reflexes stay peaceful: skip hostile targets, act only on benign

--- a/plugins/rift_vessel/vessel_base.py
+++ b/plugins/rift_vessel/vessel_base.py
@@ -426,7 +426,12 @@ class VesselConnectorBase(ABC):
                 matched.append(entry)
         return matched[: max(0, int(limit))]
 
-    async def motor_step(self, goal: Dict[str, Any] | None) -> Dict[str, Any]:
+    async def motor_step(
+        self,
+        goal: Dict[str, Any] | None,
+        *,
+        passive_activity_allowed: bool = True,
+    ) -> Dict[str, Any]:
         """Take **one** fast, reflexive step of the body toward ``goal``.
 
         This is the *motorics* half of autonomy (see ``core.vessel_beat`` and
@@ -442,9 +447,27 @@ class VesselConnectorBase(ABC):
         embodiment stays snappy and responsive. It must **never** create an
         Agent Lane task, a Drone, or a diary entry.
 
+        **Passive activity** (see docs/rift_vessel.rst): when ``goal`` is
+        ``None`` and ``passive_activity_allowed`` is ``True``, a connector may
+        — instead of returning the bare no-op below — opportunistically work a
+        nearby low-risk structural affordance or explore, so the body stays
+        embodied while cognition has not yet authored a goal. This is
+        deliberately the *lowest*-priority layer: it must reuse this same
+        ``motor_step`` call (never a separate agentic loop or reasoning turn),
+        must be leased/bounded rather than committed to indefinitely, and must
+        stop the instant a real goal, danger, an in-flight deliberate action,
+        or ``passive_activity_allowed=False`` (e.g. an actively chatting
+        player) says otherwise. See
+        ``plugins.rift_vessel.minecraft.MinecraftConnector._run_passive_activity``
+        for a concrete implementation.
+
         Args:
             goal: The current active goal dict (``{"description", "note", ...}``)
                   or ``None`` when Synth has not set one yet.
+            passive_activity_allowed: Whether a passive activity may engage
+                  this tick (session/player-quiet context resolved by the
+                  interface scheduler). Connectors without passive activity
+                  can ignore this.
 
         Returns:
             A small status dict, e.g. ``{"acted": True, "action": "wander"}`` or

--- a/plugins/rift_vessel/vessel_plugin.py
+++ b/plugins/rift_vessel/vessel_plugin.py
@@ -911,6 +911,42 @@ config_registry.get_value(
     component="vessel_plugin",
     advanced=True,
 )
+config_registry.get_value(
+    "VESSEL_PASSIVE_ACTIVITY_ENABLED",
+    True,
+    value_type=bool,
+    label="Passive Activity",
+    description=(
+        "When enabled, if the body has no goal to pursue at all (before the "
+        "first will beat, or between a finished goal and the next one) the "
+        "fast motor reflex opportunistically works a nearby low-risk "
+        "affordance (mine/use) or explores, instead of standing inert. Always "
+        "the lowest-priority layer: a real goal, danger, an in-flight "
+        "deliberate action, or an actively chatting player all take over "
+        "immediately. Purely structural, on the fast reflex layer (no LLM, no "
+        "diary, no new agentic loop). Only used when Autonomous In-World Play "
+        "is enabled."
+    ),
+    group="plugins",
+    component="vessel_plugin",
+    advanced=True,
+)
+config_registry.get_value(
+    "VESSEL_PASSIVE_ACTIVITY_LEASE_TICKS",
+    12,
+    value_type=int,
+    label="Passive Activity: Lease (ticks)",
+    description=(
+        "How many consecutive motor ticks the body may keep pursuing the same "
+        "passively-chosen affordance before it lets go and reselects. Bounds a "
+        "passive activity so it never commits to one unreachable target "
+        "forever. With the default motor interval (~3 s per tick) 12 ticks is "
+        "roughly 36 s. Clamped 2–200."
+    ),
+    group="plugins",
+    component="vessel_plugin",
+    advanced=True,
+)
 
 
 class VesselPlugin(AIPluginBase):

--- a/tests/test_vessel_beat.py
+++ b/tests/test_vessel_beat.py
@@ -29,6 +29,7 @@ from core.vessel_beat import (
     is_autonomy_enabled,
     is_goal_beat_enabled,
     is_motor_enabled,
+    is_passive_activity_enabled,
     is_reflection_enabled,
     resolve_action_interval,
     resolve_beat_interval,
@@ -526,6 +527,23 @@ def test_is_motor_enabled_failsafe_on_error() -> None:
         raise RuntimeError("config down")
 
     assert is_motor_enabled(_boom) is False
+
+
+def test_is_passive_activity_enabled_defaults_true_and_reads_flag() -> None:
+    # Default on when the key is absent.
+    assert is_passive_activity_enabled(lambda k, d: d) is True
+    assert is_passive_activity_enabled(lambda k, d: False) is False
+    assert is_passive_activity_enabled(lambda k, d: True) is True
+
+
+def test_is_passive_activity_enabled_failsafe_on_error() -> None:
+    def _boom(key: str, default: Any) -> Any:
+        raise RuntimeError("config down")
+
+    # Fail-safe defaults to True (matching the config registration default),
+    # unlike is_motor_enabled's fail-safe False — a config read failure must
+    # not silently kill the lowest-priority embodiment layer.
+    assert is_passive_activity_enabled(_boom) is True
 
 
 def test_resolve_will_quiet_sec_default_and_clamp() -> None:

--- a/tests/test_vessel_minecraft_motor.py
+++ b/tests/test_vessel_minecraft_motor.py
@@ -98,11 +98,28 @@ async def test_motor_step_not_connected() -> None:
 
 
 @pytest.mark.asyncio
-async def test_motor_step_no_goal() -> None:
+async def test_motor_step_no_goal_and_passive_activity_disallowed() -> None:
+    # With passive activity explicitly disallowed this tick (e.g. the
+    # interface scheduler suppressing it, per docs/rift_vessel.rst), a goal-
+    # less tick is still a true no-op — the pre-passive-activity behaviour.
     conn = _FakeConnector(connected=True)
-    result = await conn.motor_step(None)
+    result = await conn.motor_step(None, passive_activity_allowed=False)
     assert result == {"acted": False, "reason": "no_goal"}
     assert conn.calls == []
+
+
+@pytest.mark.asyncio
+async def test_motor_step_no_goal_engages_passive_activity_by_default() -> None:
+    # Passive activity (see docs/rift_vessel.rst) is the lowest-priority
+    # embodiment layer: by default (``passive_activity_allowed`` defaults to
+    # True) a goal-less tick no longer idles — with nothing benign nearby it
+    # falls back to the same directional march used elsewhere in the reflex.
+    conn = _FakeConnector(connected=True)
+    result = await conn.motor_step(None)
+    assert result["acted"] is True
+    assert result["reason"] == "passive_activity"
+    assert result["action"] == "goto"
+    assert conn.calls
 
 
 @pytest.mark.asyncio
@@ -1455,3 +1472,221 @@ async def test_survival_guard_preempts_deliberate_action_in_flight() -> None:
     result = await conn.motor_step(_ACTIVE_GOAL)
     assert result.get("reason") == "survival:drowning"
     assert ("surface", {}) in conn.calls
+
+
+# ----------------------------------------------------------------------
+# Passive activity (lowest-priority embodiment layer — docs/rift_vessel.rst)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_motor_step_passive_activity_mines_in_reach_block() -> None:
+    # No goal, but a benign block affordance is right there — work it instead
+    # of standing inert.
+    conn = _FakeConnector(
+        affordances=[
+            {"kind": "block", "target": "oak_log", "verb": "mine", "distance": 1.0}
+        ]
+    )
+    result = await conn.motor_step(None)
+    assert result == {
+        "acted": True,
+        "action": "mine",
+        "target": "oak_log",
+        "target_kind": "block",
+        "reason": "passive_activity",
+    }
+    assert ("mine", {"target": "oak_log"}) in conn.calls
+
+
+@pytest.mark.asyncio
+async def test_motor_step_passive_activity_uses_in_reach_entity() -> None:
+    # A non-block affordance (e.g. a chest) is "used", not mined — mirroring
+    # the goal-directed reflex's kind-based dispatch, not the affordance's own
+    # ``verb`` field (every affordance from ``_build_affordances`` already
+    # says ``use``; ``mine`` is the reflex's own decision for blocks only).
+    conn = _FakeConnector(
+        affordances=[
+            {"kind": "entity", "target": "chest", "verb": "use", "distance": 1.0}
+        ]
+    )
+    result = await conn.motor_step(None)
+    assert result == {
+        "acted": True,
+        "action": "use",
+        "target": "chest",
+        "target_kind": "entity",
+        "reason": "passive_activity",
+    }
+    assert ("use", {"target": "chest"}) in conn.calls
+
+
+@pytest.mark.asyncio
+async def test_motor_step_passive_activity_walks_to_out_of_reach_affordance() -> None:
+    conn = _FakeConnector(
+        affordances=[
+            {"kind": "block", "target": "oak_log", "verb": "mine", "distance": 10.0}
+        ]
+    )
+    result = await conn.motor_step(None)
+    assert result["acted"] is True
+    assert result["action"] == "goto"
+    assert result["target"] == "oak_log"
+    assert result["reason"] == "passive_activity"
+    assert ("goto", {"target": "oak_log"}) in conn.calls
+
+
+@pytest.mark.asyncio
+async def test_motor_step_passive_activity_skips_utility_blocks() -> None:
+    # A torch is structurally benign (verb "use") but must never be reflex-
+    # mined (AGENTS.md §5c — stripping a player's light source). With nothing
+    # else nearby, passive activity falls through to the directional march
+    # instead of touching it.
+    conn = _FakeConnector(
+        affordances=[
+            {"kind": "block", "target": "torch", "verb": "use", "distance": 1.0}
+        ]
+    )
+    result = await conn.motor_step(None)
+    assert result["acted"] is True
+    assert result["action"] == "goto"
+    assert result["reason"] == "passive_activity"
+    assert "target" not in result
+    assert all(call[0] != "use" for call in conn.calls)
+
+
+@pytest.mark.asyncio
+async def test_motor_step_passive_activity_ignores_hostile_affordances() -> None:
+    # Only a hostile "attack" affordance is present — reflexes stay peaceful
+    # even in the passive layer, so the body marches instead of engaging.
+    conn = _FakeConnector(
+        affordances=[
+            {"kind": "entity", "target": "zombie", "verb": "attack", "distance": 1.0}
+        ]
+    )
+    result = await conn.motor_step(None)
+    assert result["acted"] is True
+    assert result["action"] == "goto"
+    assert result["reason"] == "passive_activity"
+    assert all(call[0] != "attack" for call in conn.calls)
+
+
+@pytest.mark.asyncio
+async def test_motor_step_passive_activity_persists_target_across_ticks() -> None:
+    # The same out-of-reach affordance stays live across ticks: the reflex
+    # keeps pursuing the SAME target (not re-rolling a new one every tick)
+    # and its lease tick counter accrues.
+    conn = _FakeConnector(
+        affordances=[
+            {"kind": "block", "target": "oak_log", "verb": "mine", "distance": 10.0}
+        ]
+    )
+    await conn.motor_step(None)
+    await conn.motor_step(None)
+    assert conn._passive_activity is not None
+    assert conn._passive_activity["target"] == "oak_log"
+    assert conn._passive_activity["ticks"] == 2
+    assert conn.calls == [
+        ("goto", {"target": "oak_log"}),
+        ("goto", {"target": "oak_log"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_motor_step_passive_activity_lease_expires_and_marches() -> None:
+    # Once a selection's lease is exhausted, that exact target is excluded
+    # from the immediate reselection (else a perpetually-nearest affordance
+    # would never actually be let go). With no other candidate, the body
+    # falls through to the directional march instead of continuing forever.
+    conn = _FakeConnector(
+        affordances=[
+            {"kind": "block", "target": "oak_log", "verb": "mine", "distance": 10.0}
+        ]
+    )
+    conn._passive_activity_lease_ticks = 2
+
+    r1 = await conn.motor_step(None)
+    r2 = await conn.motor_step(None)
+    r3 = await conn.motor_step(None)
+
+    assert r1["target"] == "oak_log"
+    assert r2["target"] == "oak_log"
+    # Lease exhausted on tick 2 (ticks reached the limit) — tick 3 must not
+    # keep chasing the same target.
+    assert "target" not in r3
+    assert r3["action"] == "goto"
+    assert r3["reason"] == "passive_activity"
+
+
+@pytest.mark.asyncio
+async def test_motor_step_passive_activity_cleared_when_goal_takes_over() -> None:
+    # A conscious goal change interrupts passive activity immediately: once a
+    # real goal is supplied, any pending passive-activity lease is dropped.
+    conn = _FakeConnector(
+        affordances=[
+            {"kind": "block", "target": "oak_log", "verb": "mine", "distance": 10.0}
+        ]
+    )
+    await conn.motor_step(None)
+    assert conn._passive_activity is not None
+
+    await conn.motor_step(_ACTIVE_GOAL)
+    assert conn._passive_activity is None
+
+
+@pytest.mark.asyncio
+async def test_motor_step_passive_activity_yields_to_deliberate_action() -> None:
+    # The deliberate-action busy guard runs before the no-goal branch, so
+    # passive activity never engages while a cognition-driven action is
+    # in flight.
+    conn = _FakeConnector(
+        affordances=[
+            {"kind": "block", "target": "oak_log", "verb": "mine", "distance": 1.0}
+        ]
+    )
+    conn._deliberate_in_flight = 1
+    result = await conn.motor_step(None)
+    assert result == {"acted": False, "reason": "deliberate_action_in_flight"}
+    assert conn.calls == []
+
+
+@pytest.mark.asyncio
+async def test_motor_step_passive_activity_yields_to_survival_guard() -> None:
+    # Danger pre-empts even the goal-less passive-activity fallback: the
+    # survival guard runs first, unconditionally.
+    conn = _FakeConnector()
+    conn._sp_enabled = True
+    conn._sp_low_oxygen = float(MinecraftConnector._LOW_OXYGEN)
+    conn._sp_low_health = float(MinecraftConnector._LOW_HEALTH_FLEE)
+    conn._sp_hostile_dist = float(MinecraftConnector._HOSTILE_NEAR_DIST)
+    conn._sp_fight_back = True
+    conn._sp_fight_max_fails = int(MinecraftConnector._FIGHT_MAX_FAILS)
+    conn._sp_use_ranged = True
+    conn._sp_ranged_min_dist = float(MinecraftConnector._RANGED_MIN_DIST)
+    conn._sp_appraisal_enabled = True
+    conn._sp_engage_ratio = float(MinecraftConnector._ENGAGE_RATIO)
+    conn._sp_weak_mob_power = float(MinecraftConnector._WEAK_MOB_POWER)
+    conn._world_state = WorldState(
+        environment="minecraft",
+        health=20.0,
+        position={"x": 0.0, "y": 64.0, "z": 0.0},
+        possible_actions=[],
+        flags={"connected": True},
+        extra={
+            "is_alive": True,
+            "oxygen": 2,
+            "health": 20.0,
+            "block_head": "water",
+            "block_feet": "water",
+            "is_in_water": True,
+            "entities": [],
+            "affordances": [
+                {"kind": "block", "target": "oak_log", "verb": "mine", "distance": 1.0}
+            ],
+        },
+    )
+
+    result = await conn.motor_step(None)
+    assert result.get("reason") == "survival:drowning"
+    assert ("surface", {}) in conn.calls
+    assert all(call[0] != "mine" for call in conn.calls)


### PR DESCRIPTION
When goal is None (no will beat has fired yet, or between goals), the
motor tick was a bare no-op — the body stood inert while cognition was
busy. Reuses motor_step() directly: no new prompt, cognition turn, Agent
Lane task or Drone. Lowest priority by construction (survival guard and
deliberate_action_in_flight both still run first) and interruptible by
a fresh goal, danger, an in-flight deliberate action, or a chatting
player.

- core/vessel_beat.py: is_passive_activity_enabled() master gate
- interface/vessel_interface.py: _maybe_run_motor_tick resolves
  passive_activity_allowed (enable flag + player-quiet window) and
  forwards it to connector.motor_step(), degrading gracefully via
  TypeError fallback for older connector overrides
- plugins/rift_vessel/vessel_base.py: motor_step gains the optional
  passive_activity_allowed kwarg (no new abstract method)
- plugins/rift_vessel/minecraft/minecraft.py: MinecraftConnector's new
  _run_passive_activity() opportunistically mines/uses a nearby benign
  affordance (never hostile, never light/utility blocks) or marches an
  exploration heading; leased via VESSEL_PASSIVE_ACTIVITY_LEASE_TICKS so
  one target can't be pursued forever, and cleared the instant a real
  goal takes over
- plugins/rift_vessel/vessel_plugin.py: registers
  VESSEL_PASSIVE_ACTIVITY_ENABLED / VESSEL_PASSIVE_ACTIVITY_LEASE_TICKS
- docs/rift_vessel.rst: documents the new layer and config keys
- tests: is_passive_activity_enabled coverage in test_vessel_beat.py;
  passive-activity selection, lease expiry, and priority/interruption
  cases in test_vessel_minecraft_motor.py
