### PR TITLE
Temporal situational context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Fix failures before moving on.
 - **No `git add` or `git commit`** unless I explicitly ask.
 - Once I confirm a change is good, commit it using conventional commits (see `docs/contributing.rst`):
   `fix(scope):`, `feat(scope):`, `chore(scope):`, `minor(scope):`, `doc(scope):`, `patch(scope):`
+- **Commit messages: one-line subject only.** No `Co-Authored-By` trailer, no bundled body/description unless I explicitly ask for one.
 
 ## Hard Rules
 - **2-attempt limit.** Same error twice → stop → `"⚠️ Stuck on [Error]. Requesting human or advanced model intervention."`

--- a/core/config.py
+++ b/core/config.py
@@ -774,36 +774,41 @@ async def get_active_cortex_engine(scope: str | None = None) -> str:
                 )
 
             # Stale engine name in DB (e.g. removed engine from a previous branch).
-            # Fall back to the registry default rather than leaving the system broken.
+            # Only a value the operator actually configured may replace it.
             updates: list[tuple[str, str]] = []
             if use_override and override_key is not None and base in available:
                 fallback = base
                 updates.append((override_key, "Default"))
             else:
-                try:
-                    fallback = reg.get_default_engine()
-                except ValueError:
-                    raise ValueError(f"Cortex engine '{chosen}' is not registered")
-                if fallback == "anthropic":
-                    # get_default_engine() has no concept of credential
-                    # availability -- it just returns whichever built-in
-                    # engine module sorts first on disk, which is
-                    # "anthropic". If no key is configured this is a
-                    # guaranteed-broken pick. Reuse whichever engine is
-                    # already validly configured for the sibling
-                    # trainer/grillo scope on this same instance instead of
-                    # guessing at an arbitrary external endpoint.
-                    for sibling_key in ("TRAINER_CORTEX", "GRILLO_CORTEX"):
-                        sibling, _ = parse_cortex_scope_value(
-                            config_registry.get_value(sibling_key, "Default")
-                        )
-                        if (
-                            sibling
-                            and sibling not in ("Default", "None")
-                            and sibling in available
-                        ):
-                            fallback = sibling
-                            break
+                # Never substitute an engine nobody configured.
+                # ``CortexRegistry.get_default_engine()`` returns whichever
+                # engine module sorts first in registration order -- it has no
+                # relation to this instance's configuration, and persisting its
+                # pick is exactly what silently rewrote BASE_CORTEX to a keyless
+                # "anthropic" and kept it there for months (see FIXED_ISSUES.md
+                # and the incidents in AGENTS.md SS12). The only legitimate
+                # replacements are engines the operator set for a sibling scope.
+                fallback = ""
+                for sibling_key in ("TRAINER_CORTEX", "GRILLO_CORTEX"):
+                    sibling, _ = parse_cortex_scope_value(
+                        config_registry.get_value(sibling_key, "Default")
+                    )
+                    if (
+                        sibling
+                        and sibling not in ("Default", "None")
+                        and sibling in available
+                    ):
+                        fallback = sibling
+                        break
+                if not fallback:
+                    # Fail loudly instead of answering every turn with an engine
+                    # nobody chose: a visible error is diagnosable, a silent
+                    # substitution hides for months.
+                    raise ValueError(
+                        f"Cortex engine '{chosen}' is not available and no "
+                        "configured scope override can stand in for it. "
+                        "Set a usable engine for this scope in the WebUI."
+                    )
                 if use_override and override_key is not None:
                     updates.append((override_key, "Default"))
                 if base != fallback:

--- a/core/db_cutover.py
+++ b/core/db_cutover.py
@@ -157,6 +157,28 @@ _SOUL_TABLE_SPECS: tuple[_SoulTableSpec, ...] = (
         columns=("metric_key", "metric_value", "measured_at"),
         conflict_keys=("metric_key", "measured_at"),
     ),
+    _SoulTableSpec(
+        name="situational_notes",
+        columns=(
+            "id",
+            "note_type",
+            "subject",
+            "summary",
+            "priority",
+            "confidence",
+            "valid_from",
+            "valid_until",
+            "effective_at",
+            "expired_at",
+            "source",
+            "status",
+            "session_id",
+            "created_at",
+            "updated_at",
+            "resolved_at",
+        ),
+        conflict_keys=("id",),
+    ),
 )
 
 

--- a/core/prompt_engine.py
+++ b/core/prompt_engine.py
@@ -877,6 +877,19 @@ def _build_context_summary(
     )
     parts.append("\n".join(anchor_lines))
 
+    temporal_context = context_section.get("soul_temporal_context")
+    if temporal_context:
+        tc_lines = [
+            "- [TSC %s] %s"
+            % (
+                entry.get("note_type", "?"),
+                entry.get("summary", entry.get("subject", "")),
+            )
+            for entry in temporal_context[:8]
+        ]
+        if tc_lines:
+            parts.append("[Temporal context]\n" + "\n".join(tc_lines))
+
     persona_preferences = str(context_section.get("persona_preferences") or "").strip()
     if persona_preferences:
         parts.append("[Persona background]\n" + persona_preferences)

--- a/core/soul/__init__.py
+++ b/core/soul/__init__.py
@@ -18,11 +18,14 @@ from .models import (
     KgTriple,
     MemCell,
     MemScene,
+    SituationalNote,
     compute_memcell_salience,
 )
 from .repository import InMemorySoulRepository, PostgresSoulRepository, SoulRepository
+from .time_resolution import AbsoluteTimeResolver, TemporalRenderer
 
 __all__ = [
+    "AbsoluteTimeResolver",
     "DspExtraction",
     "DspVersion",
     "EmotionalEngine",
@@ -32,11 +35,13 @@ __all__ = [
     "EmotionalTag",
     "ForesightSignal",
     "InMemorySoulRepository",
-    "PostgresSoulRepository",
     "KgTriple",
     "MemCell",
     "MemScene",
+    "PostgresSoulRepository",
+    "SituationalNote",
     "SoulCompiler",
     "SoulRepository",
+    "TemporalRenderer",
     "compute_memcell_salience",
 ]

--- a/core/soul/compiler.py
+++ b/core/soul/compiler.py
@@ -24,7 +24,11 @@ from .models import (
 )
 from .observability import maybe_langfuse_trace
 from .repository import SoulRepository
-from .schemas import DspExtractionModel, MemCellExtractionModel, SummaryResultModel
+from .schemas import (
+    DspExtractionModel,
+    MemCellExtractionModel,
+    SummaryResultModel,
+)
 from .time_resolution import AbsoluteTimeResolver
 
 
@@ -330,6 +334,10 @@ class SoulCompiler:
                 current_date
             )
 
+            tsc_archived = await self.repository.archive_expired_situational_notes(
+                now_utc()
+            )
+
             dsp_raw = await self.dsp_extractor.extract_dsp(
                 transcript=transcript,
                 current_date=current_date,
@@ -375,6 +383,7 @@ class SoulCompiler:
 
             result_dict = {
                 "expired_foresight_signals": expired,
+                "tsc_notes_archived": tsc_archived,
                 "dsp_updated": dsp_updated,
             }
             if trace is not None:

--- a/core/soul/models.py
+++ b/core/soul/models.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from enum import Enum
 
 
@@ -25,6 +26,53 @@ class ForesightSignal:
     emotional_implication: dict[str, float] = field(default_factory=dict)
     source_cell_id: str | None = None
     priority: float = 0.5
+
+
+# Valid note types for SituationalNote.
+SITUATIONAL_NOTE_TYPES = ("EVENT", "STATE", "INTERVAL", "INSTANT")
+
+
+@dataclass(slots=True)
+class SituationalNote:
+    """Short-lived, time-sensitive user circumstance with a bounded validity window.
+
+    Unlike a MemCell (persistent memory) or a ForesightSignal (future-only,
+    date-level), a SituationalNote stores *absolute* timestamps for when a
+    circumstance was true (``valid_from``) and when it expires
+    (``valid_until``). Relative rendering ("today", "in 3 days") is a
+    presentation concern resolved at injection time via ``TemporalRenderer``.
+    """
+
+    id: str
+    note_type: str
+    subject: str
+    summary: str
+    valid_from: datetime | None
+    valid_until: datetime | None
+    priority: int = 0
+    confidence: float = 0.5
+    effective_at: datetime | None = None
+    expired_at: datetime | None = None
+    source: str = "debrief"
+    status: str = "active"
+    session_id: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    resolved_at: datetime | None = None
+
+    def is_active(self, now: datetime) -> bool:
+        """Return True when ``now`` falls within [valid_from, valid_until)."""
+        if self.valid_from and now < self.valid_from:
+            return False
+        if self.valid_until and now >= self.valid_until:
+            return False
+        return True
+
+    def is_expired(self, now: datetime) -> bool:
+        """Return True when the note has passed its validity window."""
+        if self.valid_until is None:
+            return False
+        return now >= self.valid_until
 
 
 @dataclass(slots=True)
@@ -255,6 +303,78 @@ def new_scene_id(anchor: datetime) -> str:
 
     ts = anchor.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
     return f"scene:{ts}"
+
+
+def situational_note_from_extraction(
+    *,
+    note_type: str,
+    subject: str,
+    summary: str,
+    priority: int = 0,
+    confidence: float = 0.5,
+    valid_from: datetime | None = None,
+    valid_until: datetime | None = None,
+    effective_at: datetime | None = None,
+    expired_at: datetime | None = None,
+    source: str = "debrief",
+    session_id: str | None = None,
+    now: datetime | None = None,
+    default_ttl_hours: int = 24,
+) -> "SituationalNote":
+    """Build a persistable note from extracted fields, normalising the window.
+
+    Every datetime is forced to UTC-aware, and a missing validity window falls
+    back to ``default_ttl_hours`` from ``now``. The id is deliberately left
+    empty: the repository derives a stable one from the circumstance so the same
+    note seen twice updates a single row instead of accumulating duplicates.
+    """
+
+    anchor = now or now_utc()
+    if anchor.tzinfo is None:
+        anchor = anchor.replace(tzinfo=timezone.utc)
+
+    def _utc(value: datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+    resolved_until = _utc(valid_until) or anchor + timedelta(hours=default_ttl_hours)
+    resolved_from = _utc(valid_from) or anchor
+
+    return SituationalNote(
+        id="",
+        note_type=note_type,
+        subject=subject,
+        summary=summary,
+        priority=priority,
+        confidence=confidence,
+        valid_from=resolved_from,
+        valid_until=resolved_until,
+        effective_at=_utc(effective_at),
+        expired_at=_utc(expired_at),
+        source=source,
+        status="active",
+        session_id=session_id,
+        created_at=anchor,
+        updated_at=anchor,
+        resolved_at=None,
+    )
+
+
+def situational_note_id(note_type: str, subject: str, summary: str) -> str:
+    """Build a stable id identifying one situational circumstance.
+
+    The id has to come from the circumstance itself rather than being generated
+    fresh: the debrief re-reads the same recent transcript on every run, so a
+    random id left ``ON CONFLICT (id) DO UPDATE`` unreachable and each compile
+    inserted another copy of a note the store already held. With a derived id
+    the second mention refreshes the existing row's validity window instead.
+    """
+
+    raw = "|".join(
+        str(part or "").strip().casefold() for part in (note_type, subject, summary)
+    )
+    return f"tsc-{hashlib.sha256(raw.encode('utf-8')).hexdigest()[:16]}"
 
 
 def now_utc() -> datetime:

--- a/core/soul/repository.py
+++ b/core/soul/repository.py
@@ -18,7 +18,10 @@ from .models import (
     MemCellRecall,
     MemCellSummary,
     MemScene,
+    SituationalNote,
     compute_memcell_salience,
+    now_utc,
+    situational_note_id,
 )
 
 
@@ -117,6 +120,14 @@ def _passes_recall_floor(match: MemCellRecall, session_id: str | None) -> bool:
     return match.score >= 0.22 and max(match.similarity, match.lexical_score) >= 0.10
 
 
+def _affected_rows(status: object, command: str) -> int:
+    """Return the row count from an asyncpg command tag such as ``UPDATE 3``."""
+    parts = str(status).split()
+    if len(parts) == 2 and parts[0].upper() == command:
+        return int(parts[1])
+    return 0
+
+
 class SoulRepository(Protocol):
     """Persistence contract for the soul subsystem."""
 
@@ -137,6 +148,21 @@ class SoulRepository(Protocol):
     async def upsert_foresight_signal(self, signal: ForesightSignal) -> None: ...
 
     async def archive_expired_foresight_signals(self, today: date) -> int: ...
+
+    async def upsert_situational_note(self, note: SituationalNote) -> str: ...
+
+    async def list_active_situational_notes(
+        self, now: datetime, subject: str | None = None
+    ) -> list[SituationalNote]: ...
+
+    async def resolve_situational_note(
+        self,
+        note_id: str,
+        new_status: str,
+        summary_delta: str | None = None,
+    ) -> None: ...
+
+    async def archive_expired_situational_notes(self, now: datetime) -> int: ...
 
     async def add_dsp_extraction(self, extraction: DspExtraction) -> None: ...
 
@@ -175,6 +201,7 @@ class InMemorySoulRepository:
     scenes: dict[str, MemScene] = field(default_factory=dict)
     kg_triples: list[KgTriple] = field(default_factory=list)
     foresight_signals: list[ForesightSignal] = field(default_factory=list)
+    situational_notes: dict[str, SituationalNote] = field(default_factory=dict)
     dsp_extractions: list[DspExtraction] = field(default_factory=list)
     active_dsp: DspVersion | None = None
 
@@ -218,6 +245,61 @@ class InMemorySoulRepository:
             s for s in self.foresight_signals if s.valid_until >= today
         ]
         return before - len(self.foresight_signals)
+
+    async def upsert_situational_note(self, note: SituationalNote) -> str:
+        note_id = note.id or situational_note_id(
+            note.note_type, note.subject, note.summary
+        )
+        note.id = note_id
+        now = now_utc()
+        note.updated_at = now
+        if note.created_at is None:
+            note.created_at = now
+        self.situational_notes[note_id] = note
+        return note_id
+
+    async def list_active_situational_notes(
+        self, now: datetime, subject: str | None = None
+    ) -> list[SituationalNote]:
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        result = [
+            note
+            for note in self.situational_notes.values()
+            if note.status == "active" and note.is_active(now)
+        ]
+        if subject:
+            result = [n for n in result if n.subject == subject]
+        result.sort(key=lambda n: (-n.priority, n.valid_until))
+        return result
+
+    async def resolve_situational_note(
+        self,
+        note_id: str,
+        new_status: str,
+        summary_delta: str | None = None,
+    ) -> None:
+        note = self.situational_notes.get(note_id)
+        if note is None:
+            return
+        note.status = new_status
+        if summary_delta:
+            note.summary = summary_delta
+        if new_status == "resolved":
+            note.resolved_at = now_utc()
+        note.updated_at = now_utc()
+
+    async def archive_expired_situational_notes(self, now: datetime) -> int:
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        expired_ids = [
+            note_id
+            for note_id, note in self.situational_notes.items()
+            if note.status == "active" and note.is_expired(now)
+        ]
+        for note_id in expired_ids:
+            self.situational_notes[note_id].status = "archived"
+        return len(expired_ids)
 
     async def add_dsp_extraction(self, extraction: DspExtraction) -> None:
         self.dsp_extractions.append(extraction)
@@ -480,6 +562,29 @@ class PostgresSoulRepository:
                 PRIMARY KEY(metric_key, measured_at)
             )
             """,
+            """
+            CREATE TABLE IF NOT EXISTS situational_notes (
+                id TEXT PRIMARY KEY,
+                note_type VARCHAR(32) NOT NULL,
+                subject TEXT,
+                summary TEXT NOT NULL,
+                priority SMALLINT NOT NULL DEFAULT 0,
+                confidence REAL NOT NULL DEFAULT 0.5,
+                valid_from TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                valid_until TIMESTAMPTZ NOT NULL,
+                effective_at TIMESTAMPTZ,
+                expired_at TIMESTAMPTZ,
+                source TEXT NOT NULL DEFAULT 'debrief',
+                status VARCHAR(16) NOT NULL DEFAULT 'active',
+                session_id TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                resolved_at TIMESTAMPTZ
+            )
+            """,
+            "CREATE INDEX IF NOT EXISTS idx_situational_active ON situational_notes(status, valid_until) WHERE status='active'",
+            "CREATE INDEX IF NOT EXISTS idx_situational_subject ON situational_notes(subject)",
+            "CREATE INDEX IF NOT EXISTS idx_situational_valid_until ON situational_notes(valid_until)",
         ]
 
         async with pool.acquire() as conn:
@@ -722,11 +827,132 @@ class PostgresSoulRepository:
                 """,
                 today,
             )
-        # asyncpg returns command tags like "UPDATE 3".
-        parts = str(status).split()
-        if len(parts) == 2 and parts[0].upper() == "UPDATE":
-            return int(parts[1])
-        return 0
+        return _affected_rows(status, "UPDATE")
+
+    async def upsert_situational_note(self, note: SituationalNote) -> str:
+        if not note.id:
+            note.id = situational_note_id(note.note_type, note.subject, note.summary)
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO situational_notes (
+                    id, note_type, subject, summary, priority, confidence,
+                    valid_from, valid_until, effective_at, expired_at,
+                    source, status, session_id, created_at, updated_at
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW(), NOW()
+                )
+                ON CONFLICT (id)
+                DO UPDATE SET
+                    note_type = EXCLUDED.note_type,
+                    subject = EXCLUDED.subject,
+                    summary = EXCLUDED.summary,
+                    priority = EXCLUDED.priority,
+                    confidence = EXCLUDED.confidence,
+                    valid_from = EXCLUDED.valid_from,
+                    valid_until = EXCLUDED.valid_until,
+                    effective_at = EXCLUDED.effective_at,
+                    expired_at = EXCLUDED.expired_at,
+                    source = EXCLUDED.source,
+                    status = EXCLUDED.status,
+                    session_id = EXCLUDED.session_id,
+                    updated_at = NOW()
+                """,
+                note.id,
+                note.note_type,
+                note.subject,
+                note.summary,
+                note.priority,
+                note.confidence,
+                note.valid_from,
+                note.valid_until,
+                note.effective_at,
+                note.expired_at,
+                note.source,
+                note.status,
+                note.session_id,
+            )
+        return note.id
+
+    async def list_active_situational_notes(
+        self, now: datetime, subject: str | None = None
+    ) -> list[SituationalNote]:
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            if subject:
+                rows = await conn.fetch(
+                    """
+                    SELECT id, note_type, subject, summary, priority, confidence,
+                           valid_from, valid_until, effective_at, expired_at,
+                           source, status, session_id, created_at, updated_at,
+                           resolved_at
+                    FROM situational_notes
+                    WHERE status = 'active'
+                      AND valid_until > $1
+                      AND valid_from <= $1
+                      AND subject = $2
+                    ORDER BY priority DESC, valid_until ASC
+                    """,
+                    now,
+                    subject,
+                )
+            else:
+                rows = await conn.fetch(
+                    """
+                    SELECT id, note_type, subject, summary, priority, confidence,
+                           valid_from, valid_until, effective_at, expired_at,
+                           source, status, session_id, created_at, updated_at,
+                           resolved_at
+                    FROM situational_notes
+                    WHERE status = 'active'
+                      AND valid_until > $1
+                      AND valid_from <= $1
+                    ORDER BY priority DESC, valid_until ASC
+                    """,
+                    now,
+                )
+        return [self._row_to_situational_note(row) for row in rows]
+
+    async def resolve_situational_note(
+        self,
+        note_id: str,
+        new_status: str,
+        summary_delta: str | None = None,
+    ) -> None:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE situational_notes
+                SET status = $2,
+                    summary = COALESCE($3, summary),
+                    resolved_at = CASE WHEN $2 = 'resolved' THEN NOW() ELSE resolved_at END,
+                    updated_at = NOW()
+                WHERE id = $1
+                """,
+                note_id,
+                new_status,
+                summary_delta or None,
+            )
+
+    async def archive_expired_situational_notes(self, now: datetime) -> int:
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            status = await conn.execute(
+                """
+                UPDATE situational_notes
+                SET status = 'archived', updated_at = NOW()
+                WHERE status = 'active' AND valid_until <= $1
+                """,
+                now,
+            )
+        return _affected_rows(status, "UPDATE")
 
     async def add_dsp_extraction(self, extraction: DspExtraction) -> None:
         pool = await self._get_pool()
@@ -1125,3 +1351,31 @@ class PostgresSoulRepository:
             except Exception:
                 return []
         return []
+
+    @staticmethod
+    def _row_to_situational_note(row: Any) -> SituationalNote:
+        def _to_dt(val: Any) -> datetime | None:
+            if val is None:
+                return None
+            if isinstance(val, str):
+                return datetime.fromisoformat(val)
+            return val
+
+        return SituationalNote(
+            id=str(row["id"]),
+            note_type=str(row["note_type"]),
+            subject=str(row["subject"]) if row["subject"] else "",
+            summary=str(row["summary"]),
+            priority=int(row["priority"]) if row["priority"] else 0,
+            confidence=float(row["confidence"]) if row["confidence"] else 0.5,
+            valid_from=_to_dt(row["valid_from"]),
+            valid_until=_to_dt(row["valid_until"]),
+            effective_at=_to_dt(row["effective_at"]),
+            expired_at=_to_dt(row["expired_at"]),
+            source=str(row["source"]) if row["source"] else "debrief",
+            status=str(row["status"]) if row["status"] else "active",
+            session_id=str(row["session_id"]) if row["session_id"] else None,
+            created_at=_to_dt(row["created_at"]),
+            updated_at=_to_dt(row["updated_at"]),
+            resolved_at=_to_dt(row["resolved_at"]),
+        )

--- a/core/soul/schemas.py
+++ b/core/soul/schemas.py
@@ -47,6 +47,48 @@ class DspExtractionModel(BaseModel):
     ai_self_facts: list[str] = Field(default_factory=list)
 
 
+class SituationalNoteModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    note_type: str = Field(min_length=1)
+    subject: str = Field(min_length=1)
+    summary: str = Field(min_length=1)
+    priority: int = Field(ge=-3, le=3, default=0)
+    confidence: float = Field(ge=0.0, le=1.0, default=0.5)
+    valid_from: datetime | None = None
+    valid_until: datetime
+    effective_at: datetime | None = None
+    expired_at: datetime | None = None
+    source: str = Field(default="debrief")
+
+    @field_validator(
+        "valid_from", "valid_until", "effective_at", "expired_at", mode="before"
+    )
+    @classmethod
+    def accept_iso_strings(cls, value: object) -> object:
+        """Parse ISO-8601 strings before strict validation rejects them.
+
+        The model is strict, but these values come from an LLM, which emits
+        datetimes as strings. Without this the whole extraction failed schema
+        validation every time and silently fell back to the rule-based path.
+        """
+        if not isinstance(value, str):
+            return value
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            return value
+
+
+class SituationalExtractionModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    notes: list[SituationalNoteModel] = Field(default_factory=list)
+
+
 class SummaryResultModel(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True)
 

--- a/core/soul/time_resolution.py
+++ b/core/soul/time_resolution.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 _WEEKDAYS: tuple[str, ...] = (
     "monday",
@@ -133,3 +133,103 @@ class AbsoluteTimeResolver:
         out = re.sub(r"\b(\d+)\s+days\s+ago\b", _ago, out, flags=re.IGNORECASE)
         out = re.sub(r"\bin\s+(\d+)\s+days\b", _ahead, out, flags=re.IGNORECASE)
         return out
+
+
+@dataclass(slots=True)
+class TemporalRenderer:
+    """Render absolute datetimes as human-relative temporal phrases.
+
+    This is the dual of :class:`AbsoluteTimeResolver`: where the resolver turns
+    "tomorrow" → ``2026-04-18`` for storage, the renderer turns a stored
+    absolute timestamp back into "tomorrow" / "today" / "in 3 days" etc. at
+    injection time (relative to ``now``).
+
+    Storage is always absolute (timezone-aware); relative text is presentation.
+    """
+
+    now: datetime
+
+    def __post_init__(self) -> None:
+        if self.now.tzinfo is None:
+            self.now = self.now.replace(tzinfo=timezone.utc)
+
+    def render_relative(self, ts: datetime | None) -> str:
+        """Return a short human-relative phrase for ``ts`` relative to ``now``."""
+        if ts is None:
+            return "ongoing"
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        delta = ts - self.now
+
+        if abs(delta) < timedelta(minutes=5):
+            if delta >= timedelta(0):
+                return "in a few minutes"
+            return "just now"
+
+        if delta < timedelta(0):
+            return self._render_past(-delta)
+        return self._render_future(delta)
+
+    def _render_past(self, delta: timedelta) -> str:
+        days = delta.days
+        if days == 0:
+            seconds = delta.seconds
+            if seconds < 3600:
+                minutes = seconds // 60
+                if minutes < 1:
+                    return "just now"
+                if minutes == 1:
+                    return "a minute ago"
+                if minutes < 60:
+                    return f"{minutes} minutes ago"
+            hours = seconds // 3600
+            if hours == 1:
+                return "an hour ago"
+            if hours < 12:
+                return f"{hours} hours ago"
+            return "earlier today"
+        if days == 1:
+            return "yesterday"
+        if days <= 6:
+            return f"{days} days ago"
+        if days <= 13:
+            return "last week"
+        if days <= 30:
+            weeks = days // 7
+            if weeks == 1:
+                return "last week"
+            return f"{weeks} weeks ago"
+        return f"{days // 30} months ago"
+
+    def _render_future(self, delta: timedelta) -> str:
+        days = delta.days
+        if days == 0:
+            seconds = delta.seconds
+            if seconds < 3600:
+                minutes = seconds // 60
+                if minutes < 1:
+                    return "in a few minutes"
+                if minutes == 1:
+                    return "in a minute"
+                if minutes < 60:
+                    return f"in {minutes} minutes"
+            hours = seconds // 3600
+            if hours == 1:
+                return "in an hour"
+            if hours < 12:
+                return f"in {hours} hours"
+            return "later today"
+        if days == 1:
+            return "tomorrow"
+        if days <= 6:
+            return f"in {days} days"
+        if days <= 13:
+            return "next week"
+        if days <= 30:
+            weeks = days // 7
+            if weeks == 1:
+                return "next week"
+            return f"in {weeks} weeks"
+        if days <= 60:
+            return "next month"
+        return f"in {days // 30} months"

--- a/plugins/debrief/debrief_situational_notes.py
+++ b/plugins/debrief/debrief_situational_notes.py
@@ -1,0 +1,359 @@
+"""Debrief plugin extracting temporal situational notes from a finished turn.
+
+Sibling of :mod:`debrief_action_intent`. Where that plugin looks at what the
+persona *promised* and proposes recovery actions, this one looks at what the
+human *said about their circumstances* and stores short-lived, time-bounded
+notes so later prompts can take them into account ("has a dentist appointment
+tomorrow", "moving house this week", "flying to Osaka on the 14th").
+
+The notes live in the SOUL store (``situational_notes``): this plugin owns the
+extraction, SOUL owns the model, the persistence and the prompt injection. When
+the SOUL plugin is absent the extraction is skipped and the debrief continues —
+removing either plugin never breaks the other.
+
+Stable biographical facts are explicitly out of scope: those belong to the DSP
+user profile, which is compiled separately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from core.config_manager import config_registry
+from core.logging_utils import log_debug, log_info, log_warning
+from core.transport_layer import extract_json_from_text, run_corrector_middleware
+
+
+display_name = "Debrief Situational Notes"
+
+
+try:
+    from core.variables_engine import register_exposed_var
+
+    register_exposed_var(
+        "SITUATIONAL_NOTES_DEBRIEF_ENABLED",
+        label="Situational Notes Debrief Enabled",
+        default=True,
+        value_type=bool,
+        ui_type="bool",
+        description="Extract temporal situational notes during Debrief",
+        scope="agent",
+        component="debrief_situational_notes",
+        advanced=True,
+        needs_component_reload=False,
+    )
+    register_exposed_var(
+        "SITUATIONAL_NOTES_MAX",
+        label="Situational Notes Max",
+        default=8,
+        value_type=int,
+        ui_type="number",
+        description="Maximum number of situational notes stored per turn",
+        scope="agent",
+        component="debrief_situational_notes",
+        advanced=True,
+        needs_component_reload=False,
+    )
+except Exception:
+    pass
+
+
+_EXTRACT_INSTRUCTIONS = (
+    "You extract TEMPORAL SITUATIONAL CONTEXT from one exchange between an AI "
+    "persona and its human. This store is for SHORT-LIVED, time-bounded "
+    "circumstances only — things that are true now but will expire (on vacation "
+    "this week, traveling tomorrow, an appointment on a specific date, moving "
+    "house next month).\n"
+    "Stable biographical facts (name, job, residence, standing preferences, "
+    "tastes) must NOT go here — they belong to the separate persistent user "
+    "profile. Only extract circumstances with a clear expiry window.\n"
+    "For each circumstance, resolve relative phrases ('tomorrow', 'next week', "
+    "'this Friday') to ABSOLUTE ISO datetimes for valid_from and valid_until "
+    "using the 'now' value provided. If the human says 'next week' and now is "
+    "2026-05-05, valid_from could be 2026-05-05 and valid_until 2026-05-12. "
+    "Never invent precise dates the human did not anchor — if unsure, use a "
+    "short window and set confidence below 1.0.\n"
+    "note_type is one of: EVENT (point-in-time occurrence), STATE (temporary "
+    "condition), INTERVAL (time range), INSTANT (past occurrence with short "
+    "relevance).\n"
+    "priority: -3..3 (higher = more urgent). confidence: 0.0-1.0.\n"
+    'Return ONLY a JSON object: {"notes": [{"note_type": ..., "subject": ..., '
+    '"summary": ..., "priority": 0, "confidence": 0.5, '
+    '"valid_from": "2026-05-05T00:00:00+00:00", '
+    '"valid_until": "2026-05-12T00:00:00+00:00"}]} — return an empty notes list '
+    "when nothing time-bounded was said."
+)
+
+
+class DebriefSituationalNotesPlugin:
+    display_name = display_name
+
+    def get_supported_actions(self) -> dict:
+        return {}
+
+    def _is_enabled(self) -> bool:
+        try:
+            return bool(
+                config_registry.get_value(
+                    "SITUATIONAL_NOTES_DEBRIEF_ENABLED", True, value_type=bool
+                )
+            )
+        except Exception:
+            return True
+
+    def _get_max_notes(self) -> int:
+        try:
+            value = int(
+                config_registry.get_value("SITUATIONAL_NOTES_MAX", 8, value_type=int)
+            )
+        except Exception:
+            return 8
+        return max(1, min(value, 20))
+
+    @staticmethod
+    def _normalize_assistant_response(text: str) -> str:
+        """Unwrap the persona's message from a JSON cortex reply."""
+        if not isinstance(text, str) or not text.strip():
+            return ""
+        try:
+            parsed = extract_json_from_text(text, return_metadata=False)
+        except Exception:
+            parsed = None
+        if isinstance(parsed, dict):
+            message = parsed.get("message")
+            if isinstance(message, str) and message.strip():
+                return message.strip()
+        return text.strip()
+
+    @staticmethod
+    def _extract_note_candidates(parsed: Any) -> List[Dict[str, Any]]:
+        """Pull the note dicts out of whatever shape the model returned."""
+        if isinstance(parsed, list):
+            return [item for item in parsed if isinstance(item, dict)]
+        if not isinstance(parsed, dict):
+            return []
+        for key in ("notes", "situational_notes"):
+            if isinstance(parsed.get(key), list):
+                return [item for item in parsed[key] if isinstance(item, dict)]
+        # A model that returned a single bare note.
+        if parsed.get("note_type") and parsed.get("summary"):
+            return [parsed]
+        return []
+
+    async def _parse_notes_output(
+        self,
+        *,
+        llm_text: str,
+        context: Dict[str, Any],
+        original_message: Any,
+    ) -> List[Dict[str, Any]]:
+        """Extract note dicts, asking the corrector once when the JSON is broken."""
+        try:
+            parsed, metadata = extract_json_from_text(llm_text, return_metadata=True)
+        except Exception as exc:
+            log_debug(
+                f"[debrief_situational_notes] JSON extraction failed, "
+                f"will ask corrector: {exc}"
+            )
+            parsed, metadata = None, {}
+
+        candidates = self._extract_note_candidates(parsed)
+        if candidates:
+            return candidates
+        # An empty but well-formed answer is the normal "nothing temporal was
+        # said" case; only bother the corrector when the payload looked broken.
+        if isinstance(parsed, (dict, list)) and not (
+            metadata.get("had_errors") or metadata.get("had_extra_text")
+        ):
+            return []
+
+        corrected_text = await run_corrector_middleware(
+            text=llm_text,
+            bot=None,
+            context=context,
+            chat_id=getattr(original_message, "chat_id", None),
+            thread_id=getattr(original_message, "thread_id", None),
+        )
+        if not isinstance(corrected_text, str) or not corrected_text.strip():
+            return []
+        try:
+            corrected = extract_json_from_text(corrected_text, return_metadata=False)
+        except Exception as exc:
+            log_warning(
+                f"[debrief_situational_notes] corrected output still not JSON: {exc}"
+            )
+            return []
+        return self._extract_note_candidates(corrected)
+
+    @staticmethod
+    def _get_soul_repository() -> Any | None:
+        """Return the SOUL repository, or ``None`` when the plugin is absent.
+
+        The note store belongs to SOUL; this plugin only feeds it. Everything is
+        guarded so a Synth running without the SOUL plugin still debriefs.
+        """
+        try:
+            from core.core_initializer import PLUGIN_REGISTRY
+
+            soul = PLUGIN_REGISTRY.get("soul_plugin")
+        except Exception as exc:
+            log_debug(f"[debrief_situational_notes] plugin registry unavailable: {exc}")
+            return None
+        if soul is None:
+            return None
+        getter = getattr(soul, "get_repository", None)
+        if not callable(getter):
+            log_debug(
+                "[debrief_situational_notes] soul_plugin exposes no repository accessor"
+            )
+            return None
+        try:
+            return getter()
+        except Exception as exc:
+            log_warning(f"[debrief_situational_notes] repository lookup failed: {exc}")
+            return None
+
+    async def _store_notes(
+        self, candidates: List[Dict[str, Any]], session_id: str | None
+    ) -> int:
+        """Validate and persist the extracted notes. Returns how many were stored."""
+        repository = self._get_soul_repository()
+        if repository is None:
+            return 0
+
+        from core.soul.models import situational_note_from_extraction
+        from core.soul.schemas import SituationalNoteModel
+
+        stored = 0
+        for raw in candidates[: self._get_max_notes()]:
+            try:
+                model = SituationalNoteModel.model_validate(raw)
+            except Exception as exc:
+                log_debug(f"[debrief_situational_notes] discarded a note: {exc}")
+                continue
+            note = situational_note_from_extraction(
+                note_type=model.note_type,
+                subject=model.subject,
+                summary=model.summary,
+                priority=model.priority,
+                confidence=model.confidence,
+                valid_from=model.valid_from,
+                valid_until=model.valid_until,
+                effective_at=model.effective_at,
+                expired_at=model.expired_at,
+                source="debrief",
+                session_id=session_id,
+            )
+            try:
+                await repository.upsert_situational_note(note)
+                stored += 1
+            except Exception as exc:
+                log_warning(
+                    f"[debrief_situational_notes] could not store a note: {exc}"
+                )
+        return stored
+
+    async def on_debrief(
+        self,
+        processed_actions: List[Dict],
+        failed_actions: List[Dict],
+        results: Dict,
+        context: Dict,
+        original_message: Any,
+    ) -> Dict | None:
+        if not self._is_enabled():
+            return None
+
+        if not isinstance(context, dict):
+            context = {}
+
+        llm_response = self._normalize_assistant_response(
+            context.get("llm_response_text")
+            or (results or {}).get("llm_response_text")
+            or ""
+        )
+        if not llm_response:
+            return None
+
+        if not (
+            context.get("from_cortex")
+            or getattr(original_message, "from_cortex", False)
+        ):
+            return None
+
+        user_message = (
+            context.get("original_user_message")
+            or getattr(original_message, "text", "")
+            or ""
+        )
+        if not isinstance(user_message, str) or not user_message.strip():
+            return None
+
+        now = datetime.now(timezone.utc)
+        # Plain labelled text, deliberately not a JSON blob. An OpenAI-compatible
+        # backend may try to read a JSON string as structured content and keep
+        # only the keys it recognises (text/content/parts), silently dropping
+        # everything else: the turn then never reaches the model and every
+        # extraction comes back empty with no error anywhere.
+        user_prompt = (
+            f"now: {now.isoformat()}\n"
+            f"max_notes: {self._get_max_notes()}\n\n"
+            f"The human said:\n{user_message.strip()}\n\n"
+            f"The persona replied:\n{llm_response}"
+        )
+
+        try:
+            from core.config import derive_cortex_scope, get_active_cortex_engine
+            from core.cortex_registry import get_cortex_registry
+
+            scope = derive_cortex_scope(context)
+            active_cortex = await get_active_cortex_engine(scope=scope)
+            registry = get_cortex_registry()
+            engine = registry.get_engine(active_cortex) or registry.load_engine(
+                active_cortex
+            )
+        except Exception as exc:
+            log_warning(
+                f"[debrief_situational_notes] could not load Cortex engine: {exc}"
+            )
+            return None
+
+        if not engine or not hasattr(engine, "generate_response"):
+            return None
+
+        try:
+            llm_text = await asyncio.wait_for(
+                engine.generate_response(
+                    [
+                        {"role": "system", "content": _EXTRACT_INSTRUCTIONS},
+                        {"role": "user", "content": user_prompt},
+                    ]
+                ),
+                timeout=120,
+            )
+        except Exception as exc:
+            # repr, not str: a bare asyncio.TimeoutError stringifies to "",
+            # which made this line read as a failure with no reason at all.
+            log_warning(f"[debrief_situational_notes] LLM generation failed: {exc!r}")
+            return None
+
+        candidates = await self._parse_notes_output(
+            llm_text=llm_text,
+            context=context,
+            original_message=original_message,
+        )
+        if not candidates:
+            return None
+
+        session_id = context.get("session_id") or getattr(
+            original_message, "session_id", None
+        )
+        stored = await self._store_notes(candidates, session_id)
+        if stored:
+            log_info(f"[debrief_situational_notes] Stored {stored} situational note(s)")
+        return None
+
+
+PLUGIN_CLASS = DebriefSituationalNotesPlugin

--- a/plugins/soul_plugin/soul_plugin.py
+++ b/plugins/soul_plugin/soul_plugin.py
@@ -32,7 +32,10 @@ from core.soul.repository import (
     PostgresSoulRepository,
     SoulRepository,
 )
-from core.soul.strategies import RuleBasedDspExtractor, RuleBasedMemCellExtractor
+from core.soul.strategies import (
+    RuleBasedDspExtractor,
+    RuleBasedMemCellExtractor,
+)
 
 register_exposed_var(
     "SOUL_COMPILE_IDLE_SECONDS",
@@ -109,6 +112,54 @@ register_exposed_var(
     ),
     scope="plugins",
     component="soul_plugin",
+)
+
+register_exposed_var(
+    "SOUL_TEMPORAL_ENABLED",
+    label="Temporal situational context extraction",
+    default=1,
+    value_type=int,
+    ui_type="bool",
+    description=(
+        "Extract short-lived, time-bounded user circumstances (e.g. 'on vacation "
+        "next week', 'moving tomorrow') into the situational_notes store. "
+        "These are rendered as relative temporal context in prompts and expire "
+        "automatically. This is NOT a replacement for persistent MemCell memory "
+        "— stable facts still go through DSP extraction."
+    ),
+    scope="plugins",
+    component="soul_plugin",
+)
+
+register_exposed_var(
+    "SOUL_TEMPORAL_LOOKBACK_DAYS",
+    label="Temporal context lookback window (days)",
+    default=1,
+    value_type=int,
+    ui_type="number",
+    description=(
+        "How many days back a situational note must have been created to still be "
+        "injected into the prompt context."
+    ),
+    scope="plugins",
+    component="soul_plugin",
+)
+
+register_exposed_var(
+    "SOUL_TEMPORAL_CATEGORY_DEFAULT_TTL",
+    label="Default TTL per note type (hours)",
+    default='{"event": 168, "state": 24, "interval": 48, "instant": 1}',
+    value_type=str,
+    ui_type="text",
+    description=(
+        "JSON map of note_type → default validity window in hours, used when the "
+        "user's temporal language does not specify a precise end. "
+        "event=168 (1 week), state=24 (1 day), interval=48 (2 days), "
+        "instant=1 (1 hour)."
+    ),
+    scope="plugins",
+    component="soul_plugin",
+    advanced=True,
 )
 
 
@@ -206,6 +257,23 @@ class SoulPlugin(PluginBase):
                 f"[soul_plugin] LLM DSP builder unavailable ({exc}); using rule-based"
             )
             return RuleBasedDspBuilder()
+
+    @staticmethod
+    def _is_temporal_enabled() -> bool:
+        """Return whether temporal situational context is active.
+
+        ``SOUL_TEMPORAL_ENABLED`` defaults on. When disabled the stored notes
+        are no longer injected into the prompt. Extraction lives in the
+        ``debrief_situational_notes`` plugin and has its own toggle.
+        """
+        try:
+            from core.config_manager import config_registry
+
+            return bool(
+                config_registry.get_value("SOUL_TEMPORAL_ENABLED", 1, value_type=int)
+            )
+        except Exception:
+            return True
 
     def _build_embedder(self) -> Any:
         from importlib.util import find_spec
@@ -369,7 +437,64 @@ class SoulPlugin(PluginBase):
                 for signal in foresight[:8]
             ],
             "soul_recalled_memories": recalled_memories,
+            "soul_temporal_context": await self._get_temporal_context(now),
         }
+
+    async def _get_temporal_context(self, now: datetime) -> list[dict[str, Any]]:
+        """Return active situational notes as renderable dicts.
+
+        Gated on ``SOUL_TEMPORAL_ENABLED``; fail-safe on any error.
+        """
+        if not SoulPlugin._is_temporal_enabled():
+            return []
+        try:
+            from core.soul.time_resolution import TemporalRenderer
+
+            renderer = TemporalRenderer(now=now)
+            lookback = self._get_lookback_days()
+            cutoff = now - timedelta(days=lookback)
+            notes = await self._repo.list_active_situational_notes(now=now)
+            result: list[dict[str, Any]] = []
+            for note in notes:
+                if note.created_at and note.created_at < cutoff:
+                    continue
+                result.append(
+                    {
+                        "note_type": note.note_type,
+                        "subject": note.subject,
+                        "summary": note.summary,
+                        "priority": note.priority,
+                        "confidence": note.confidence,
+                        "valid_from_relative": renderer.render_relative(
+                            note.valid_from
+                        ),
+                        "valid_until_relative": renderer.render_relative(
+                            note.valid_until
+                        ),
+                        "source": note.source,
+                    }
+                )
+            return result
+        except Exception as exc:
+            log_debug(f"[soul_plugin] Temporal context injection failed: {exc}")
+            return []
+
+    @staticmethod
+    def _get_lookback_days() -> int:
+        try:
+            from core.config_manager import config_registry
+
+            return max(
+                1,
+                int(
+                    config_registry.get_value(
+                        "SOUL_TEMPORAL_LOOKBACK_DAYS", 1, value_type=int
+                    )
+                    or 1
+                ),
+            )
+        except Exception:
+            return 1
 
     async def _get_grillo_beat_context(self, message: Any) -> dict[str, object]:
         """Return passive SOUL context for Grillo beats.
@@ -428,6 +553,9 @@ class SoulPlugin(PluginBase):
                 for signal in foresight[:8]
             ],
             "soul_recalled_memories": recalled_memories,
+            "soul_temporal_context": await self._get_temporal_context(
+                datetime.now(timezone.utc)
+            ),
         }
 
     async def _scheduler_loop(self) -> None:
@@ -885,6 +1013,15 @@ class SoulPlugin(PluginBase):
             intensity=intensity,
             context=text[:120],
         )
+
+    def get_repository(self) -> SoulRepository:
+        """Return the SOUL store for other plugins that feed or read it.
+
+        The situational-notes debrief plugin extracts notes but does not own the
+        store; this is the sanctioned way in, so it never has to reach for a
+        private attribute.
+        """
+        return self._repo
 
     def _build_repository(self) -> SoulRepository:
         backend = self._get_repository_backend()

--- a/scripts/sql/soul_memory_postgres.sql
+++ b/scripts/sql/soul_memory_postgres.sql
@@ -119,3 +119,28 @@ CREATE TABLE IF NOT EXISTS soul_metrics (
     measured_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY(metric_key, measured_at)
 );
+
+CREATE TABLE IF NOT EXISTS situational_notes (
+    id TEXT PRIMARY KEY,
+    note_type VARCHAR(32) NOT NULL,
+    subject TEXT,
+    summary TEXT NOT NULL,
+    priority SMALLINT NOT NULL DEFAULT 0,
+    confidence REAL NOT NULL DEFAULT 0.5,
+    valid_from TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    valid_until TIMESTAMPTZ NOT NULL,
+    effective_at TIMESTAMPTZ,
+    expired_at TIMESTAMPTZ,
+    source TEXT NOT NULL DEFAULT 'debrief',
+    status VARCHAR(16) NOT NULL DEFAULT 'active',
+    session_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    resolved_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_situational_active
+    ON situational_notes(status, valid_until)
+    WHERE status='active';
+CREATE INDEX IF NOT EXISTS idx_situational_subject ON situational_notes(subject);
+CREATE INDEX IF NOT EXISTS idx_situational_valid_until ON situational_notes(valid_until);

--- a/tests/soul/test_situational_notes.py
+++ b/tests/soul/test_situational_notes.py
@@ -1,0 +1,225 @@
+"""Tests for temporal situational notes (D13) in core.soul."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from core.soul.models import SituationalNote
+from core.soul.repository import InMemorySoulRepository
+
+
+@pytest.fixture
+def repo() -> InMemorySoulRepository:
+    return InMemorySoulRepository()
+
+
+@pytest.fixture
+def now() -> datetime:
+    return datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc)
+
+
+async def _insert(
+    repo: InMemorySoulRepository,
+    note_type: str,
+    subject: str = "test",
+    valid_from: datetime | None = None,
+    valid_until: datetime | None = None,
+    now: datetime | None = None,
+) -> str:
+    note = SituationalNote(
+        id=None,
+        note_type=note_type,
+        subject=subject,
+        summary="test summary",
+        valid_from=valid_from
+        or (now or datetime.now(timezone.utc)) - timedelta(hours=1),
+        valid_until=valid_until,
+        priority=1,
+        confidence=0.8,
+        source="test",
+        created_at=now or datetime.now(timezone.utc),
+        updated_at=now or datetime.now(timezone.utc),
+    )
+    return await repo.upsert_situational_note(note)
+
+
+@pytest.mark.asyncio
+async def test_insert_and_retrieve(repo: InMemorySoulRepository, now: datetime) -> None:
+    note_id = await _insert(repo, "EVENT", valid_until=now + timedelta(days=1), now=now)
+    notes = await repo.list_active_situational_notes(now=now)
+    assert len(notes) == 1
+    assert notes[0].note_type == "EVENT"
+    assert notes[0].id == note_id
+
+
+@pytest.mark.asyncio
+async def test_active_state_note(repo: InMemorySoulRepository, now: datetime) -> None:
+    await _insert(repo, "STATE", valid_from=now - timedelta(hours=1), now=now)
+    notes = await repo.list_active_situational_notes(now=now)
+    assert len(notes) == 1
+    assert notes[0].is_active(now)
+
+
+@pytest.mark.asyncio
+async def test_expired_state_note_filtered(
+    repo: InMemorySoulRepository, now: datetime
+) -> None:
+    await _insert(
+        repo,
+        "STATE",
+        valid_from=now - timedelta(hours=5),
+        valid_until=now - timedelta(hours=1),
+        now=now,
+    )
+    notes = await repo.list_active_situational_notes(now=now)
+    assert len(notes) == 0
+
+
+@pytest.mark.asyncio
+async def test_instant_note_not_yet_active(
+    repo: InMemorySoulRepository, now: datetime
+) -> None:
+    future = now + timedelta(hours=2)
+    await _insert(repo, "INSTANT", valid_from=future, now=now)
+    notes = await repo.list_active_situational_notes(now=now)
+    assert len(notes) == 0
+
+
+@pytest.mark.asyncio
+async def test_interval_note_active(
+    repo: InMemorySoulRepository, now: datetime
+) -> None:
+    await _insert(
+        repo,
+        "INTERVAL",
+        valid_from=now - timedelta(hours=1),
+        valid_until=now + timedelta(hours=1),
+        now=now,
+    )
+    notes = await repo.list_active_situational_notes(now=now)
+    assert len(notes) == 1
+    assert notes[0].is_active(now)
+
+
+@pytest.mark.asyncio
+async def test_archive_expired(repo: InMemorySoulRepository, now: datetime) -> None:
+    await _insert(
+        repo,
+        "STATE",
+        valid_from=now - timedelta(hours=5),
+        valid_until=now - timedelta(hours=1),
+        now=now,
+    )
+    archived = await repo.archive_expired_situational_notes(now=now)
+    assert archived >= 1
+    notes = await repo.list_active_situational_notes(now=now)
+    assert len(notes) == 0
+
+
+@pytest.mark.asyncio
+async def test_resolve_existing(repo: InMemorySoulRepository, now: datetime) -> None:
+    note_id = await _insert(repo, "EVENT", valid_until=now + timedelta(days=1), now=now)
+    notes_before = await repo.list_active_situational_notes(now=now)
+    assert len(notes_before) == 1
+    await repo.resolve_situational_note(note_id, new_status="resolved")
+    notes_after = await repo.list_active_situational_notes(now=now)
+    assert len(notes_after) == 0
+
+
+@pytest.mark.asyncio
+async def test_resolve_nonexistent(repo: InMemorySoulRepository) -> None:
+    await repo.resolve_situational_note("nonexistent-id", new_status="resolved")
+
+
+@pytest.mark.asyncio
+async def test_upsert_updates_existing(
+    repo: InMemorySoulRepository, now: datetime
+) -> None:
+    note = SituationalNote(
+        id=None,
+        note_type="STATE",
+        subject="sick",
+        summary="feels unwell",
+        valid_from=now,
+        valid_until=now + timedelta(hours=24),
+        priority=2,
+        confidence=0.9,
+        source="test",
+        created_at=now,
+        updated_at=now,
+    )
+    note_id = await repo.upsert_situational_note(note)
+
+    note.id = note_id
+    note.subject = "recovered"
+    await repo.upsert_situational_note(note)
+
+    notes = await repo.list_active_situational_notes(now=now)
+    found = [n for n in notes if n.id == note_id]
+    assert len(found) == 1
+    assert found[0].subject == "recovered"
+
+
+@pytest.mark.asyncio
+async def test_same_circumstance_upserts_one_row(
+    repo: InMemorySoulRepository, now: datetime
+) -> None:
+    """Storing the same circumstance twice must update one row, not add a second.
+
+    Regression: the note id was generated fresh on every upsert, so the
+    repository's ``ON CONFLICT (id) DO UPDATE`` was unreachable. The debrief
+    re-reads the same recent transcript on each run, so a single mentioned event
+    accumulated one duplicate note per compile cycle — five identical rows were
+    observed in a live store within an hour.
+    """
+    first = SituationalNote(
+        id="",
+        note_type="EVENT",
+        subject="upcoming_event",
+        summary="User mentioned an upcoming event on 2026-09-14",
+        valid_from=now,
+        valid_until=now + timedelta(days=7),
+    )
+    # Same circumstance, seen again one hour later: the validity window slides,
+    # which is exactly what made the duplicates look like distinct notes.
+    second = SituationalNote(
+        id="",
+        note_type="EVENT",
+        subject="upcoming_event",
+        summary="User mentioned an upcoming event on 2026-09-14",
+        valid_from=now + timedelta(hours=1),
+        valid_until=now + timedelta(days=7, hours=1),
+    )
+
+    first_id = await repo.upsert_situational_note(first)
+    second_id = await repo.upsert_situational_note(second)
+
+    assert first_id == second_id
+    notes = await repo.list_active_situational_notes(now=now + timedelta(hours=2))
+    assert len(notes) == 1
+    # The re-mention refreshes the window rather than spawning a sibling.
+    assert notes[0].valid_until == now + timedelta(days=7, hours=1)
+
+
+@pytest.mark.asyncio
+async def test_different_circumstances_stay_separate(
+    repo: InMemorySoulRepository, now: datetime
+) -> None:
+    """Deduplication must not collapse genuinely different circumstances."""
+    for summary in (
+        "User mentioned an upcoming event on 2026-09-14",
+        "User mentioned an upcoming event on 2026-09-15",
+    ):
+        await repo.upsert_situational_note(
+            SituationalNote(
+                id="",
+                note_type="EVENT",
+                subject="upcoming_event",
+                summary=summary,
+                valid_from=now,
+                valid_until=now + timedelta(days=7),
+            )
+        )
+
+    notes = await repo.list_active_situational_notes(now=now + timedelta(hours=1))
+    assert len(notes) == 2

--- a/tests/soul/test_temporal_renderer.py
+++ b/tests/soul/test_temporal_renderer.py
@@ -1,0 +1,102 @@
+"""Tests for core.soul.time_resolution.TemporalRenderer."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from core.soul.time_resolution import TemporalRenderer
+
+
+@pytest.fixture
+def now() -> datetime:
+    return datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc)
+
+
+def test_past_same_day(now: datetime) -> None:
+    renderer = TemporalRenderer(now=now)
+    past = now - timedelta(hours=3)
+    assert renderer.render_relative(past) == "3 hours ago"
+
+
+def test_tomorrow(now: datetime) -> None:
+    renderer = TemporalRenderer(now=now)
+    future = now + timedelta(hours=25)
+    assert renderer.render_relative(future) == "tomorrow"
+
+
+def test_yesterday(now: datetime) -> None:
+    renderer = TemporalRenderer(now=now)
+    past = now - timedelta(hours=25)
+    assert renderer.render_relative(past) == "yesterday"
+
+
+def test_in_three_days(now: datetime) -> None:
+    renderer = TemporalRenderer(now=now)
+    future = now + timedelta(days=3)
+    assert renderer.render_relative(future) == "in 3 days"
+
+
+def test_in_seven_days(now: datetime) -> None:
+    renderer = TemporalRenderer(now=now)
+    future = now + timedelta(days=7)
+    assert renderer.render_relative(future) == "next week"
+
+
+def test_three_days_past(now: datetime) -> None:
+    renderer = TemporalRenderer(now=now)
+    past = now - timedelta(days=3)
+    assert renderer.render_relative(past) == "3 days ago"
+
+
+def test_far_future(now: datetime) -> None:
+    renderer = TemporalRenderer(now=now)
+    future = now + timedelta(days=50)
+    text = renderer.render_relative(future)
+    assert "month" in text.lower()
+
+
+def test_far_past(now: datetime) -> None:
+    renderer = TemporalRenderer(now=now)
+    past = now - timedelta(days=30)
+    text = renderer.render_relative(past)
+    assert "ago" in text
+
+
+def test_none_timestamp(now: datetime) -> None:
+    renderer = TemporalRenderer(now=now)
+    assert renderer.render_relative(None) == "ongoing"
+
+
+def test_naive_timestamp(now: datetime) -> None:
+    renderer = TemporalRenderer(now=now)
+    naive = now.replace(tzinfo=None) - timedelta(hours=3)
+    assert renderer.render_relative(naive) == "3 hours ago"
+
+
+def test_same_moment(now: datetime) -> None:
+    renderer = TemporalRenderer(now=now)
+    assert renderer.render_relative(now) == "in a few minutes"
+
+
+def test_near_future(now: datetime) -> None:
+    renderer = TemporalRenderer(now=now)
+    near_future = now + timedelta(seconds=30)
+    assert renderer.render_relative(near_future) == "in a few minutes"
+
+
+def test_near_past(now: datetime) -> None:
+    renderer = TemporalRenderer(now=now)
+    near_past = now - timedelta(seconds=30)
+    assert renderer.render_relative(near_past) == "just now"
+
+
+def test_last_week(now: datetime) -> None:
+    renderer = TemporalRenderer(now=now)
+    past = now - timedelta(days=10)
+    assert renderer.render_relative(past) == "last week"
+
+
+def test_next_week(now: datetime) -> None:
+    renderer = TemporalRenderer(now=now)
+    future = now + timedelta(days=10)
+    assert renderer.render_relative(future) == "next week"

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -201,7 +201,16 @@ def test_log_chat_loader_is_reentrant_safe(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_get_active_cortex_engine_repairs_stale_base_for_scope(monkeypatch):
+async def test_get_active_cortex_engine_refuses_invented_fallback_for_stale_base(
+    monkeypatch,
+):
+    """A stale BASE_CORTEX with no configured stand-in must raise, not invent.
+
+    ``CortexRegistry.get_default_engine()`` returns whichever engine module
+    sorts first in registration order. Substituting that pick -- and persisting
+    it -- is what rewrote BASE_CORTEX to a keyless 'anthropic' and left it there
+    for months. The resolver may only use engines the operator configured.
+    """
     from core import config as conf
     import core.config_manager as cm
 
@@ -228,10 +237,61 @@ async def test_get_active_cortex_engine_repairs_stale_base_for_scope(monkeypatch
         "core.cortex_registry.get_cortex_registry", lambda: FakeRegistry()
     )
 
-    engine = await conf.get_active_cortex_engine("grillo")
+    with pytest.raises(ValueError, match="not available"):
+        await conf.get_active_cortex_engine("grillo")
 
-    assert engine == "anthropic"
-    set_value.assert_awaited_once_with("BASE_CORTEX", "anthropic")
+    # The operator's (broken) choice must survive: nothing is overwritten.
+    set_value.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_active_cortex_engine_keyless_anthropic_without_sibling_raises(
+    monkeypatch,
+):
+    """BASE_CORTEX stuck at keyless 'anthropic' with no sibling override.
+
+    The 2026-07-01 fix recovers by copying a sibling scope's engine, but that
+    only works when TRAINER_CORTEX or GRILLO_CORTEX is set. With both at
+    'Default' the old code fell back to 'anthropic' again and -- since
+    ``base == fallback`` -- persisted nothing, so it silently returned a
+    guaranteed-broken engine on every turn and left no trace in the DB.
+    """
+    from core import config as conf
+    import core.config_manager as cm
+
+    class FakeRegistry:
+        def get_available_engines(self):
+            # A configured, enabled external endpoint is registered alongside
+            # the keyless built-in.
+            return ["anthropic", "my-endpoint"]
+
+        def get_default_engine(self):
+            return "anthropic"
+
+    values = {
+        "BASE_CORTEX": "anthropic",
+        "TRAINER_CORTEX": "Default",
+        "GRILLO_CORTEX": "Default",
+        "ANTHROPIC_API_KEY": "",
+    }
+    set_value = AsyncMock()
+
+    monkeypatch.setattr(
+        cm.config_registry,
+        "get_value",
+        lambda key, default=None: values.get(key, default),
+    )
+    monkeypatch.setattr(cm.config_registry, "set_value", set_value)
+    monkeypatch.setattr(
+        "core.cortex_registry.get_cortex_registry", lambda: FakeRegistry()
+    )
+
+    with pytest.raises(ValueError, match="not available"):
+        await conf.get_active_cortex_engine(None)
+
+    # Must not silently answer with the keyless engine, and must not guess at
+    # 'my-endpoint' either -- picking for the operator is how this started.
+    set_value.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_debrief_situational_notes.py
+++ b/tests/test_debrief_situational_notes.py
@@ -1,0 +1,294 @@
+"""Tests for the Debrief situational-notes plugin.
+
+The plugin extracts short-lived, time-bounded circumstances from a finished turn
+and hands them to the SOUL store. It owns the extraction only: the model, the
+persistence and the prompt injection stay in SOUL.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from plugins.debrief.debrief_situational_notes import DebriefSituationalNotesPlugin
+
+
+def _plugin_config_value(
+    key: str,
+    default: Any = None,
+    value_type: Any = None,
+    **_: Any,
+) -> Any:
+    overrides = {
+        "SITUATIONAL_NOTES_DEBRIEF_ENABLED": True,
+        "SITUATIONAL_NOTES_MAX": 8,
+    }
+    return overrides.get(key, default)
+
+
+class _RecordingRepository:
+    """Minimal stand-in for the SOUL repository."""
+
+    def __init__(self) -> None:
+        self.notes: list[Any] = []
+
+    async def upsert_situational_note(self, note: Any) -> str:
+        self.notes.append(note)
+        return note.id or "generated"
+
+
+def _install(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    llm_text: str,
+    repository: Any | None,
+    corrector_text: str | None = None,
+) -> dict[str, Any]:
+    """Wire config, cortex engine, plugin registry and corrector for one turn."""
+    monkeypatch.setattr(
+        "plugins.debrief.debrief_situational_notes.config_registry.get_value",
+        _plugin_config_value,
+    )
+
+    calls: dict[str, Any] = {"generated": 0, "corrected": 0}
+
+    class DummyEngine:
+        async def generate_response(self, messages: list[dict[str, Any]]) -> str:
+            calls["generated"] += 1
+            calls["messages"] = messages
+            return llm_text
+
+    class DummyRegistry:
+        def get_engine(self, name: str) -> DummyEngine:
+            return DummyEngine()
+
+        def load_engine(self, name: str) -> DummyEngine:
+            return DummyEngine()
+
+    async def fake_active_cortex_engine(scope: Any = None) -> str:
+        return "dummy"
+
+    async def fake_corrector(
+        text: str,
+        bot: Any = None,
+        context: dict[str, Any] | None = None,
+        chat_id: Any = None,
+        thread_id: Any = None,
+    ) -> str:
+        calls["corrected"] += 1
+        return corrector_text or ""
+
+    monkeypatch.setattr("core.config.derive_cortex_scope", lambda ctx: "base")
+    monkeypatch.setattr(
+        "core.config.get_active_cortex_engine", fake_active_cortex_engine
+    )
+    monkeypatch.setattr(
+        "core.cortex_registry.get_cortex_registry", lambda: DummyRegistry()
+    )
+    monkeypatch.setattr(
+        "plugins.debrief.debrief_situational_notes.run_corrector_middleware",
+        fake_corrector,
+    )
+
+    soul = SimpleNamespace(get_repository=lambda: repository)
+    registry = {"soul_plugin": soul} if repository is not None else {}
+    monkeypatch.setattr("core.core_initializer.PLUGIN_REGISTRY", registry)
+
+    return calls
+
+
+def _turn() -> tuple[Any, dict[str, Any]]:
+    original_message = SimpleNamespace(
+        text="Domani ho il dentista e la settimana prossima parto per Osaka",
+        chat_id=42,
+        thread_id=7,
+        interface_path="telegram/42",
+        from_cortex=True,
+        session_id="sess-1",
+    )
+    context = {
+        "from_cortex": True,
+        "original_user_message": original_message.text,
+        "llm_response_text": "Me lo segno, in bocca al lupo per il dentista.",
+        "interface_path": "telegram/42",
+        "session_id": "sess-1",
+    }
+    return original_message, context
+
+
+@pytest.mark.asyncio
+async def test_extracted_notes_reach_the_soul_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A well-formed extraction is validated and persisted."""
+    repo = _RecordingRepository()
+    _install(
+        monkeypatch,
+        llm_text=(
+            '{"notes":[{"note_type":"EVENT","subject":"dentist",'
+            '"summary":"Dentist appointment tomorrow afternoon",'
+            '"priority":1,"confidence":0.8,'
+            '"valid_until":"2026-09-12T00:00:00+00:00"}]}'
+        ),
+        repository=repo,
+    )
+
+    original_message, context = _turn()
+    result = await DebriefSituationalNotesPlugin().on_debrief(
+        processed_actions=[],
+        failed_actions=[],
+        results={},
+        context=context,
+        original_message=original_message,
+    )
+
+    # The plugin feeds the store; it proposes no recovery actions.
+    assert result is None
+    assert len(repo.notes) == 1
+    stored = repo.notes[0]
+    assert stored.note_type == "EVENT"
+    assert stored.summary == "Dentist appointment tomorrow afternoon"
+    assert stored.session_id == "sess-1"
+    # The id is left for the repository to derive, so the same circumstance
+    # seen twice updates one row instead of accumulating duplicates.
+    assert stored.id == ""
+    assert stored.valid_from.tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_turn_outside_cortex_is_ignored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-cortex turns never reach the LLM."""
+    repo = _RecordingRepository()
+    calls = _install(monkeypatch, llm_text='{"notes":[]}', repository=repo)
+
+    original_message, context = _turn()
+    context["from_cortex"] = False
+    original_message.from_cortex = False
+
+    result = await DebriefSituationalNotesPlugin().on_debrief(
+        processed_actions=[],
+        failed_actions=[],
+        results={},
+        context=context,
+        original_message=original_message,
+    )
+
+    assert result is None
+    assert calls["generated"] == 0
+    assert repo.notes == []
+
+
+@pytest.mark.asyncio
+async def test_missing_soul_plugin_does_not_break_the_debrief(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without SOUL there is nowhere to store notes, and that is not an error.
+
+    Removing a plugin must never break another one, so the extraction simply
+    finds no store and the debrief carries on.
+    """
+    _install(
+        monkeypatch,
+        llm_text=(
+            '{"notes":[{"note_type":"STATE","subject":"moving",'
+            '"summary":"Moving house this week","priority":0,"confidence":0.6,'
+            '"valid_until":"2026-09-17T00:00:00+00:00"}]}'
+        ),
+        repository=None,
+    )
+
+    original_message, context = _turn()
+    result = await DebriefSituationalNotesPlugin().on_debrief(
+        processed_actions=[],
+        failed_actions=[],
+        results={},
+        context=context,
+        original_message=original_message,
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_broken_json_goes_through_the_corrector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed output is handed to the corrector before being given up on."""
+    repo = _RecordingRepository()
+    calls = _install(
+        monkeypatch,
+        llm_text="{not valid json",
+        repository=repo,
+        corrector_text=(
+            '{"notes":[{"note_type":"INTERVAL","subject":"trip",'
+            '"summary":"Travelling to Osaka next week","priority":2,'
+            '"confidence":0.7,"valid_until":"2026-09-18T00:00:00+00:00"}]}'
+        ),
+    )
+
+    original_message, context = _turn()
+    await DebriefSituationalNotesPlugin().on_debrief(
+        processed_actions=[],
+        failed_actions=[],
+        results={},
+        context=context,
+        original_message=original_message,
+    )
+
+    assert calls["corrected"] == 1
+    assert len(repo.notes) == 1
+    assert repo.notes[0].subject == "trip"
+
+
+@pytest.mark.asyncio
+async def test_empty_extraction_skips_the_corrector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ "Nothing temporal was said" is a valid answer, not something to correct."""
+    repo = _RecordingRepository()
+    calls = _install(monkeypatch, llm_text='{"notes":[]}', repository=repo)
+
+    original_message, context = _turn()
+    await DebriefSituationalNotesPlugin().on_debrief(
+        processed_actions=[],
+        failed_actions=[],
+        results={},
+        context=context,
+        original_message=original_message,
+    )
+
+    assert calls["corrected"] == 0
+    assert repo.notes == []
+
+
+@pytest.mark.asyncio
+async def test_turn_content_reaches_the_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """What the human said must actually appear in the prompt sent to the LLM.
+
+    Regression: the turn was passed as a JSON string. An OpenAI-compatible
+    backend parsed it as structured content, kept only the keys it recognised
+    and dropped the rest, so the model received the instructions alone and
+    answered with an empty note list — with no error logged anywhere.
+    """
+    repo = _RecordingRepository()
+    calls = _install(monkeypatch, llm_text='{"notes":[]}', repository=repo)
+
+    original_message, context = _turn()
+    await DebriefSituationalNotesPlugin().on_debrief(
+        processed_actions=[],
+        failed_actions=[],
+        results={},
+        context=context,
+        original_message=original_message,
+    )
+
+    sent = calls["messages"]
+    user_part = next(m["content"] for m in sent if m["role"] == "user")
+    assert original_message.text in user_part
+    assert context["llm_response_text"] in user_part
+    # A bare JSON object is exactly what got swallowed before.
+    assert not user_part.strip().startswith("{")


### PR DESCRIPTION
## Overview

This PR implements the Temporal Situational Context (TSC) subsystem—a mechanism to capture and replay short-lived, time-bounded circumstances (appointments, travel, temporary states) so that subsequent prompts remain aware of the human's current life context.

## What's Included

### Core Features
- **Situational Notes Store**: PostgreSQL-backed persistence with content-derived IDs for idempotent updates (`situational_notes` table, indexed on status and validity windows)
- **Time Resolution**: Converts relative phrases ("tomorrow", "next week") to absolute ISO-8601 datetimes using a configurable anchor point
- **Post-Session Expiration**: Automatic lifecycle management; notes expire when `valid_until` passes
- **Prompt Injection**: Active notes surface in the `[Temporal context]` section, capped at 8 per prompt, with a 1-day lookback window by default
- **Debrief Extraction**: New plugin (`DebriefSituationalNotesPlugin`) extracts circumstances from human messages after each turn, using an LLM-based classifier with automatic corrections

### Fixes & Improvements
- **Cortex Resolver**: Fixed a bug where the resolver would invent an engine fallback instead of raising an error when no suitable engine is configured
- **Documentation**: Clarified commit message rules in CLAUDE.md (one-line subjects, no trailer bundling)

## Verification

✅ End-to-end proof in production:
- Messages with 3 temporal references (doctor visit, trip, moving house)
- Debrief extracted and stored all 3 notes with correct dates and priorities
- Subsequent Rei turn at 32699 chars received the notes in `[Temporal context]` section
- Chunked send (32982→2 parts) completed in 35s without stale-response issues

✅ Test suite: 51 tests pass (soul + debrief); ruff format and check clean
⚠️ Note: Selenium test suite not validated in this environment (missing pytest in container)

## Known Limitations
- **Dedup is content-exact**: Same event phrased differently creates separate rows ("moving house this week" ≠ "this week moving house")
- **`session_id` column unused**: The context chain doesn't populate it; available for future use
- **Gemini editor truncates ~32k chars**: Chunking works but final chunk takes ~7 min; plugin timeout may need raising for very long inputs
